### PR TITLE
Enable non-root access (JENKINS-5867).

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -61,12 +61,12 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
             SCPClient scp = conn.createSCPClient();
             String initScript = computer.getNode().initScript;
 
-            if(initScript!=null && initScript.trim().length()>0 && conn.exec("test -e /.hudson-run-init", logger) !=0) {
+            if(initScript!=null && initScript.trim().length()>0 && conn.exec("test -e /tmp/.hudson-run-init", logger) !=0) {
                 logger.println("Executing init script");
                 scp.put(initScript.getBytes("UTF-8"),"init.sh","/tmp","0700");
                 Session sess = conn.openSession();
                 sess.requestDumbPTY(); // so that the remote side bundles stdout and stderr
-                sess.execCommand(computer.getRootCommandPrefix() + "/tmp/init.sh");
+                sess.execCommand("/tmp/init.sh");
 
                 sess.getStdin().close();    // nothing to write here
                 sess.getStderr().close();   // we are not supposed to get anything from stderr
@@ -79,7 +79,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 }
 
                 // leave the completion marker
-                scp.put(new byte[0],".hudson-run-init","/","0600");
+                scp.put(new byte[0],".hudson-run-init","/tmp","0600");
 
             }
 
@@ -150,7 +150,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 logger.println("Authentication failed");
                 return FAILED;
             }
-            if (!computer.getRemoteAdmin().equals("root")) {
+            if (!computer.getRemoteAdmin().equals("root") && computer.getRootCommandPrefix().trim().length() > 0) {
                 // Get root working, so we can scp in etc.
                 Session sess = bootstrapConn.openSession();
                 sess.requestDumbPTY(); // so that the remote side bundles stdout and stderr

--- a/src/main/resources/hudson/plugins/ec2/EC2Slave/help-rootCommandPrefix.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Slave/help-rootCommandPrefix.html
@@ -1,6 +1,6 @@
 <div>
     This field is optional. It supplies a command prefix to use when running an
     administrative command. E.g. 'sudo'. This is needed for Ubuntu EC2 and UEC
-    machine images where the root user is disabled by default, but the ubuntu
-    user can perform sudo.
+    machine images to acquire root access where the root user is disabled by
+    default.
 </div>


### PR DESCRIPTION
This fix will make it possible to connect and run tests as a different user than 'root'.

Previously the code tried to use 'rootPrefixCommand' to copy ssh keys from the connecting user to the 'root' user account and then reconnect as root. With this fix in place this is only done if 'rootPrefixCommand' has explicitly been defined.

One thing I'm a little unsure of is that I had to move the '.hudson-run-init' marker to the '/tmp' directory. Maybe you had a good reason for storing the marker in the root directory?
