### PR TITLE
Bring back remoteFS in the slave configuration page.

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly
@@ -57,13 +57,17 @@ THE SOFTWARE.
         <f:entry title="${%# of executors}" field="numExecutors">
           <f:textbox />
         </f:entry>
-        
+                
         <f:entry title="${%Labels}" field="labelString">
           <f:textbox />
         </f:entry>
 
         <f:entry title="${%Init Script}" field="initScript">
           <f:textarea />
+        </f:entry>
+
+        <f:entry title="${%Remote FS root}" field="remoteFS">
+          <f:textbox />
         </f:entry>
 
         <f:entry title="${%Remote user}" field="remoteAdmin">


### PR DESCRIPTION
When updating the EC2 slave configuration, any remoteFS that is set would be blanked out, since it got lost in the configure.jelly page in a previous commit.
