### PR TITLE
Upgrade aws-java-sdk dependency to 1.3.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.3.7</version>
+      <version>1.3.30</version>
       <exclusions>
         <exclusion>
           <groupId>commons-codec</groupId>


### PR DESCRIPTION
Very old version of this dependency was transitively pulling in an alpha release of httpclient lib's, causing problems fixing other bugs.
