### PR TITLE
fallback a manual or timeout-based terminate to stop if terminate fails

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Slave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Slave.java
@@ -57,7 +57,7 @@ import net.sf.json.JSONObject;
 
 /**
  * Slave running on EC2.
- * 
+ *
  * @author Kohsuke Kawaguchi
  */
 public final class EC2Slave extends Slave {
@@ -93,7 +93,7 @@ public final class EC2Slave extends Slave {
     private final int sshPort;
 
     public static final String TEST_ZONE = "testZone";
-    
+
     public EC2Slave(String instanceId, String description, String remoteFS, int sshPort, int numExecutors, String labelString, Mode mode, String initScript, String remoteAdmin, String rootCommandPrefix, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags) throws FormException, IOException {
         this(instanceId, description, remoteFS, sshPort, numExecutors, mode, labelString, initScript, Collections.<NodeProperty<?>>emptyList(), remoteAdmin, rootCommandPrefix, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, false);
     }
@@ -177,26 +177,51 @@ public final class EC2Slave extends Slave {
     	}
     	return i;
     }
-    
+
     /**
      * Terminates the instance in EC2.
      */
     public void terminate() {
+        if (!isAlive(true)) {
+            /* The node has been killed externally, so we've nothing to do here */
+            LOGGER.info("EC2 instance already terminated: "+getInstanceId());
+        } else if (!terminateInstance()) {
+            LOGGER.info("EC2 terminate failed, attempting a stop");
+            stop();
+            return;
+        }
+
         try {
-            if (!isAlive(true)) {
-                /* The node has been killed externally, so we've nothing to do here */
-                LOGGER.info("EC2 instance already terminated: "+getInstanceId());
-            } else {
-                AmazonEC2 ec2 = EC2Cloud.get().connect();
-                TerminateInstancesRequest request = new TerminateInstancesRequest(Collections.singletonList(getInstanceId()));
-                ec2.terminateInstances(request);
-                LOGGER.info("Terminated EC2 instance (terminated): "+getInstanceId());
-            }
             Hudson.getInstance().removeNode(this);
-        } catch (AmazonClientException e) {
-            LOGGER.log(Level.WARNING,"Failed to terminate EC2 instance: "+getInstanceId(),e);
         } catch (IOException e) {
             LOGGER.log(Level.WARNING,"Failed to terminate EC2 instance: "+getInstanceId(),e);
+        }
+    }
+
+    void stop() {
+        try {
+            AmazonEC2 ec2 = EC2Cloud.get().connect();
+            StopInstancesRequest request = new StopInstancesRequest(
+                    Collections.singletonList(getInstanceId()));
+            ec2.stopInstances(request);
+            LOGGER.info("EC2 instance stopped: " + getInstanceId());
+            toComputer().disconnect(null);
+        } catch (AmazonClientException e) {
+            Instance i = getInstance(getNodeName());
+            LOGGER.log(Level.WARNING, "Failed to terminate EC2 instance: "+getInstanceId() + " info: "+((i != null)?i:"") , e);
+        }
+    }
+
+    boolean terminateInstance() {
+        try {
+            AmazonEC2 ec2 = EC2Cloud.get().connect();
+            TerminateInstancesRequest request = new TerminateInstancesRequest(Collections.singletonList(getInstanceId()));
+            ec2.terminateInstances(request);
+            LOGGER.info("Terminated EC2 instance (terminated): "+getInstanceId());
+            return true;
+        } catch (AmazonClientException e) {
+            LOGGER.log(Level.WARNING,"Failed to terminate EC2 instance: "+getInstanceId(),e);
+            return false;
         }
     }
 
@@ -204,20 +229,10 @@ public final class EC2Slave extends Slave {
 		LOGGER.info("EC2 instance idle time expired: "+getInstanceId());
 		if (!stopOnTerminate) {
 			terminate();
-			return;
 		}
-
-		try {
-			AmazonEC2 ec2 = EC2Cloud.get().connect();
-			StopInstancesRequest request = new StopInstancesRequest(
-					Collections.singletonList(getInstanceId()));
-			ec2.stopInstances(request);
-			toComputer().disconnect(null);
-		} catch (AmazonClientException e) {
-	        Instance i = getInstance(getNodeName());
-			LOGGER.log(Level.WARNING, "Failed to terminate EC2 instance: "+getInstanceId() + " info: "+((i != null)?i:"") , e);
-		}
-		LOGGER.info("EC2 instance stopped: " + getInstanceId());
+        else {
+            stop();
+        }
 	}
 
     String getRemoteAdmin() {
@@ -306,7 +321,7 @@ public final class EC2Slave extends Slave {
 
             for(EC2Tag t : tags) {
                 inst_tags.add(new Tag(t.getName(), t.getValue()));
-            }            
+            }
 
             CreateTagsRequest tag_request = new CreateTagsRequest();
             tag_request.withResources(inst.getInstanceId()).setTags(inst_tags);
@@ -361,14 +376,14 @@ public final class EC2Slave extends Slave {
     public boolean getUsePrivateDnsName() {
         return usePrivateDnsName;
     }
-    
+
     public static ListBoxModel fillZoneItems(String accessId, String secretKey, String region) throws IOException, ServletException {
 		ListBoxModel model = new ListBoxModel();
 		if (AmazonEC2Cloud.testMode) {
 			model.add(TEST_ZONE);
 			return model;
 		}
-			
+
 		if (!StringUtils.isEmpty(accessId) && !StringUtils.isEmpty(secretKey) && !StringUtils.isEmpty(region)) {
 			AmazonEC2 client = EC2Cloud.connect(accessId, secretKey, AmazonEC2Cloud.getEc2EndpointUrl(region));
 			DescribeAvailabilityZonesResult zones = client.describeAvailabilityZones();
@@ -380,8 +395,8 @@ public final class EC2Slave extends Slave {
 		}
 		return model;
 	}
-    
-    
+
+
     @Extension
     public static final class DescriptorImpl extends SlaveDescriptor {
         @Override


### PR DESCRIPTION
re-send of pull req #27

I'm observing that in some cases, Amazon EC2 will force-provision one of my instances that has termination protection applied to it as one of Jenkins new nodes. This leads to the undesirable state that the automated "termination" of this instance, as well as a manual attempt to terminate this instance, produces the exception "AWS Error Code: OperationNotPermitted, AWS Error Message: The instance 'i-5d694121' may not be terminated. Modify its 'disableApiTermination' instance attribute and try again."

As any failure like this regarding EC2 essentially means monetary charges to the owner's amazon account, it is critical that in the event of a failure like this, the instance is at least stopped; else automated builds start up instances which stay running and charging money indefinitely until someone manually intervenes.

This pull request reworks the terminate() method to fall back to a new stop() method in the event of any AmazonClientException. The implementation for stop() which was factored out of the idleTimeout() method, which now has a simple conditional of calling terminate() or stop() based on the value of stopOnTerminate. As is the case before, I'm running this on jenkins.sqlalchemy.org and if I encounter any issues with it, I'll update the pullreq over here.
