### PR TITLE
Give Jenkins nodes useful names.

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -55,7 +55,8 @@ public class EC2Computer extends SlaveComputer {
     }
 
     public String getInstanceId() {
-        return getName();
+        EC2Slave node = (EC2Slave) super.getNode();
+	return node.getInstanceId();
     }
 
     /**

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -225,7 +225,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         AmazonEC2 ec2 = getParent().connect();
 
         try {
-            logger.println("Launching "+ami);
+            logger.println("Launching " + ami + " for template " + description);
             KeyPair keyPair = parent.getPrivateKey().find(ec2);
             if(keyPair==null) {
                 throw new AmazonClientException("No matching keypair found on EC2. Is the EC2 private key a valid one?");


### PR DESCRIPTION
EC2 slave nodes will now include their template name and EC2 instance
identifiers in the node name used throughout the Jenkins UI.

Addresses [JENKINS-15078].
