### PR TITLE
Fix minor fallout from giving nodes useful names

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Slave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Slave.java
@@ -209,7 +209,7 @@ public final class EC2Slave extends Slave {
             LOGGER.info("EC2 instance stopped: " + getInstanceId());
             toComputer().disconnect(null);
         } catch (AmazonClientException e) {
-            Instance i = getInstance(getNodeName());
+            Instance i = getInstance(getInstanceId());
             LOGGER.log(Level.WARNING, "Failed to terminate EC2 instance: "+getInstanceId() + " info: "+((i != null)?i:"") , e);
         }
     }


### PR DESCRIPTION
Per commit 88222567e84ae42c602d5ac8430a95957ea083e3, we need to rely on getInstanceId() to get the e2 instance id rather than getNodeName() that was previously used.

Looks like one minor case was missed; this pull request changes that line to use getInstanceId() instead.
