### PR TITLE
Provide backwards compatibility for EC2Slave name change.

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Slave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Slave.java
@@ -61,7 +61,7 @@ import net.sf.json.JSONObject;
  * @author Kohsuke Kawaguchi
  */
 public final class EC2Slave extends Slave {
-    public String instanceId;
+    private String instanceId;
     /**
      * Comes from {@link SlaveTemplate#initScript}.
      */
@@ -126,9 +126,9 @@ public final class EC2Slave extends Slave {
     protected Object readResolve() {
 	/*
 	 * If instanceId is null, this object was deserialized from an old
-	 * version of the plugin, where this field did not exist. In those
-	 * versions, the node name *was* the instance ID, so we can get it
-	 * from there.
+	 * version of the plugin, where this field did not exist (prior to
+	 * version 1.18). In those versions, the node name *was* the instance
+	 * ID, so we can get it from there.
 	 */
 	if (instanceId == null) {
 	    instanceId = getNodeName();


### PR DESCRIPTION
Commit 88222567e84ae42c602d5ac8430a95957ea083e3 changed the way that
Node objects are constructed from EC2Slave objects, in order to make the
Node 'name' fields more useful. It also added a field called 'instanceId'
to EC2Slave, and stopped relying on Node.getNodeName() to recover that
information. In order to provide compatibility with configurations from
before this change was made, this patch notes whether instanceId is null,
and if it is, extracts the instance ID from the Node's name.
