### PR TITLE
Add a 'test' that lists the available EC2 instance types.

### DIFF
--- a/src/test/java/hudson/plugins/ec2/EC2InstanceTypesTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2InstanceTypesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+ * Copyright (c) 2013, Bloomberg L.P.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
When AWS adds new instance types, the AWS SDK is updated to include them, and this
plugin is updated to bring in the new version of the SDK. In order to confirm that
doing so actually does make the new instance types available, this 'test' lists
the known instance types while the plugin is being tested.
