### PR TITLE
Fix setting EC2 tags on slaves (broken in 1.17 by d5154c60). JENKINS-15239

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -299,6 +299,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             if (tags != null && !tags.isEmpty()) {
                 inst_tags = new HashSet<Tag>();
                 for(EC2Tag t : tags) {
+                    inst_tags.add(new Tag(t.getName(), t.getValue()));
                     diFilters.add(new Filter("tag:"+t.getName()).withValues(t.getValue()));
                 }
             }


### PR DESCRIPTION
Without this, if you have any tags set in your slave templates, an attempt to provision a slave will fail with a stacktrace (because Amazon doesn't like the empty createTags request).
