### PR TITLE
Ensure that template instance caps are not zero.

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -75,7 +75,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public final String jvmopts;
     public final String subnetId;
     public final String idleTerminationMinutes;
-    public final int instanceCap;
+    public int instanceCap;
     public final boolean stopOnTerminate;
     private final List<EC2Tag> tags;
     public final boolean usePrivateDnsName;
@@ -542,6 +542,19 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     protected Object readResolve() {
         labelSet = Label.parse(labels);
         securityGroupSet = parseSecurityGroups();
+	
+	/**
+	 * In releases of this plugin prior to 1.18, template-specific instance caps could be configured
+	 * but were not enforced. As a result, it was possible to have the instance cap for a template
+	 * be configured to 0 (zero) with no ill effects. Starting with version 1.18, template-specific
+	 * instance caps are enforced, so if a configuration has a cap of zero for a template, no instances
+	 * will be launched from that template. Since there is no practical value of intentionally setting
+	 * the cap to zero, this block will override such a setting to a value that means 'no cap'.
+	 */
+	if (this.instanceCap == 0) {
+	    this.instanceCap = Integer.MAX_VALUE;
+	}
+
         return this;
     }
 
@@ -611,7 +624,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             if (value == null || value.trim() == "") return FormValidation.ok();
             try {
                 int val = Integer.parseInt(value);
-                if (val >= 0) return FormValidation.ok();
+                if (val > 0) return FormValidation.ok();
             } catch ( NumberFormatException nfe ) {}
             return FormValidation.error("InstanceCap must be a non-negative integer (or null)");
         }


### PR DESCRIPTION
Until this patch it was possible to explicitly set a template's
instance cap to zero; this caused no harm as template instance caps
were not enforced until version 1.18. With that version, though,
a cap of zero will keep any instances from being launched, which is
not useful (and is somewhat difficult to debug). This patch disallows
setting template instance caps to zero, and ensures that any that are
already configured to zero are ignored.
