### PR TITLE
Decrement excessWorkload based on executors on the new slave

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -319,7 +319,7 @@ public abstract class EC2Cloud extends Cloud {
             final SlaveTemplate t = getTemplate(label);
             int amiCap = t.getInstanceCap();
 
-            for( ; excessWorkload>0; excessWorkload-- ) {
+            while (excessWorkload>0) {
 
                 if (!addProvisionedSlave(t.ami, amiCap)) {
                     break;
@@ -350,6 +350,9 @@ public abstract class EC2Cloud extends Cloud {
                             }
                         })
                         ,t.getNumExecutors()));
+
+                excessWorkload -= t.getNumExecutors();
+
             }
             return r;
         } catch (AmazonClientException e) {


### PR DESCRIPTION
Without this, Jenkins would spin up one slave for each job
of excessWorkload even though a slave might be able to handle
more than one. This would cost real money.

Addresses [JENKINS-12767]
