### PR TITLE
[JENKINS-19058] Fix cannot add tags to Spot Instances

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -261,6 +261,13 @@ public abstract class EC2AbstractSlave extends Slave {
         return stopOnTerminate;
     }
 
+	/**
+	 * Called when the slave is connected to Jenkins
+	 */
+	public void onConnected() {
+		// Do nothing by default.
+	}
+
     protected boolean isAlive(boolean force) {
         fetchLiveInstanceData(force);
         if (lastFetchInstance == null) 

--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -59,7 +59,7 @@ public class EC2Computer extends SlaveComputer {
         EC2AbstractSlave node = (EC2AbstractSlave) super.getNode();
 	return node.getInstanceId();
     }
-    
+
     public String getEc2Type() {
     	return getNode().getEc2Type();
     }
@@ -70,7 +70,7 @@ public class EC2Computer extends SlaveComputer {
     	}
     	return "";
     }
-    
+
     public EC2Cloud	getCloud() {
     	EC2AbstractSlave node = (EC2AbstractSlave) super.getNode();
     	return node.cloud;
@@ -157,7 +157,7 @@ public class EC2Computer extends SlaveComputer {
         request.setInstanceIds(Collections.<String>singletonList(getNode().getInstanceId()));
         return getCloud().connect().describeInstances(request).getReservations().get(0).getInstances().get(0);
     }
-    
+
     /**
      * When the slave is deleted, terminate the instance.
      */
@@ -183,5 +183,12 @@ public class EC2Computer extends SlaveComputer {
     public String getRootCommandPrefix() {
         return getNode().getRootCommandPrefix();
     }
-    
+
+	public void onConnected(){
+		EC2AbstractSlave node = getNode();
+		if (node != null) {
+			node.onConnected();
+		}
+	}
+
 }

--- a/src/main/java/hudson/plugins/ec2/EC2ComputerListener.java
+++ b/src/main/java/hudson/plugins/ec2/EC2ComputerListener.java
@@ -1,0 +1,17 @@
+package hudson.plugins.ec2;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+import hudson.model.Computer;
+import hudson.slaves.ComputerListener;
+
+@Extension
+public class EC2ComputerListener extends ComputerListener {
+
+	@Override
+	public void onOnline(Computer c, TaskListener listener) {
+		if(c instanceof EC2Computer){
+			((EC2Computer) c).onConnected();
+		}
+	}
+}

--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -115,6 +115,13 @@ public final class EC2SpotSlave extends EC2AbstractSlave {
 		return instanceId;
 	}
 
+	@Override
+	public void onConnected() {
+		// The spot request has been fulfilled and is connected. If the Spot
+		// request had tags, we want those on the instance.
+		pushLiveInstancedata();
+	}
+
 	@Extension
 	public static final class DescriptorImpl extends EC2AbstractSlave.DescriptorImpl {
 		


### PR DESCRIPTION
Add a ComputerListener so that we can take action when a
slave is connected. This allows us to be notified when a
Spot instance is connected and add the Spot Request's tags
to its instance.
