### PR TITLE
[JENKINS-19301] Fix: spot instance feature cannot be used within VPC

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -471,12 +471,18 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
 				/* If we have a subnet ID then we can only use VPC security groups */
 				if (!securityGroupSet.isEmpty()) {
-					List<String> group_ids = getEc2SecurityGroups(ec2);
+                    List<String> group_ids = getEc2SecurityGroups(ec2);
+                    ArrayList<GroupIdentifier> groups = new ArrayList<GroupIdentifier>();
 
-					if (!group_ids.isEmpty()) {
-						launchSpecification.setSecurityGroups(group_ids);
-					}
-				}
+                    for (String group_id : group_ids) {
+                      GroupIdentifier group = new GroupIdentifier();
+                      group.setGroupId(group_id);
+                      groups.add(group);
+                    }
+
+                    if (!groups.isEmpty())
+                        launchSpecification.setAllSecurityGroups(groups);
+                }
 			} else {
 				/* No subnet: we can use standard security groups by name */
 				if (securityGroupSet.size() > 0)


### PR DESCRIPTION
Fixed ability to launch spot instance within a VPC with custom VPC security group

Fixes:
Status Code: 400, AWS Service: AmazonEC2, AWS Request ID: 6079cf60-3c23-4ea7-935a-807bd5f81b95, AWS Error Code: InvalidParameterCombination, AWS Error Message: The parameter groupName cannot be used with the parameter subnet
