### PR TITLE
JENKINS-19500 Fix: Unable to delete slave for spot request that no longer exists.

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -92,9 +92,22 @@ public final class EC2SpotSlave extends EC2AbstractSlave {
 		AmazonEC2 ec2 = cloud.connect();
 
 		DescribeSpotInstanceRequestsRequest dsirRequest = new DescribeSpotInstanceRequestsRequest().withSpotInstanceRequestIds(spotRequestId);
-		DescribeSpotInstanceRequestsResult dsirResult = ec2.describeSpotInstanceRequests(dsirRequest);
-		List<SpotInstanceRequest> siRequests = dsirResult.getSpotInstanceRequests();
-		if (siRequests.size() <= 0) return null;
+		DescribeSpotInstanceRequestsResult dsirResult = null;
+		List<SpotInstanceRequest> siRequests = null;
+
+		try{
+			dsirResult = ec2.describeSpotInstanceRequests(dsirRequest);
+			siRequests = dsirResult.getSpotInstanceRequests();
+
+		} catch (AmazonServiceException e){
+			// Spot request is no longer valid
+			LOGGER.log(Level.WARNING, "Failed to fetch spot instance request for requestId: " + spotRequestId);
+		} catch (AmazonClientException e){
+			// Spot request is no longer valid
+			LOGGER.log(Level.WARNING, "Failed to fetch spot instance request for requestId: " + spotRequestId);
+		}
+
+		if (dsirResult == null || siRequests.size() <= 0) return null;
 		return siRequests.get(0);
 	}
 


### PR DESCRIPTION
Stops the following error from occuring: https://gist.github.com/mriddle/e2dd024c992b7de35552

Enables the user to delete a slave entry for a spot instance that no longer exists by returning null when AWS is unable to find the spot instance for the given request ID.
