### PR TITLE
JENKINS-19500 Remove slave from Jenkins even when instance termination fails

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -72,10 +72,10 @@ public final class EC2SpotSlave extends EC2AbstractSlave {
 
 		} catch (AmazonServiceException e){
 			// Spot request is no longer valid
-			LOGGER.log(Level.WARNING, "Failed to terminated instance and cancel Spot request: " + spotInstanceRequestId);
+			LOGGER.log(Level.WARNING, "Failed to terminated instance and cancel Spot request: " + spotInstanceRequestId, e);
 		} catch (AmazonClientException e){
 			// Spot request is no longer valid
-			LOGGER.log(Level.WARNING, "Failed to terminated instance and cancel Spot request: " + spotInstanceRequestId);
+			LOGGER.log(Level.WARNING, "Failed to terminated instance and cancel Spot request: " + spotInstanceRequestId, e);
 		}
 
 		try{


### PR DESCRIPTION
The comments for the terminate method suggest that we should attempt to terminate the instance if there is one and  always remove the slave.

I have moved the Jenkins slave termination outside of the spot termination try/catch so that it will always terminate the instance even if there is an AWS exception.

Is there a case when we might not want to do this?
