### PR TITLE
Windows slave support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,25 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>node-iterator-api</artifactId>
       <version>1.1</version>
+		</dependency>
+    <dependency>
+	    <groupId>jcifs</groupId>
+	    <artifactId>jcifs</artifactId>
+	    <version>1.3.17</version>
+		</dependency>
+		<!-- force version 4.1.1 because of 4.1 bug:
+		     https://issues.apache.org/jira/browse/HTTPCLIENT-1056
+		     that prevents authentication caching, resulting in very
+				 poor performances for WinRM -->
+    <dependency>
+    	<groupId>org.apache.httpcomponents</groupId>
+    	<artifactId>httpclient</artifactId>
+    	<version>4.1.1</version>
+    </dependency>
+    <dependency>
+    	<groupId>org.apache.httpcomponents</groupId>
+    	<artifactId>httpcore</artifactId>
+    	<version>4.1.1</version>
     </dependency>
   </dependencies>
 
@@ -102,6 +121,7 @@ THE SOFTWARE.
       <url>http://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+  
   <build>
   	<pluginManagement>
   		<plugins>

--- a/src/main/java/hudson/plugins/ec2/AMITypeData.java
+++ b/src/main/java/hudson/plugins/ec2/AMITypeData.java
@@ -1,0 +1,9 @@
+package hudson.plugins.ec2;
+
+import hudson.model.AbstractDescribableImpl;
+
+public abstract class AMITypeData extends AbstractDescribableImpl<AMITypeData>
+{
+    public abstract boolean isWindows();
+    public abstract boolean isUnix();
+}

--- a/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
@@ -5,6 +5,7 @@ import hudson.model.Descriptor.FormException;
 import hudson.model.Hudson;
 import hudson.model.Node;
 import hudson.plugins.ec2.ssh.EC2UnixLauncher;
+import hudson.plugins.ec2.win.EC2WindowsLauncher;
 import hudson.slaves.NodeProperty;
 
 import java.io.IOException;
@@ -29,18 +30,18 @@ import com.amazonaws.services.ec2.model.*;
  */
 public final class EC2OndemandSlave extends EC2AbstractSlave {
 	
-    public EC2OndemandSlave(String instanceId, String description, String remoteFS, int sshPort, int numExecutors, String labelString, Mode mode, String initScript, String remoteAdmin, String rootCommandPrefix, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName,int launchTimeout) throws FormException, IOException {
-    	this(description + " (" + instanceId + ")", instanceId, description, remoteFS, sshPort, numExecutors, labelString, Mode.NORMAL, initScript, Collections.<NodeProperty<?>>emptyList(), remoteAdmin, rootCommandPrefix, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, false, launchTimeout);
+    public EC2OndemandSlave(String instanceId, String description, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName,int launchTimeout, AMITypeData amiType) throws FormException, IOException {
+    	this(description + " (" + instanceId + ")", instanceId, description, remoteFS, numExecutors, labelString, Mode.NORMAL, initScript, Collections.<NodeProperty<?>>emptyList(), remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, false, launchTimeout, amiType);
     }
     
-    public EC2OndemandSlave(String instanceId, String description, String remoteFS, int sshPort, int numExecutors, String labelString, Mode mode, String initScript, String remoteAdmin, String rootCommandPrefix, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout) throws FormException, IOException {
-    	this(description + " (" + instanceId + ")", instanceId, description, remoteFS, sshPort, numExecutors, labelString, Mode.NORMAL, initScript, Collections.<NodeProperty<?>>emptyList(), remoteAdmin, rootCommandPrefix, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, usePrivateDnsName, launchTimeout);
+    public EC2OndemandSlave(String instanceId, String description, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout, AMITypeData amiType) throws FormException, IOException {
+    	this(description + " (" + instanceId + ")", instanceId, description, remoteFS, numExecutors, labelString, Mode.NORMAL, initScript, Collections.<NodeProperty<?>>emptyList(), remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, usePrivateDnsName, launchTimeout, amiType);
     } 	 
 
     @DataBoundConstructor
-    public EC2OndemandSlave(String name, String instanceId, String description, String remoteFS, int sshPort, int numExecutors, String labelString, Mode mode, String initScript, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String rootCommandPrefix, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout) throws FormException, IOException {
+    public EC2OndemandSlave(String name, String instanceId, String description, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout, AMITypeData amiType) throws FormException, IOException {
     	
-        super(name, instanceId, description, remoteFS, sshPort, numExecutors, mode, labelString, new EC2UnixLauncher(), new EC2RetentionStrategy(idleTerminationMinutes), initScript, nodeProperties, remoteAdmin, rootCommandPrefix, jvmopts, stopOnTerminate, idleTerminationMinutes, tags, cloudName, usePrivateDnsName, launchTimeout);
+        super(name, instanceId, description, remoteFS, numExecutors, mode, labelString, amiType.isWindows() ? new EC2WindowsLauncher() : new EC2UnixLauncher(), new EC2RetentionStrategy(idleTerminationMinutes), initScript, nodeProperties, remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, tags, cloudName, usePrivateDnsName, launchTimeout, amiType);
 
         this.publicDNS = publicDNS;
         this.privateDNS = privateDNS;
@@ -49,8 +50,8 @@ public final class EC2OndemandSlave extends EC2AbstractSlave {
     /**
      * Constructor for debugging.
      */
-    public EC2OndemandSlave(String instanceId) throws FormException, IOException {
-        this(instanceId, instanceId, "debug", "/tmp/hudson", 22, 1, "debug", Mode.NORMAL, "", Collections.<NodeProperty<?>>emptyList(), null, null, null, false, null, "Fake public", "Fake private", null, null, false, 0);
+    public EC2OndemandSlave(String instanceId, String description, String remoteFS, int i, String labels, Mode mode, String initScript, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String string, String string2, List<EC2Tag> list, String name, boolean usePrivateDnsName, int j) throws FormException, IOException {
+        this(instanceId, instanceId, "debug", "/tmp/hudson", 1, "debug", Mode.NORMAL, "", Collections.<NodeProperty<?>>emptyList(), null, null, false, null, "Fake public", "Fake private", null, null, false, 0, new UnixData(null, null));
     }
 
     

--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -26,14 +26,14 @@ public final class EC2SpotSlave extends EC2AbstractSlave {
 
 	private final String spotInstanceRequestId;
 
-	public EC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int sshPort, int numExecutors, Mode mode, String initScript, String labelString, String remoteAdmin, String rootCommandPrefix, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout) throws FormException, IOException {
-		this(name, spotInstanceRequestId, description, remoteFS, sshPort, numExecutors, mode, initScript, labelString, Collections.<NodeProperty<?>>emptyList(), remoteAdmin, rootCommandPrefix, jvmopts, idleTerminationMinutes, tags, cloudName, usePrivateDnsName, launchTimeout);
+	public EC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int numExecutors, Mode mode, String initScript, String labelString, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout, AMITypeData amiType) throws FormException, IOException {
+		this(name, spotInstanceRequestId, description, remoteFS, numExecutors, mode, initScript, labelString, Collections.<NodeProperty<?>>emptyList(), remoteAdmin, jvmopts, idleTerminationMinutes, tags, cloudName, usePrivateDnsName, launchTimeout, amiType);
 	}
 
 	@DataBoundConstructor
-	public EC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int sshPort, int numExecutors, Mode mode, String initScript, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String rootCommandPrefix, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout) throws FormException, IOException {
+	public EC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int numExecutors, Mode mode, String initScript, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout, AMITypeData amiType) throws FormException, IOException {
 
-		super(name, "", description, remoteFS, sshPort, numExecutors, mode, labelString, new EC2SpotComputerLauncher(), new EC2SpotRetentionStrategy(idleTerminationMinutes), initScript, nodeProperties, remoteAdmin, rootCommandPrefix, jvmopts, false, idleTerminationMinutes, tags, cloudName, usePrivateDnsName, launchTimeout);
+		super(name, "", description, remoteFS, numExecutors, mode, labelString, new EC2SpotComputerLauncher(), new EC2SpotRetentionStrategy(idleTerminationMinutes), initScript, nodeProperties, remoteAdmin, jvmopts, false, idleTerminationMinutes, tags, cloudName, usePrivateDnsName, launchTimeout, amiType);
 
 		this.name = name;
 		this.spotInstanceRequestId = spotInstanceRequestId;

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -52,6 +52,7 @@ import org.kohsuke.stapler.QueryParameter;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.*;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Template of {@link EC2AbstractSlave} to launch.
@@ -65,7 +66,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public final SpotConfiguration spotConfig;
     public final String securityGroups;
     public final String remoteFS;
-    public final String sshPort;
     public final InstanceType type;
     public final String labels;
     public final Node.Mode mode;
@@ -73,7 +73,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public final String userData;
     public final String numExecutors;
     public final String remoteAdmin;
-    public final String rootCommandPrefix;
     public final String jvmopts;
     public final String subnetId;
     public final String idleTerminationMinutes;
@@ -84,20 +83,27 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     private final List<EC2Tag> tags;
     public final boolean usePrivateDnsName;
     protected transient EC2Cloud parent;
-
+    public AMITypeData amiType;
+    
     public int launchTimeout;
 
     private transient /*almost final*/ Set<LabelAtom> labelSet;
 	private transient /*almost final*/ Set<String> securityGroupSet;
+	
+	/* those are retained for backward compatibility */
+	@Deprecated
+	public transient String sshPort;
+	@Deprecated
+	public transient String rootCommandPrefix;
 
     @DataBoundConstructor
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS, String sshPort, InstanceType type, String labelString, Node.Mode mode, String description, String initScript, String userData, String numExecutors, String remoteAdmin, String rootCommandPrefix, String jvmopts, boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, boolean usePrivateDnsName, String instanceCapStr, String iamInstanceProfile, boolean useEphemeralDevices, String launchTimeoutStr) {
+    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS, InstanceType type, String labelString, Node.Mode mode, String description, String initScript, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts, boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, boolean usePrivateDnsName, String instanceCapStr, String iamInstanceProfile, boolean useEphemeralDevices, String launchTimeoutStr) {
         this.ami = ami;
         this.zone = zone;
         this.spotConfig = spotConfig;
         this.securityGroups = securityGroups;
         this.remoteFS = remoteFS;
-        this.sshPort = sshPort;
+        this.amiType = amiType;
         this.type = type;
         this.labels = Util.fixNull(labelString);
         this.mode = mode;
@@ -106,7 +112,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.userData = userData;
         this.numExecutors = Util.fixNull(numExecutors).trim();
         this.remoteAdmin = remoteAdmin;
-        this.rootCommandPrefix = rootCommandPrefix;
         this.jvmopts = jvmopts;
         this.stopOnTerminate = stopOnTerminate;
         this.subnetId = subnetId;
@@ -132,6 +137,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         readResolve(); // initialize
     }
 
+    /**
+     * Backward compatible constructor for reloading previous version data
+     */
+    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS, String sshPort, InstanceType type, String labelString, Node.Mode mode, String description, String initScript, String userData, String numExecutors, String remoteAdmin, String rootCommandPrefix, String jvmopts, boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, boolean usePrivateDnsName, String instanceCapStr, String iamInstanceProfile, boolean useEphemeralDevices, String launchTimeoutStr)
+    {
+    	this(ami, zone, spotConfig, securityGroups, remoteFS, type, labelString, mode, description, initScript, userData, numExecutors, remoteAdmin, new UnixData(rootCommandPrefix, sshPort), jvmopts, stopOnTerminate, subnetId, tags, idleTerminationMinutes, usePrivateDnsName, instanceCapStr, iamInstanceProfile, useEphemeralDevices, launchTimeoutStr); 
+    }
+    
     public EC2Cloud getParent() {
         return parent;
     }
@@ -184,6 +197,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public int getSshPort() {
         try {
+        	String sshPort = "";
+        	if (amiType.isUnix()) {
+        		sshPort = ((UnixData)amiType).getSshPort();
+        	}
             return Integer.parseInt(sshPort);
         } catch (NumberFormatException e) {
             return 22;
@@ -195,7 +212,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     public String getRootCommandPrefix() {
-        return rootCommandPrefix;
+        return amiType.isUnix() ? ((UnixData)amiType).getRootCommandPrefix() : "";
     }
 
     public String getSubnetId() {
@@ -553,11 +570,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 	}
 
     protected EC2OndemandSlave newOndemandSlave(Instance inst) throws FormException, IOException {
-        return new EC2OndemandSlave(inst.getInstanceId(), description, remoteFS, getSshPort(), getNumExecutors(), labels, mode, initScript, remoteAdmin, rootCommandPrefix, jvmopts, stopOnTerminate, idleTerminationMinutes, inst.getPublicDnsName(), inst.getPrivateDnsName(), EC2Tag.fromAmazonTags(inst.getTags()), parent.name, usePrivateDnsName, getLaunchTimeout());
+        return new EC2OndemandSlave(inst.getInstanceId(), description, remoteFS, getNumExecutors(), labels, mode, initScript, remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, inst.getPublicDnsName(), inst.getPrivateDnsName(), EC2Tag.fromAmazonTags(inst.getTags()), parent.name, usePrivateDnsName, getLaunchTimeout(), amiType);
     }
 
     protected EC2SpotSlave newSpotSlave(SpotInstanceRequest sir, String name) throws FormException, IOException {
-        return new EC2SpotSlave(name, sir.getSpotInstanceRequestId(), description, remoteFS, getSshPort(), getNumExecutors(), mode, initScript, labels, remoteAdmin, rootCommandPrefix, jvmopts, idleTerminationMinutes, EC2Tag.fromAmazonTags(sir.getTags()), parent.name, usePrivateDnsName, getLaunchTimeout());
+        return new EC2SpotSlave(name, sir.getSpotInstanceRequestId(), description, remoteFS, getNumExecutors(), mode, initScript, labels, remoteAdmin, jvmopts, idleTerminationMinutes, EC2Tag.fromAmazonTags(sir.getTags()), parent.name, usePrivateDnsName, getLaunchTimeout(), amiType);
     }
 
     /**
@@ -653,6 +670,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         	instanceCap = Integer.MAX_VALUE;
         }
 
+        if (amiType == null) {
+        	amiType = new UnixData(rootCommandPrefix, sshPort);
+        }
         return this;
     }
 
@@ -672,6 +692,25 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
     }
 
+    public boolean isWindowsSlave()
+    {
+      return amiType.isWindows();
+    }
+
+    public boolean isUnixSlave()
+    {
+      return amiType.isUnix();
+    }
+
+    public String getAdminPassword()
+    {
+      return amiType.isWindows() ? ((WindowsData)amiType).getPassword() : "";
+    }
+    
+    private boolean isUseHTTPS() {
+        return amiType.isWindows() ? ((WindowsData)amiType).isUseHTTPS() : false;
+    }
+
     @Extension
     public static final class DescriptorImpl extends Descriptor<SlaveTemplate> {
         @Override
@@ -679,6 +718,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             return null;
         }
 
+        public List<Descriptor<AMITypeData>> getAMITypeDescriptors()
+        {
+            return Hudson.getInstance().<AMITypeData,Descriptor<AMITypeData>>getDescriptorList(AMITypeData.class);
+        }
+        
         /**
          * Since this shares much of the configuration with {@link EC2Computer}, check its help page, too.
          */

--- a/src/main/java/hudson/plugins/ec2/UnixData.java
+++ b/src/main/java/hudson/plugins/ec2/UnixData.java
@@ -1,0 +1,77 @@
+package hudson.plugins.ec2;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class UnixData extends AMITypeData {
+
+    private final String rootCommandPrefix;
+    private final String sshPort;
+
+    @DataBoundConstructor
+    public UnixData(String rootCommandPrefix, String sshPort)
+    {
+        this.rootCommandPrefix = rootCommandPrefix;
+        this.sshPort = sshPort;
+    }
+
+    public boolean isWindows() {
+        return false;
+    }
+
+    public boolean isUnix() {
+        return true;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<AMITypeData> 
+    {
+        public String getDisplayName() {
+            return "unix";
+        }
+    }
+
+    public String getRootCommandPrefix() {
+        return rootCommandPrefix;
+    }
+
+    public String getSshPort() {
+        return sshPort == null || sshPort.length() == 0 ? "22" : sshPort;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime
+                        * result
+                        + ((rootCommandPrefix == null) ? 0 : rootCommandPrefix
+                                        .hashCode());
+        result = prime * result + ((sshPort == null) ? 0 : sshPort.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!(obj instanceof UnixData))
+            return false;
+        UnixData other = (UnixData) obj;
+        if (rootCommandPrefix == null) {
+            if (other.rootCommandPrefix != null)
+                return false;
+        } else if (!rootCommandPrefix.equals(other.rootCommandPrefix))
+            return false;
+        if (sshPort == null) {
+            if (other.sshPort != null)
+                return false;
+        } else if (!sshPort.equals(other.sshPort))
+            return false;
+        return true;
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/WindowsData.java
+++ b/src/main/java/hudson/plugins/ec2/WindowsData.java
@@ -1,0 +1,95 @@
+package hudson.plugins.ec2;
+
+import java.util.concurrent.TimeUnit;
+
+import hudson.Extension;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Hudson;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class WindowsData extends AMITypeData {
+
+    private final String password;
+    private final boolean useHTTPS;
+    private final String bootDelay;
+
+    @DataBoundConstructor
+    public WindowsData(String password, boolean useHTTPS, String bootDelay)
+    {
+        this.password = password;
+        this.useHTTPS = useHTTPS;
+        this.bootDelay= bootDelay;
+    }
+
+    public boolean isWindows() {
+        return true;
+    }
+
+    public boolean isUnix() {
+        return false;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public boolean isUseHTTPS() {
+        return useHTTPS;
+    }
+
+    public String getBootDelay() {
+        return bootDelay;
+    }
+
+    public int getBootDelayInMillis() {
+        try {
+            return (int) TimeUnit.SECONDS.toMillis(Integer.parseInt(bootDelay));
+        } catch (NumberFormatException nfe ) {
+            return 0;
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<AMITypeData> 
+    {
+        public String getDisplayName() {
+            return "windows";
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((bootDelay == null) ? 0 : bootDelay.hashCode());
+        result = prime * result + ((password == null) ? 0 : password.hashCode());
+        result = prime * result + (useHTTPS ? 1231 : 1237);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!(obj instanceof WindowsData))
+            return false;
+        WindowsData other = (WindowsData) obj;
+        if (bootDelay == null) {
+            if (other.bootDelay != null)
+                return false;
+        } else if (!bootDelay.equals(other.bootDelay))
+            return false;
+        if (password == null) {
+            if (other.password != null)
+                return false;
+        } else if (!password.equals(other.password))
+            return false;
+        if (useHTTPS != other.useHTTPS)
+            return false;
+        return true;
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -1,0 +1,153 @@
+package hudson.plugins.ec2.win;
+
+import hudson.model.Descriptor;
+import hudson.model.Hudson;
+import hudson.plugins.ec2.EC2Computer;
+import hudson.plugins.ec2.EC2ComputerLauncher;
+import hudson.plugins.ec2.win.winrm.WindowsProcess;
+import hudson.remoting.Channel;
+import hudson.remoting.Channel.Listener;
+import hudson.slaves.ComputerLauncher;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.IOUtils;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.ec2.model.Instance;
+import com.trilead.ssh2.Session;
+
+public class EC2WindowsLauncher extends EC2ComputerLauncher {
+
+    final long sleepBetweenAttemps = TimeUnit.SECONDS.toMillis(10);
+    
+    @Override
+    protected void launch(EC2Computer computer, PrintStream logger, Instance inst) throws IOException, AmazonClientException,
+    InterruptedException {
+        final WinConnection connection = connectToWinRM(computer, logger);
+
+        try {
+            String initScript = computer.getNode().initScript;
+
+            if(initScript!=null && initScript.trim().length()>0 && !connection.exists("C:\\Windows\\Temp\\.jenkins-init")) {
+                logger.println("Executing init script");
+                OutputStream init = connection.putFile("C:\\Windows\\Temp\\init.bat");
+                init.write(initScript.getBytes("utf-8"));
+                
+                WindowsProcess initProcess = connection.execute("cmd /c C:\\Windows\\Temp\\init.bat");
+                IOUtils.copy(initProcess.getStdout(),logger);
+
+                int exitStatus = initProcess.waitFor();
+                if (exitStatus!=0) {
+                    logger.println("init script failed: exit code="+exitStatus);
+                    return;
+                }
+
+                OutputStream initGuard = connection.putFile("C:\\Windows\\Temp\\.jenkins-init");
+                initGuard.write("init ran".getBytes());
+                logger.println("init script failed ran successfully");
+            }
+
+            
+            OutputStream slaveJar = connection.putFile("C:\\Windows\\Temp\\slave.jar");
+            slaveJar.write(Hudson.getInstance().getJnlpJars("slave.jar").readFully());
+
+            logger.println("slave.jar sent remotely. Bootstrapping it");
+            
+            final String jvmopts = computer.getNode().jvmopts;
+            final WindowsProcess process = connection.execute("java " + (jvmopts != null ? jvmopts : "") + " -jar C:\\Windows\\Temp\\slave.jar", 86400);
+            computer.setChannel(process.getStdout(), process.getStdin(), logger, new Listener() {
+                @Override
+                public void onClosed(Channel channel, IOException cause) {
+                    process.destroy();
+                    connection.close();
+                }
+            });
+        } catch (Throwable ioe) {
+            logger.println("Ouch:");
+            ioe.printStackTrace(logger);
+        } finally {
+            connection.close();
+        }
+    }
+
+    private WinConnection connectToWinRM(EC2Computer computer, PrintStream logger) throws AmazonClientException,
+    InterruptedException {
+        final long timeout = computer.getNode().getLaunchTimeoutInMillis();
+        final long startTime = System.currentTimeMillis();
+        
+        logger.println(computer.getNode().getDisplayName() + " booted at " + computer.getNode().getCreatedTime());
+        boolean alreadyBooted = (startTime - computer.getNode().getCreatedTime()) > TimeUnit.MINUTES.toMillis(3);
+        while (true) {
+            try {
+                long waitTime = System.currentTimeMillis() - startTime;
+                if (waitTime > timeout) {
+                    throw new AmazonClientException("Timed out after " + (waitTime / 1000)
+                            + " seconds of waiting for winrm to be connected");
+                }
+                Instance instance = computer.updateInstanceDescription();
+                String vpc_id = instance.getVpcId();
+                String ip, host;
+
+                if (computer.getNode().usePrivateDnsName) {
+                    host = instance.getPrivateDnsName();
+                    ip = instance.getPrivateIpAddress(); // SmbFile doesn't quite work with hostnames
+                } else {
+                    /*
+                     * VPC hosts don't have public DNS names, so we need to use
+                     * an IP address instead
+                     */
+                    if (vpc_id == null || vpc_id.equals("")) {
+                        host = instance.getPublicDnsName();
+                        ip = instance.getPublicIpAddress(); // SmbFile doesn't quite work with hostnames
+                    } else {
+                        host = instance.getPrivateDnsName();
+                        ip = instance.getPrivateIpAddress();
+                    }
+                }
+
+                if ("0.0.0.0".equals(host)) {
+                    logger.println("Invalid host 0.0.0.0, your host is most likely waiting for an ip address.");
+                    throw new IOException("goto sleep");
+                }
+
+                logger.println("Connecting to " + host + "(" + ip + ") with WinRM as " + computer.getNode().remoteAdmin);
+
+                WinConnection connection = new WinConnection(ip, computer.getNode().remoteAdmin, computer.getNode().getAdminPassword());
+                connection.setUseHTTPS(computer.getNode().isUseHTTPS());
+                if (!connection.ping()) {
+                    logger.println("Waiting for WinRM to come up. Sleeping 10s.");
+                    Thread.sleep(sleepBetweenAttemps);
+                    continue;
+                }
+                
+                if (!alreadyBooted || computer.getNode().stopOnTerminate) {
+                    logger.println("WinRM service responded. Waiting for WinRM service to stabilize on " + computer.getNode().getDisplayName());
+                    Thread.sleep(computer.getNode().getBootDelay());
+                    alreadyBooted = true;
+                    logger.println("WinRM should now be ok on " + computer.getNode().getDisplayName());
+                    if (!connection.ping()) {
+                        logger.println("WinRM not yet up. Sleeping 10s.");
+                        Thread.sleep(sleepBetweenAttemps);
+                        continue;
+                    }
+                }
+
+                logger.println("Connected with WinRM.");
+                return connection; // successfully connected
+            } catch (IOException e) {
+                logger.println("Waiting for WinRM to come up. Sleeping 10s.");
+                Thread.sleep(sleepBetweenAttemps);
+            }
+        }
+    }
+
+    @Override
+    public Descriptor<ComputerLauncher> getDescriptor() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/win/WinConnection.java
+++ b/src/main/java/hudson/plugins/ec2/win/WinConnection.java
@@ -1,0 +1,133 @@
+package hudson.plugins.ec2.win;
+
+import hudson.plugins.ec2.win.winrm.WinRM;
+import hudson.plugins.ec2.win.winrm.WindowsProcess;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.regex.Pattern;
+
+import jcifs.smb.NtlmPasswordAuthentication;
+import jcifs.smb.SmbFile;
+import static java.util.regex.Pattern.quote;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class WinConnection {
+    private static final Logger log = Logger.getLogger(WinConnection.class.getName());
+
+    // ^[a-zA-Z]\:(\\|\/)([^\\\/\:\*\?\<\>\"\|]+(\\|\/){0,1})+$
+    private static final Pattern VALIDATE_WINDOWS_PATH = Pattern.compile("^[A-Za-z]:\\\\[-a-zA-Z0-9_.\\\\]*");
+
+    private String host;
+    private String username;
+    private String password;
+
+    private final NtlmPasswordAuthentication authentication;
+
+    private boolean useHTTPS;
+
+    public WinConnection(String host, String username, String password) {
+        this.host = host;
+        this.username = username;
+        this.password = password;
+        this.authentication = new NtlmPasswordAuthentication(null, username, password);
+    }
+
+    public WinRM winrm() {
+        WinRM winrm = new WinRM(host, username, password);
+        winrm.setUseHTTPS(useHTTPS);
+        return winrm;
+    }
+
+    public WinRM winrm(int timeout) {
+        WinRM winrm = winrm();
+        winrm.setTimeout(timeout);
+        return winrm;
+    }
+
+    public WindowsProcess execute(String commandLine) {
+        return execute(commandLine, 60);
+    }
+
+    public WindowsProcess execute(String commandLine, int timeout) {
+        return winrm(timeout).execute(commandLine);
+    }
+
+    public OutputStream putFile(String path) throws IOException {
+        SmbFile smbFile = new SmbFile(encodeForSmb(path), authentication);
+        return smbFile.getOutputStream();
+    }
+
+    public InputStream getFile(String path) throws IOException {
+        SmbFile smbFile = new SmbFile(encodeForSmb(path), authentication);
+        return smbFile.getInputStream();
+    }
+
+    public boolean exists(String path) throws IOException {
+        SmbFile smbFile = new SmbFile(encodeForSmb(path), authentication);
+        return smbFile.exists();
+    }
+   
+    private String encodeForSmb(String path) {
+        if (!VALIDATE_WINDOWS_PATH.matcher(path).matches()) {
+            throw new IllegalArgumentException("Path '" + path + "' is not a valid windows path like C:\\Windows\\Temp");
+        }
+
+        StringBuilder smbUrl = new StringBuilder(smbURLPrefix());
+        smbUrl.append(toAdministrativeSharePath(path).replace('\\', '/'));
+        return smbUrl.toString();
+    }
+
+    private String toAdministrativeSharePath(String path) {
+        // administrative windows share are DRIVE$path like
+        return path.substring(0, 1) + "$" + path.substring(2);
+    }
+
+    private String smbURLPrefix() {
+        StringBuilder prefix = new StringBuilder();
+        prefix.append("smb://");
+        if (username != null) {
+            prefix.append(urlEncode(username.replaceFirst(quote("\\"), ";")));
+            prefix.append(":");
+            prefix.append(urlEncode(password));
+            prefix.append("@");
+        }
+        // port?
+        prefix.append(urlEncode(host));
+        prefix.append('/');
+        return prefix.toString();
+    }
+
+    private static String urlEncode(String value) {
+        try {
+            return URLEncoder.encode(value, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Invalid SMB URL", e);
+        }
+    }
+
+    public boolean ping() {
+        log.log(Level.FINE, "pinging " + host);
+        try {
+            winrm().ping();
+            SmbFile test = new SmbFile(encodeForSmb("C:\\"), authentication);
+            test.connect();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public void close() {
+    }
+
+    public void setUseHTTPS(boolean useHTTPS) {
+        this.useHTTPS = useHTTPS;
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/RuntimeIOException.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/RuntimeIOException.java
@@ -1,0 +1,19 @@
+package hudson.plugins.ec2.win.winrm;
+
+public class RuntimeIOException extends RuntimeException {
+    public RuntimeIOException() {
+        super();
+    }
+
+    public RuntimeIOException(String message) {
+        super(message);
+    }
+
+    public RuntimeIOException(Throwable cause) {
+        super(cause);
+    }
+
+    public RuntimeIOException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WinRM.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WinRM.java
@@ -1,0 +1,134 @@
+package hudson.plugins.ec2.win.winrm;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Logger;
+
+public class WinRM {
+    private static final Logger log = Logger.getLogger(WinRM.class.getName());
+
+    private String host;
+    private String username;
+    private String password;
+    private int timeout = 60;
+
+    private boolean useHTTPS;
+
+    public WinRM(String host, String username, String password) {
+        this.host = host;
+        this.username = username;
+        this.password = password;
+    }
+
+    public void ping() throws IOException {
+        final WinRMClient client = new WinRMClient(buildURL(), username, password);
+        client.setTimeout(secToDuration(timeout));
+        client.setUseHTTPS(isUseHTTPS());
+        try {
+            client.openShell();
+        } finally {
+            try {
+                client.deleteShell();
+            } catch (Exception e) {
+            }
+        }
+    }
+
+    public WindowsProcess execute(String commandLine) {
+        final WinRMClient client = new WinRMClient(buildURL(), username, password);
+        client.setTimeout(secToDuration(timeout));
+        client.setUseHTTPS(isUseHTTPS());
+        try {
+            client.openShell();
+            client.executeCommand(commandLine);
+
+            return new WindowsProcess(client, commandLine);
+        } catch (IOException exc) {
+            throw new RuntimeException("Cannot execute command " + commandLine + " on " + this, exc);
+        }
+    }
+
+    public URL buildURL() {
+        String scheme = useHTTPS ? "https" : "http";
+        int port = useHTTPS ? 5986 : 5985;
+
+        try {
+            return new URL(scheme, host, port, "/wsman");
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Invalid winrm url");
+        }
+    }
+
+    /**
+     * @return the useHTTPS
+     */
+    public boolean isUseHTTPS() {
+        return useHTTPS;
+    }
+
+    /**
+     * @param useHTTPS
+     *            the useHTTPS to set
+     */
+    public void setUseHTTPS(boolean useHTTPS) {
+        this.useHTTPS = useHTTPS;
+    }
+
+    /**
+     * @return the timeout
+     */
+    public int getTimeout() {
+        return timeout;
+    }
+
+    /**
+     * @param timeout
+     *            the timeout to set
+     */
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
+    }
+
+    /**
+     * # Convert the number of seconds to an ISO8601 duration format # @see
+     * http://tools.ietf.org/html/rfc2445#section-4.3.6 # @param [Fixnum]
+     * seconds The amount of seconds for this duration
+     * 
+     * @param timeout
+     * @return
+     */
+    private String secToDuration(int seconds) {
+        StringBuilder iso = new StringBuilder("P");
+        if (seconds > 604800) {
+            // more than a week
+            int weeks = seconds / 604800;
+            seconds -= (604800 * weeks);
+            iso.append(weeks).append("W");
+        }
+
+        if (seconds > 86400) {
+            // more than a day
+            int days = seconds / 86400;
+            seconds -= (86400 * days);
+            iso.append(days).append("D");
+        }
+
+        if (seconds > 0) {
+            iso.append('T');
+            if (seconds > 3600) { // more than an hour
+                int hours = seconds / 3600;
+                seconds -= (3600 * hours);
+                iso.append(hours).append("H");
+            }
+            if (seconds > 60) { // more than a minute
+                int minutes = seconds / 60;
+                seconds -= (60 * minutes);
+                iso.append(minutes).append("M");
+            }
+            iso.append(seconds).append("S");
+        }
+
+        return iso.toString();
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
@@ -1,0 +1,317 @@
+package hudson.plugins.ec2.win.winrm;
+
+import hudson.plugins.ec2.win.winrm.request.RequestFactory;
+import hudson.plugins.ec2.win.winrm.soap.Namespaces;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.io.PipedOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.ConnectException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.net.ssl.SSLException;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.ParseException;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.params.AuthPolicy;
+import org.apache.http.client.protocol.ClientContext;
+import org.apache.http.conn.HttpHostConnectException;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.apache.http.params.CoreConnectionPNames;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.ExecutionContext;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.dom4j.XPath;
+import org.jaxen.SimpleNamespaceContext;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+public class WinRMClient {
+    private static final Logger log = Logger.getLogger(WinRMClient.class.getName());
+
+    private URL url;
+    private String username;
+    private String password;
+    private String shellId;
+
+    private String commandId;
+    private int exitCode;
+
+    private SimpleNamespaceContext namespaceContext;
+
+    private final RequestFactory factory;
+
+    private ThreadLocal<BasicAuthCache> authCache = new ThreadLocal<BasicAuthCache>();
+    private boolean useHTTPS;
+    private Scheme httpsScheme;
+    private BasicCredentialsProvider credsProvider;
+
+
+    public WinRMClient(URL url, String username, String password) {
+        this.url = url;
+        this.username = username;
+        this.password = password;
+        this.factory = new RequestFactory(url);
+        setupHTTPClient();
+    }
+
+    public void openShell() {
+        log.log(Level.FINE, "opening winrm shell to: " + url);
+        Document request = factory.newOpenShellRequest().build();
+        shellId = first(sendRequest(request), "//*[@Name='ShellId']");
+        log.log(Level.FINER, "shellid: " + shellId);
+    }
+
+    public void executeCommand(String command) {
+        log.log(Level.FINE, "winrm execute on " + shellId + " command: " + command);
+        Document request = factory.newExecuteCommandRequest(shellId, command).build();
+        commandId = first(sendRequest(request), "//" + Namespaces.NS_WIN_SHELL.getPrefix() + ":CommandId");
+        log.log(Level.FINER, "winrm started execution on " + shellId + " commandId: " + commandId);
+    }
+
+    public void deleteShell() {
+        if (shellId == null) {
+            throw new IllegalStateException("no shell has been created");
+        }
+
+        log.log(Level.FINE, "closing winrm shell " + shellId);
+
+        Document request = factory.newDeleteShellRequest(shellId).build();
+        sendRequest(request);
+
+    }
+
+    public void signal() {
+        if (commandId == null) {
+            throw new IllegalStateException("no command is running");
+        }
+
+        log.log(Level.FINE, "signalling winrm shell " + shellId + " command: " + commandId);
+
+        Document request = factory.newSignalRequest(shellId, commandId).build();
+        sendRequest(request);
+    }
+
+    public void sendInput(byte[] input) {
+        log.log(Level.FINE, "--> sending " + input.length);
+
+        Document request = factory.newSendInputRequest(input, shellId, commandId).build();
+        sendRequest(request);
+    }
+
+    public boolean slurpOutput(PipedOutputStream stdout, PipedOutputStream stderr) throws IOException {
+        log.log(Level.FINE, "--> SlurpOutput");
+        ImmutableMap<String, PipedOutputStream> streams = ImmutableMap.of("stdout", stdout, "stderr", stderr);
+
+        Document request = factory.newGetOutputRequest(shellId, commandId).build();
+        Document response = sendRequest(request);
+
+        XPath xpath = DocumentHelper.createXPath("//" + Namespaces.NS_WIN_SHELL.getPrefix() + ":Stream");
+        namespaceContext = new SimpleNamespaceContext();
+        namespaceContext.addNamespace(Namespaces.NS_WIN_SHELL.getPrefix(), Namespaces.NS_WIN_SHELL.getURI());
+        xpath.setNamespaceContext(namespaceContext);
+
+        Base64 base64 = new Base64();
+        for (Element e : (List<Element>) xpath.selectNodes(response)) {
+            PipedOutputStream stream = streams.get(e.attribute("Name").getText().toLowerCase());
+            final byte[] decode = base64.decode(e.getText());
+            log.log(Level.FINE, "piping " + decode.length + " bytes from " + e.attribute("Name").getText().toLowerCase());
+
+            stream.write(decode);
+        }
+
+        XPath done = DocumentHelper
+                .createXPath("//*[@State='http://schemas.microsoft.com/wbem/wsman/1/windows/shell/CommandState/Done']");
+        done.setNamespaceContext(namespaceContext);
+        if (Iterables.isEmpty(done.selectNodes(response))) {
+            log.log(Level.FINE, "keep going baby!");
+            return true;
+        } else {
+            exitCode = Integer.parseInt(first(response, "//" + Namespaces.NS_WIN_SHELL.getPrefix() + ":ExitCode"));
+            log.log(Level.FINE, "no more output - command is now done - exit code: " + exitCode);
+        }
+        return false;
+    }
+
+    public int exitCode() {
+        return exitCode;
+    }
+
+    private static String first(Document doc, String selector) {
+        XPath xpath = DocumentHelper.createXPath(selector);
+        try {
+            return Iterables.get((List<Element>) xpath.selectNodes(doc), 0).getText();
+        } catch (IndexOutOfBoundsException e) {
+            throw new RuntimeException("Malformed response for " + selector + " in " + doc.asXML());
+        }
+    }
+
+    private void setupHTTPClient() {
+        credsProvider = new BasicCredentialsProvider();
+        credsProvider.setCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT), new UsernamePasswordCredentials(
+                username, password));
+
+        if (useHTTPS) {
+            SSLSocketFactory socketFactory;
+            try {
+                socketFactory = new SSLSocketFactory(new TrustSelfSignedStrategy(), new AllowAllHostnameVerifier());
+                httpsScheme = new Scheme("https", 443, socketFactory);
+            } catch (KeyManagementException e) {
+            } catch (UnrecoverableKeyException e) {
+            } catch (NoSuchAlgorithmException e) {
+            } catch (KeyStoreException e) {
+            }
+        }
+    }
+
+    private DefaultHttpClient buildHTTPClient()
+    {
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+        httpclient.getAuthSchemes().unregister(AuthPolicy.SPNEGO);
+        httpclient.setCredentialsProvider(credsProvider);
+        httpclient.getParams().setParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, 5000);
+        //httpclient.setHttpRequestRetryHandler(new WinRMRetryHandler());
+        return httpclient;
+    }
+
+    private Document sendRequest(Document request) {
+        return sendRequest(request, 0);
+    }
+
+    private Document sendRequest(Document request, int retry) {
+        if (retry > 3) {
+            throw new RuntimeException("Too many retry for request");
+        }
+        
+        DefaultHttpClient httpclient = buildHTTPClient();
+        HttpContext context = new BasicHttpContext();
+        
+        if (authCache.get() == null) {
+            authCache.set(new BasicAuthCache());
+        }
+        
+        context.setAttribute(ClientContext.AUTH_CACHE, authCache.get());
+
+        if (useHTTPS) {
+            httpclient.getConnectionManager().getSchemeRegistry().register(httpsScheme);
+        }
+
+        try {
+            HttpPost post = new HttpPost(url.toURI());
+
+            HttpEntity entity = new StringEntity(request.asXML(), "application/soap+xml", "UTF-8");
+            post.setEntity(entity);
+
+            log.log(Level.FINEST, "Request:\nPOST " + url + "\n" + request.asXML());
+
+            HttpResponse response = httpclient.execute(post, context);
+            HttpEntity responseEntity = response.getEntity();
+
+            if (response.getStatusLine().getStatusCode() != 200) {
+                // check for possible timeout
+
+                if (response.getStatusLine().getStatusCode() == 500
+                        && (responseEntity.getContentType() != null && entity.getContentType().getValue()
+                        .startsWith("application/soap+xml"))) {
+                    String respStr = EntityUtils.toString(responseEntity);
+                    if (respStr.contains("TimedOut")) {
+                        return DocumentHelper.parseText(respStr);
+                    }
+                } else {
+                    // this shouldn't happen, as httpclient knows how to auth the request
+                    // but I've seen it. I blame keep-alive, so we're just going
+                    // to scrap the connections, and try again
+                    if (response.getStatusLine().getStatusCode() == 401) {
+                        // we need to force using new connections here
+                        // throw away our auth cache
+                        log.log(Level.WARNING, "winrm returned 401 - shouldn't happen though - retrying in 2 minutes");
+                        try {
+                            Thread.sleep(TimeUnit.MINUTES.toMillis(3));
+                        } catch (InterruptedException e) {
+                        }
+                        authCache.set(new BasicAuthCache());
+                        log.log(Level.WARNING, "winrm returned 401 - retrying now");
+                        return sendRequest(request, ++retry);
+                    }
+                    log.log(Level.WARNING, "winrm service " + shellId + " unexpected HTTP Response ("
+                            + response.getStatusLine().getReasonPhrase() + "): " + EntityUtils.toString(response.getEntity()));
+
+                    throw new RuntimeException("Unexpected HTTP response " + response.getStatusLine().getStatusCode() + " on "
+                            + url + ": " + response.getStatusLine().getReasonPhrase());
+                }
+            }
+
+            if (responseEntity.getContentType() == null || !entity.getContentType().getValue().startsWith("application/soap+xml")) {
+                throw new RuntimeException("Unexepected WinRM content type: " + entity.getContentType());
+            }
+
+            Document responseDocument = DocumentHelper.parseText(EntityUtils.toString(responseEntity));
+
+            log.log(Level.FINEST, "Response:\n" + responseDocument.asXML());
+            return responseDocument;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Invalid WinRM URI " + url);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Invalid WinRM body " + request.asXML());
+        } catch (ClientProtocolException e) {
+            throw new RuntimeException("HTTP Error " + e.getMessage(), e);
+        } catch (HttpHostConnectException e) {
+            log.log(Level.SEVERE, "Can't connect to host", e);
+            throw new WinRMConnectException("Can't connect to host: " + e.getMessage(), e);
+        } catch (IOException e) {
+            log.log(Level.SEVERE, "I/O Exception in HTTP POST", e);
+            throw new RuntimeIOException("I/O Exception " + e.getMessage(), e);
+        } catch (ParseException e) {
+            log.log(Level.SEVERE, "XML Parse exception in HTTP POST", e);
+            throw new RuntimeException("Unparseable XML in winRM response " + e.getMessage(), e);
+        } catch (DocumentException e) {
+            log.log(Level.SEVERE, "XML Document exception in HTTP POST", e);
+            throw new RuntimeException("Invalid XML document in winRM response " + e.getMessage(), e);
+        }
+    }
+
+    public String getTimeout() {
+        return factory.getTimeout();
+    }
+
+    public void setTimeout(String timeout) {
+        factory.setTimeout(timeout);
+    }
+
+    public void setUseHTTPS(boolean useHTTPS) {
+        this.useHTTPS = useHTTPS;
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WinRMConnectException.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WinRMConnectException.java
@@ -1,0 +1,9 @@
+package hudson.plugins.ec2.win.winrm;
+
+public class WinRMConnectException extends RuntimeIOException {
+
+    public WinRMConnectException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
@@ -1,0 +1,152 @@
+package hudson.plugins.ec2.win.winrm;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.common.io.Closeables;
+
+public class WindowsProcess {
+    private static final Logger log = Logger.getLogger(WindowsProcess.class.getName());
+
+    private final static int INPUT_BUFFER = 16 * 1024;
+    private final WinRMClient client;
+
+    private final PipedInputStream toCallersStdin;
+    private final PipedOutputStream callersStdin;
+    private final PipedInputStream callersStdout;
+    private final PipedOutputStream toCallersStdout;
+    private final PipedInputStream callersStderr;
+    private final PipedOutputStream toCallersStderr;
+
+    private boolean terminated;
+    private String command;
+
+    private Thread outputThread;
+
+    private Thread inputThread;
+
+    WindowsProcess(WinRMClient client, String command) throws IOException {
+        this.client = client;
+        this.command = command;
+
+        toCallersStdin = new PipedInputStream(INPUT_BUFFER);
+        callersStdin = new PipedOutputStream(toCallersStdin);
+        callersStdout = new PipedInputStream(INPUT_BUFFER);
+        toCallersStdout = new PipedOutputStream(callersStdout);
+        callersStderr = new PipedInputStream(INPUT_BUFFER);
+        toCallersStderr = new PipedOutputStream(callersStderr);
+        startStdoutCopyThread();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+        }
+        startStdinCopyThread();
+    }
+
+    public InputStream getStdout() {
+        return callersStdout;
+    }
+
+    public OutputStream getStdin() {
+        return callersStdin;
+    }
+
+    public InputStream getStderr() {
+        return callersStderr;
+    }
+
+    public synchronized int waitFor() {
+        if (terminated) {
+            return client.exitCode();
+        }
+
+        try {
+            try {
+                outputThread.join();
+            } finally {
+                client.deleteShell();
+                terminated = true;
+            }
+            return client.exitCode();
+        } catch (InterruptedException exc) {
+            throw new RuntimeException("Exception while executing command", exc);
+        }
+    }
+
+    public synchronized void destroy() {
+        if (terminated) {
+            return;
+        }
+
+        client.signal();
+        client.deleteShell();
+        terminated = true;
+    }
+
+    private void startStdoutCopyThread() {
+        outputThread = new Thread("output copy: " + command) {
+            @Override
+            public void run() {
+                try {
+                    for (;;) {
+                        if (!client.slurpOutput(toCallersStdout, toCallersStderr)) {
+                            log.log(Level.FINE, "no more output for " + command);
+                            break;
+                        }
+                    }
+                } catch (Exception exc) {
+                    log.log(Level.WARNING, "ouch, stdout exception for " + command, exc);
+                    exc.printStackTrace();
+                } finally {
+                    Closeables.closeQuietly(toCallersStdout);
+                    Closeables.closeQuietly(toCallersStderr);
+                }
+            }
+        };
+        outputThread.setDaemon(true);
+        outputThread.start();
+    }
+
+    private void startStdinCopyThread() {
+        inputThread = new Thread("input copy: " + command) {
+            @Override
+            public void run() {
+                try {
+                    byte[] buf = new byte[INPUT_BUFFER];
+                    for (;;) {
+                        int n = 0;
+                        try {
+                            n = toCallersStdin.read(buf);
+                        } catch(IOException ioe) {
+                            // it's safe to ignore IO Exception coming from Jenkins
+                            // This can happen with PipedInputStream if the writing Thread
+                            // is killed but the input stream is handed to another thread
+                            // in this case, we can still read from the pipe.
+                            continue;
+                        }
+                        if (n == -1)
+                            break;
+                        if (n == 0)
+                            continue;
+
+                        byte[] bufToSend = new byte[n];
+                        System.arraycopy(buf, 0, bufToSend, 0, n);
+                        log.log(Level.FINE, "piping " + bufToSend.length + " to input of " + command);
+                        client.sendInput(bufToSend);
+                    }
+                } catch (Exception exc) {
+                    log.log(Level.WARNING, "ouch, STDIN exception for " + command, exc);
+                } finally {
+                    Closeables.closeQuietly(callersStdin);
+                }
+            }
+        };
+        inputThread.setDaemon(true);
+        inputThread.start();
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/AbstractWinRMRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/AbstractWinRMRequest.java
@@ -1,0 +1,82 @@
+package hudson.plugins.ec2.win.winrm.request;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.UUID;
+
+import hudson.plugins.ec2.win.winrm.soap.HeaderBuilder;
+import hudson.plugins.ec2.win.winrm.soap.MessageBuilder;
+
+import org.dom4j.Document;
+import org.dom4j.Element;
+
+public abstract class AbstractWinRMRequest implements WinRMRequest {
+
+    protected MessageBuilder message = new MessageBuilder();
+    protected HeaderBuilder header = message.newHeader();
+
+    protected String timeout = "PT60S";
+    protected int envelopSize = 153600;
+    protected String locale = "en-US";
+
+    protected URL url;
+
+    public AbstractWinRMRequest(URL url) {
+        this.url = url;
+    }
+
+    protected abstract void construct();
+
+
+
+    public Document build() {
+        construct();
+        return message.build();
+    }
+
+    protected HeaderBuilder defaultHeader() throws URISyntaxException
+    {
+        return header.to(url.toURI())
+                .replyTo(new URI("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous"))
+                .maxEnvelopeSize(envelopSize)
+                .id(generateUUID())
+                .locale(locale)
+                .timeout(timeout);
+    }
+
+
+    protected void setBody(Element body) {
+        message.addHeader(header.build());
+        message.addBody(body);
+    }
+
+    protected String generateUUID() {
+        return "uuid:" + UUID.randomUUID().toString().toUpperCase();
+    }
+
+    public String getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(String timeout) {
+        this.timeout = timeout;
+    }
+
+    public int getEnvelopSize() {
+        return envelopSize;
+    }
+
+    public void setEnvelopSize(int envelopSize) {
+        this.envelopSize = envelopSize;
+    }
+
+    public String getLocale() {
+        return locale;
+    }
+
+    public void setLocale(String locale) {
+        this.locale = locale;
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/DeleteShellRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/DeleteShellRequest.java
@@ -1,0 +1,28 @@
+package hudson.plugins.ec2.win.winrm.request;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public class DeleteShellRequest extends AbstractWinRMRequest {
+
+    private String shellId;
+
+    public DeleteShellRequest(URL url, String shellId) {
+        super(url);
+        this.shellId = shellId;
+    }
+
+    @Override
+    protected void construct() {
+        try {
+            defaultHeader().action(new URI("http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete")).shellId(shellId)
+                    .resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd"));
+
+            setBody(null);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Error while building request content", e);
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/ExecuteCommandRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/ExecuteCommandRequest.java
@@ -1,0 +1,42 @@
+package hudson.plugins.ec2.win.winrm.request;
+
+import hudson.plugins.ec2.win.winrm.soap.Namespaces;
+import hudson.plugins.ec2.win.winrm.soap.Option;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.dom4j.QName;
+
+import com.google.common.collect.ImmutableList;
+
+public class ExecuteCommandRequest extends AbstractWinRMRequest {
+
+    private String shellId;
+    private String command;
+
+    public ExecuteCommandRequest(URL url, String shellId, String command) {
+        super(url);
+        this.command = command;
+        this.shellId = shellId;
+    }
+
+    @Override
+    protected void construct() {
+        try {
+            defaultHeader().action(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command"))
+                    .resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd")).shellId(shellId)
+                    .options(ImmutableList.of(new Option("WINRS_CONSOLEMODE_STDIN", "FALSE")));
+
+            Element body = DocumentHelper.createElement(QName.get("CommandLine", Namespaces.NS_WIN_SHELL));
+            body.addElement(QName.get("Command", Namespaces.NS_WIN_SHELL)).addText("\"" + command + "\"");
+            setBody(body);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Error while building request content", e);
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/GetOutputRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/GetOutputRequest.java
@@ -1,0 +1,38 @@
+package hudson.plugins.ec2.win.winrm.request;
+
+import hudson.plugins.ec2.win.winrm.soap.Namespaces;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.dom4j.QName;
+
+public class GetOutputRequest extends AbstractWinRMRequest {
+
+    private String shellId, commandId;
+
+    public GetOutputRequest(URL url, String shellId, String commandId) {
+        super(url);
+        this.shellId = shellId;
+        this.commandId = commandId;
+    }
+
+    @Override
+    protected void construct() {
+        try {
+            defaultHeader().action(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive"))
+                            .resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd")).shellId(shellId);
+
+            Element body = DocumentHelper.createElement(QName.get("Receive", Namespaces.NS_WIN_SHELL));
+            body.addElement(QName.get("DesiredStream", Namespaces.NS_WIN_SHELL)).addAttribute("CommandId", commandId)
+                            .addText("stdout stderr");
+            setBody(body);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Error while building request content", e);
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/OpenShellRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/OpenShellRequest.java
@@ -1,0 +1,38 @@
+package hudson.plugins.ec2.win.winrm.request;
+
+import hudson.plugins.ec2.win.winrm.soap.Namespaces;
+import hudson.plugins.ec2.win.winrm.soap.Option;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.dom4j.QName;
+
+import com.google.common.collect.ImmutableList;
+
+public class OpenShellRequest extends AbstractWinRMRequest implements WinRMRequest {
+
+    public OpenShellRequest(URL url) {
+        super(url);
+    }
+
+    protected void construct() {
+        try {
+            defaultHeader().action(new URI("http://schemas.xmlsoap.org/ws/2004/09/transfer/Create"))
+                            .resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd"))
+                            .options(ImmutableList.of(new Option("WINRS_NOPROFILE", "FALSE"), new Option("WINRS_CODEPAGE", "437")));
+
+            Element body = DocumentHelper.createElement(QName.get("Shell", Namespaces.NS_WIN_SHELL));
+            body.addElement(QName.get("InputStreams", Namespaces.NS_WIN_SHELL)).addText("stdin");
+            body.addElement(QName.get("OutputStreams", Namespaces.NS_WIN_SHELL)).addText("stdout stderr");
+            setBody(body);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Error while building request content", e);
+        }
+
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/RequestFactory.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/RequestFactory.java
@@ -1,0 +1,81 @@
+package hudson.plugins.ec2.win.winrm.request;
+
+import java.net.URL;
+
+public class RequestFactory {
+    private URL url;
+    private String timeout = "PT60S";
+    private int envelopSize = 153600;
+    private String locale = "en-US";
+
+    public RequestFactory(URL url) {
+        this.url = url;
+    }
+
+    public OpenShellRequest newOpenShellRequest() {
+        OpenShellRequest r = new OpenShellRequest(url);
+        setDefaults(r);
+        return r;
+    }
+
+    public ExecuteCommandRequest newExecuteCommandRequest(String shellId, String command) {
+        ExecuteCommandRequest r = new ExecuteCommandRequest(url, shellId, command);
+        setDefaults(r);
+        return r;
+    }
+
+    public DeleteShellRequest newDeleteShellRequest(String shellId) {
+        DeleteShellRequest r = new DeleteShellRequest(url, shellId);
+        setDefaults(r);
+        return r;
+    }
+
+    public SignalRequest newSignalRequest(String shellId, String commandId) {
+        SignalRequest r = new SignalRequest(url, shellId, commandId);
+        setDefaults(r);
+        return r;
+    }
+
+    public SendInputRequest newSendInputRequest(byte[] input, String shellId, String commandId) {
+        SendInputRequest r = new SendInputRequest(url, input, shellId, commandId);
+        setDefaults(r);
+        return r;
+    }
+
+    public GetOutputRequest newGetOutputRequest(String shellId, String commandId) {
+        GetOutputRequest r = new GetOutputRequest(url, shellId, commandId);
+        setDefaults(r);
+        return r;
+    }
+
+    private void setDefaults(AbstractWinRMRequest r) {
+        r.setTimeout(timeout);
+        r.setLocale(locale);
+        r.setEnvelopSize(envelopSize);
+    }
+
+    public String getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(String timeout) {
+        this.timeout = timeout;
+    }
+
+    public int getEnvelopSize() {
+        return envelopSize;
+    }
+
+    public void setEnvelopSize(int envelopSize) {
+        this.envelopSize = envelopSize;
+    }
+
+    public String getLocale() {
+        return locale;
+    }
+
+    public void setLocale(String locale) {
+        this.locale = locale;
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/SendInputRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/SendInputRequest.java
@@ -1,0 +1,42 @@
+package hudson.plugins.ec2.win.winrm.request;
+
+import hudson.plugins.ec2.win.winrm.soap.Namespaces;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.apache.commons.codec.binary.Base64;
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.dom4j.QName;
+
+public class SendInputRequest extends AbstractWinRMRequest {
+
+    byte[] input;
+    private String commandId, shellId;
+
+    public SendInputRequest(URL url, byte[] input, String shellId, String commandId) {
+        super(url);
+        this.input = input;
+        this.commandId = commandId;
+        this.shellId = shellId;
+    }
+
+    @Override
+    protected void construct() {
+        try {
+            defaultHeader().action(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send"))
+                            .resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd")).shellId(shellId);
+
+            Element body = DocumentHelper.createElement(QName.get("Send", Namespaces.NS_WIN_SHELL));
+            Base64 base64 = new Base64(0);
+            body.addElement(QName.get("Stream", Namespaces.NS_WIN_SHELL)).addAttribute("Name", "stdin")
+                            .addAttribute("CommandId", commandId).addText(base64.encodeToString(input));
+            setBody(body);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Error while building request content", e);
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/SignalRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/SignalRequest.java
@@ -1,0 +1,41 @@
+package hudson.plugins.ec2.win.winrm.request;
+
+import hudson.plugins.ec2.win.winrm.soap.Namespaces;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.dom4j.QName;
+
+public class SignalRequest extends AbstractWinRMRequest {
+
+    private String commandId, shellId;
+
+    public SignalRequest(URL url, String shellId, String commandId) {
+        super(url);
+        this.commandId = commandId;
+        this.shellId = shellId;
+    }
+
+    @Override
+    protected void construct() {
+        try {
+            defaultHeader().action(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command"))
+            .resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd")).shellId(shellId);
+
+            Element body = DocumentHelper.createElement(QName.get("Signal", Namespaces.NS_WIN_SHELL)).addAttribute(
+                                                                                                                   "CommandId",
+                                                                                                                   commandId);
+
+            body.addElement(QName.get("Code", Namespaces.NS_WIN_SHELL))
+            .addText("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/terminate");
+            setBody(body);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Error while building request content", e);
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/WinRMRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/WinRMRequest.java
@@ -1,0 +1,7 @@
+package hudson.plugins.ec2.win.winrm.request;
+
+import org.dom4j.Document;
+
+public interface WinRMRequest {
+    public Document build();
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/soap/Header.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/soap/Header.java
@@ -1,0 +1,93 @@
+package hudson.plugins.ec2.win.winrm.soap;
+
+import org.dom4j.Element;
+import org.dom4j.QName;
+
+import com.google.common.collect.ImmutableList;
+
+public class Header {
+    private String to;
+    private String replyTo;
+    private String maxEnvelopeSize;
+    private String timeout;
+    private String locale;
+    private String id;
+    private String action;
+    private String shellId;
+    private String resourceURI;
+    private ImmutableList<Option> optionSet;
+
+    Header(String to, String replyTo, String maxEnvelopeSize, String timeout, String locale, String id, String action,
+           String shellId, String resourceURI, ImmutableList<Option> optionSet) {
+        this.to = to;
+        this.replyTo = replyTo;
+        this.maxEnvelopeSize = maxEnvelopeSize;
+        this.timeout = timeout;
+        this.locale = locale;
+        this.id = id;
+        this.action = action;
+        this.shellId = shellId;
+        this.resourceURI = resourceURI;
+        this.optionSet = optionSet;
+    }
+
+    void toElement(Element header) {
+        if (to != null) {
+            header.addElement(QName.get("To", Namespaces.NS_ADDRESSING)).addText(to);
+        }
+
+        if (replyTo != null) {
+            mustUnderstand(
+                           header.addElement(QName.get("ReplyTo", Namespaces.NS_ADDRESSING)).addElement(
+                                                                                                        QName.get("Address", Namespaces.NS_ADDRESSING))).addText(replyTo);
+        }
+
+        if (maxEnvelopeSize != null) {
+            mustUnderstand(header.addElement(QName.get("MaxEnvelopeSize", Namespaces.NS_WSMAN_DMTF))).addText(maxEnvelopeSize);
+        }
+
+        if (id != null) {
+            header.addElement(QName.get("MessageID", Namespaces.NS_ADDRESSING)).addText(id);
+        }
+
+        if (locale != null) {
+            mustNotUnderstand(header.addElement(QName.get("Locale", Namespaces.NS_WSMAN_DMTF))).addAttribute("xml:lang", locale);
+            mustNotUnderstand(header.addElement(QName.get("DataLocale", Namespaces.NS_WSMAN_MSFT)))
+            .addAttribute("xml:lang", locale);
+        }
+
+        if (timeout != null) {
+            header.addElement(QName.get("OperationTimeout", Namespaces.NS_WSMAN_DMTF)).addText(timeout);
+        }
+
+        if (action != null) {
+            mustUnderstand(header.addElement(QName.get("Action", Namespaces.NS_ADDRESSING))).addText(action);
+        }
+
+        if (shellId != null) {
+            header.addElement(QName.get("SelectorSet", Namespaces.NS_WSMAN_DMTF))
+            .addElement(QName.get("Selector", Namespaces.NS_WSMAN_DMTF)).addAttribute("Name", "ShellId").addText(shellId);
+        }
+
+        if (resourceURI != null) {
+            mustUnderstand(header.addElement(QName.get("ResourceURI", Namespaces.NS_WSMAN_DMTF))).addText(resourceURI);
+        }
+
+        if (optionSet != null) {
+            final Element set = header.addElement(QName.get("OptionSet", Namespaces.NS_WSMAN_DMTF));
+            for (Option p : optionSet) {
+                set.addElement(QName.get("Option", Namespaces.NS_WSMAN_DMTF)).addAttribute("Name", p.getName())
+                .addText(p.getValue());
+            }
+        }
+    }
+
+    private static Element mustUnderstand(Element e) {
+        return e.addAttribute("mustUnderstand", "true");
+    }
+
+    private static Element mustNotUnderstand(Element e) {
+        return e.addAttribute("mustUnderstand", "false");
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/soap/HeaderBuilder.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/soap/HeaderBuilder.java
@@ -1,0 +1,76 @@
+package hudson.plugins.ec2.win.winrm.soap;
+
+import java.net.URI;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+public class HeaderBuilder {
+    private String to;
+    private String replyTo;
+    private String maxEnvelopeSize;
+    private String timeout;
+    private String locale;
+    private String id;
+    private String action;
+    private String shellId;
+    private String resourceURI;
+    private ImmutableList<Option> optionSet;
+
+    HeaderBuilder() {
+    }
+
+    public HeaderBuilder to(URI address) {
+        to = address.toString();
+        return this;
+    }
+
+    public HeaderBuilder replyTo(URI address) {
+        replyTo = address.toString();
+        return this;
+    }
+
+    public HeaderBuilder maxEnvelopeSize(int size) {
+        maxEnvelopeSize = Integer.toString(size);
+        return this;
+    }
+
+    public HeaderBuilder id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public HeaderBuilder locale(String locale) {
+        this.locale = locale;
+        return this;
+    }
+
+    public HeaderBuilder timeout(String timeout) {
+        this.timeout = timeout;
+        return this;
+    }
+
+    public HeaderBuilder action(URI uri) {
+        this.action = uri.toString();
+        return this;
+    }
+
+    public HeaderBuilder shellId(String shellId) {
+        this.shellId = shellId;
+        return this;
+    }
+
+    public HeaderBuilder resourceURI(URI uri) {
+        this.resourceURI = uri.toString();
+        return this;
+    }
+
+    public HeaderBuilder options(List<Option> options) {
+        this.optionSet = ImmutableList.copyOf(options);
+        return this;
+    }
+
+    public Header build() {
+        return new Header(to, replyTo, maxEnvelopeSize, timeout, locale, id, action, shellId, resourceURI, optionSet);
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/soap/MessageBuilder.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/soap/MessageBuilder.java
@@ -1,0 +1,37 @@
+package hudson.plugins.ec2.win.winrm.soap;
+
+import org.dom4j.Document;
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.dom4j.Namespace;
+import org.dom4j.QName;
+
+public class MessageBuilder {
+    private final Document doc = DocumentHelper.createDocument();
+    private final Element envelope = doc.addElement(QName.get("Envelope", Namespaces.NS_SOAP_ENV));
+
+    public MessageBuilder() {
+        for (Namespace ns : Namespaces.mostUsed()) {
+            envelope.add(ns);
+        }
+    }
+
+    public HeaderBuilder newHeader() {
+        return new HeaderBuilder();
+    }
+
+    public void addHeader(Header header) {
+        Element elem = envelope.addElement(QName.get("Header", Namespaces.NS_SOAP_ENV));
+        header.toElement(elem);
+    }
+
+    public void addBody(Element body) {
+        Element elem = envelope.addElement(QName.get("Body", Namespaces.NS_SOAP_ENV));
+        if (body != null)
+            elem.add(body);
+    }
+
+    public Document build() {
+        return doc;
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/soap/Namespaces.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/soap/Namespaces.java
@@ -1,0 +1,24 @@
+package hudson.plugins.ec2.win.winrm.soap;
+
+import java.util.List;
+
+import org.dom4j.Namespace;
+
+import com.google.common.collect.ImmutableList;
+
+public class Namespaces {
+    public static final Namespace NS_SOAP_ENV = Namespace.get("env", "http://www.w3.org/2003/05/soap-envelope");
+    public static final Namespace NS_ADDRESSING = Namespace.get("a", "http://schemas.xmlsoap.org/ws/2004/08/addressing");
+    public static final Namespace NS_CIMBINDING = Namespace.get("b", "http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd");
+    public static final Namespace NS_ENUM = Namespace.get("n", "http://schemas.xmlsoap.org/ws/2004/09/enumeration");
+    public static final Namespace NS_TRANSFER = Namespace.get("x", "http://schemas.xmlsoap.org/ws/2004/09/transfer");
+    public static final Namespace NS_WSMAN_DMTF = Namespace.get("w", "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd");
+    public static final Namespace NS_WSMAN_MSFT = Namespace.get("p", "http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd");
+    public static final Namespace NS_SCHEMA_INST = Namespace.get("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+    public static final Namespace NS_WIN_SHELL = Namespace.get("rsp", "http://schemas.microsoft.com/wbem/wsman/1/windows/shell");
+    public static final Namespace NS_WSMAN_FAULT = Namespace.get("f", "http://schemas.microsoft.com/wbem/wsman/1/wsmanfault");
+
+    public static final List<Namespace> mostUsed() {
+        return ImmutableList.of(NS_SOAP_ENV, NS_ADDRESSING, NS_WIN_SHELL, NS_WSMAN_DMTF, NS_WSMAN_MSFT);
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/soap/Option.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/soap/Option.java
@@ -1,0 +1,19 @@
+package hudson.plugins.ec2.win.winrm.soap;
+
+public class Option {
+    private final String name;
+    private final String value;
+
+    public Option(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly
@@ -92,10 +92,6 @@ THE SOFTWARE.
           <f:textbox />
         </f:entry>
         
-        <f:entry title="${%Root command prefix}" field="rootCommandPrefix">
-          <f:textbox />
-        </f:entry>
-
 	    <f:entry title="${%Stop/Disconnect on Idle Timeout}" field="stopOnTerminate">
     	  <f:checkbox />
     	</f:entry>
@@ -114,6 +110,14 @@ THE SOFTWARE.
 	    <f:entry title="${%Use private DNS}" field="usePrivateDnsName">
     	  <f:checkbox />
     	</f:entry>
+
+        <f:dropdownList name="amiType" title="${%AMI Type}">
+            <f:dropdownListBlock value="0" title="${instance.amiType.descriptor.displayName}" selected="true">
+		        <j:set var="instance" value="${instance.amiType}" />
+                <tr><td><input type="hidden" name="stapler-class" value="${instance.descriptor.clazz.name}"/></td></tr>
+                <st:include from="${instance.descriptor}" page="${instance.descriptor.configPage}" />
+            </f:dropdownListBlock>
+        </f:dropdownList>
 
         <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
 

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -76,9 +76,7 @@ THE SOFTWARE.
     <f:textbox />
   </f:entry>
 
-  <f:entry title="${%Root command prefix}" field="rootCommandPrefix">
-    <f:textbox/>
-  </f:entry>
+ <f:dropdownDescriptorSelector title="${%AMI Type}" field="amiType" descriptors="${descriptor.getAMITypeDescriptors()}" />
 
   <f:entry title="${%Labels}" field="labelString">
     <f:textbox />
@@ -106,10 +104,6 @@ THE SOFTWARE.
 
     <f:entry title="${%JVM Options}" field="jvmopts">
       <f:textbox/>
-    </f:entry>
-
-    <f:entry title="${%Remote ssh port}" field="sshPort">
-      <f:textbox />
     </f:entry>
 
     <f:entry title="${%Stop/Disconnect on Idle Timeout}" field="stopOnTerminate">

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-amiType.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-amiType.html
@@ -1,0 +1,37 @@
+<div>
+  Choose the type of AMI this slave uses:
+  <ul>
+    <li>Unix: connected to with ssh.</li>
+    <li>Windows: connected to with CIFS and WinRM/WinRS.</li>
+  </ul>
+  
+  <hr/>
+  Notes for Windows AMI:
+  <br/>
+  EC2 Windows slaves are accessed with CIFS (to send the initial Jenkins slave.jar) and WinRM to launch and connect
+to the slave afterward.
+
+  This windows AMI must be configured with:
+	<ul>
+	  <li>a security group allowing SMB over TCP (incoming TCP port 445) and WinRM (incoming TCP port 5985)</li>
+	  <li>windows firewall should allow incoming SMB over TCP</li>
+	  <li>java should be installed and available in the %PATH%</li>
+	  <li>WinRM should be enabled with the following commands (for more information see: <a href="http://support.microsoft.com/kb/555966">Microsoft article 555966</a>):
+	    <ul>
+	      <li>winrm quickconfig</li>
+	      <li>winrm set winrm/config/service/Auth @{Basic="true"}</li>
+	      <li>winrm set winrm/config/service @{AllowUnencrypted="true"}</li>
+	      <li>winrm set winrm/config/winrs @{MaxMemoryPerShellMB="1024"}</li>
+		  <li>For https:
+		     <ul>
+		         <li><a href="http://www.hansolav.net/blog/SelfsignedSSLCertificatesOnIIS7AndCommonNames.aspx">Generate a windows certificate</a></li>
+		         <li><a href="http://support.microsoft.com/kb/2019527">Install the certificate</a></li>
+		         <li>winrm create winrm/config/Listener?Address=*+Transport=HTTPS @{Hostname="HOSTNAME"; CertificateThumbprint="THUMBPRINT"}</li>
+		     </ul>
+		   </li>
+	    </ul>
+	  </li>
+	</ul>
+
+    Finally make sure to set the username to Administrator and enter the administrator password.
+</div>

--- a/src/main/resources/hudson/plugins/ec2/UnixData/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/UnixData/config.jelly
@@ -1,0 +1,33 @@
+<!--
+The MIT License
+
+Copyright (c) 2010, InfraDNA, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">	  
+      <f:entry title="${%Root command prefix}" field="rootCommandPrefix">
+	    <f:textbox/>
+	  </f:entry>
+      <f:entry title="${%Remote ssh port}" field="sshPort">
+        <f:textbox />
+      </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/ec2/WindowsData/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/WindowsData/config.jelly
@@ -1,0 +1,36 @@
+<!--
+The MIT License
+
+Copyright (c) 2010, InfraDNA, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	    <f:entry title="${%Windows Admin Password}" field="password">
+	      <f:password />
+	    </f:entry>
+	    <f:entry title="${%Use HTTPS}" field="useHTTPS">
+	      <f:checkbox />
+	    </f:entry>
+	    <f:entry title="${%Boot Delay}" field="bootDelay">
+	      <f:textbox />
+	    </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/ec2/WindowsData/help-bootDelay.html
+++ b/src/main/resources/hudson/plugins/ec2/WindowsData/help-bootDelay.html
@@ -1,0 +1,8 @@
+<div>
+Indicate here the time in seconds to wait for the machine to be ready once the plugin detects WinRM is available.
+Unfortunately, on Windows during the boot, the WinRM service might be started, and then several minutes after will be restarted.
+If this restart happens during the slave provisioning that Jenkins does, Windows will prevent the WinRM client to connect again and the
+slave will not be correctly provisioned.
+<br>
+A safe value has been found to be 3 minutes.
+</div>

--- a/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
@@ -10,7 +10,7 @@ public class EC2AbstractSlaveTest extends HudsonTestCase{
 
     int timeoutInSecs = Integer.MAX_VALUE;
     public void testGetLaunchTimeoutInMillisShouldNotOverflow() throws Exception {
-        EC2AbstractSlave slave = new EC2AbstractSlave("name","id","description","fs",22,1,null,"label",null,null,"init", new ArrayList<NodeProperty<?>>(),"remote","root","jvm",false,"idle",null,"cloud",false,Integer.MAX_VALUE ) {
+        EC2AbstractSlave slave = new EC2AbstractSlave("name","id","description","fs",1,null,"label",null,null,"init", new ArrayList<NodeProperty<?>>(),"root","jvm",false,"idle",null,"cloud",false,Integer.MAX_VALUE, new UnixData("remote", "22")) {
             @Override
             public void terminate() {
                 //To change body of implemented methods use File | Settings | File Templates.

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -173,4 +173,56 @@ public class SlaveTemplateTest extends HudsonTestCase {
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
+    public void testBackwardCompatibleUnixData(){
+        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "aaa", "10", "rrr", "sudo", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, "NotANumber");
+        assertFalse(st.isWindowsSlave());
+        assertEquals(22, st.getSshPort());
+        assertEquals("sudo", st.getRootCommandPrefix());
+    }
+
+    public void testWindowsConfigRoundTrip() throws Exception {
+        String ami = "ami1";
+        String description = "foo ami";
+
+        EC2Tag tag1 = new EC2Tag( "name1", "value1" );
+        EC2Tag tag2 = new EC2Tag( "name2", "value2" );
+        List<EC2Tag> tags = new ArrayList<EC2Tag>();
+        tags.add( tag1 );
+        tags.add( tag2 );
+
+        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, description, "bar", "aaa", "10", "rrr", new WindowsData("password", false, ""), "-Xmx1g", false, "subnet 456", tags, null, false, null, "", true, "");
+
+        List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
+        templates.add(orig);
+
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("abc", "def", "us-east-1", "ghi", "3", templates);
+        hudson.clouds.add(ac);
+
+        submit(createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud)hudson.clouds.iterator().next()).getTemplate(description);
+        assertEqualBeans(orig, received, "amiType");
+    }
+
+    public void testUnixConfigRoundTrip() throws Exception {
+        String ami = "ami1";
+        String description = "foo ami";
+
+        EC2Tag tag1 = new EC2Tag( "name1", "value1" );
+        EC2Tag tag2 = new EC2Tag( "name2", "value2" );
+        List<EC2Tag> tags = new ArrayList<EC2Tag>();
+        tags.add( tag1 );
+        tags.add( tag2 );
+
+        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, description, "bar", "aaa", "10", "rrr", new UnixData("sudo", "22"), "-Xmx1g", false, "subnet 456", tags, null, false, null, "", true, "");
+
+        List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
+        templates.add(orig);
+
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("abc", "def", "us-east-1", "ghi", "3", templates);
+        hudson.clouds.add(ac);
+
+        submit(createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud)hudson.clouds.iterator().next()).getTemplate(description);
+        assertEqualBeans(orig, received, "amiType");
+    }
 }

--- a/src/test/java/hudson/plugins/ec2/WinRMMessageTest.java
+++ b/src/test/java/hudson/plugins/ec2/WinRMMessageTest.java
@@ -1,0 +1,98 @@
+package hudson.plugins.ec2;
+
+import static org.junit.Assert.assertEquals;
+import hudson.plugins.ec2.win.winrm.request.DeleteShellRequest;
+import hudson.plugins.ec2.win.winrm.request.ExecuteCommandRequest;
+import hudson.plugins.ec2.win.winrm.request.GetOutputRequest;
+import hudson.plugins.ec2.win.winrm.request.OpenShellRequest;
+import hudson.plugins.ec2.win.winrm.request.SendInputRequest;
+import hudson.plugins.ec2.win.winrm.request.SignalRequest;
+import hudson.plugins.ec2.win.winrm.soap.Namespaces;
+
+import java.net.URL;
+
+import org.dom4j.Document;
+import org.dom4j.DocumentHelper;
+import org.dom4j.XPath;
+import org.jaxen.SimpleNamespaceContext;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WinRMMessageTest {
+
+    private URL url;
+    private SimpleNamespaceContext namespaceContext;
+
+    @Before
+    public void before() throws Exception
+    {
+        url = new URL("http://localhost");
+        namespaceContext = new SimpleNamespaceContext();
+        namespaceContext.addNamespace(Namespaces.NS_WIN_SHELL.getPrefix(), Namespaces.NS_WIN_SHELL.getURI());
+        namespaceContext.addNamespace(Namespaces.NS_ADDRESSING.getPrefix(), Namespaces.NS_ADDRESSING.getURI());
+        namespaceContext.addNamespace(Namespaces.NS_WSMAN_DMTF.getPrefix(), Namespaces.NS_WSMAN_DMTF.getURI());
+        namespaceContext.addNamespace(Namespaces.NS_WSMAN_MSFT.getPrefix(), Namespaces.NS_WSMAN_MSFT.getURI());
+        namespaceContext.addNamespace(Namespaces.NS_SOAP_ENV.getPrefix(), Namespaces.NS_SOAP_ENV.getURI());
+    }
+
+    @Test
+    public void testOpenShellMessage() throws Exception {
+        OpenShellRequest r = new OpenShellRequest(url);
+        assertEquals("http://schemas.xmlsoap.org/ws/2004/09/transfer/Create", xpath("//a:Action", r.build()));
+        assertEquals("http://localhost", xpath("//a:To", r.build()));
+        assertEquals("stdin", xpath("//env:Body/rsp:Shell/rsp:InputStreams", r.build()));
+        assertEquals("stdout stderr", xpath("//env:Body/rsp:Shell/rsp:OutputStreams", r.build()));
+    }
+
+    @Test
+    public void testDeleteShellMessage() throws Exception {
+        DeleteShellRequest r = new DeleteShellRequest(url, "SHELLID");
+        assertEquals("http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete", xpath("//a:Action", r.build()));
+        assertEquals("http://localhost", xpath("//a:To", r.build()));
+        assertEquals("SHELLID", xpath("//w:Selector[@Name=\"ShellId\"]", r.build()));
+    }
+
+    @Test
+    public void testExecuteCommandMessage() throws Exception {
+        ExecuteCommandRequest r = new ExecuteCommandRequest(url, "SHELLID", "ipconfig /all");
+        assertEquals("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command", xpath("//a:Action", r.build()));
+        assertEquals("http://localhost", xpath("//a:To", r.build()));
+        assertEquals("SHELLID", xpath("//w:Selector[@Name=\"ShellId\"]", r.build()));
+        assertEquals("FALSE", xpath("//w:Option[@Name=\"WINRS_CONSOLEMODE_STDIN\"]", r.build()));
+        assertEquals("\"ipconfig /all\"", xpath("//rsp:CommandLine/rsp:Command", r.build()));
+    }
+
+    @Test
+    public void testGetOutputMessage() throws Exception {
+        GetOutputRequest r = new GetOutputRequest(url,"SHELLID", "COMMANDID");
+        assertEquals("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive", xpath("//a:Action", r.build()));
+        assertEquals("http://localhost", xpath("//a:To", r.build()));
+        assertEquals("SHELLID", xpath("//w:Selector[@Name=\"ShellId\"]", r.build()));
+        assertEquals("stdout stderr", xpath("//rsp:Receive/rsp:DesiredStream[@CommandId=\"COMMANDID\"]", r.build()));
+    }
+
+    @Test
+    public void testSendInputMessage() throws Exception {
+        SendInputRequest r = new SendInputRequest(url,new byte[]{31, 32}, "SHELLID", "COMMANDID");
+        assertEquals("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send", xpath("//a:Action", r.build()));
+        assertEquals("http://localhost", xpath("//a:To", r.build()));
+        assertEquals("SHELLID", xpath("//w:Selector[@Name=\"ShellId\"]", r.build()));
+        assertEquals("HyA=", xpath("//rsp:Send/rsp:Stream[@CommandId=\"COMMANDID\"]", r.build()));
+    }
+
+    @Test
+    public void testSignalMessage() throws Exception {
+        SignalRequest r = new SignalRequest(url, "SHELLID", "COMMANDID");
+        assertEquals("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command", xpath("//a:Action", r.build()));
+        assertEquals("http://localhost", xpath("//a:To", r.build()));
+        assertEquals("SHELLID", xpath("//w:Selector[@Name=\"ShellId\"]", r.build()));
+        assertEquals("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/terminate", xpath("//rsp:Signal[@CommandId=\"COMMANDID\"]/rsp:Code", r.build()));
+    }
+
+    private String xpath(String xpath, Document doc)
+    {
+        XPath xp = DocumentHelper.createXPath(xpath);
+        xp.setNamespaceContext(namespaceContext);
+        return xp.valueOf(doc);
+    }
+}


### PR DESCRIPTION
This changeset introduces support for windows AMI to the ec2-plugin.
The windows slaves are connected to with SMB over TCP to send the initial
slave.jar and connected to from jenkins using WinRM/WinRS.

Unlile linux based AMI, the windows AMI requires:
- a specific security group allowing SMB over TCP (incoming TCP port 445)
- a specific securify group alloaing WinRM (incoming TCP port 5985)
- a java virtual machine installed in the Windows %PATH%
- SMB over TCP should be enabled in the windows firewall (this can be
  done with: `netsh firewall set portopening tcp 445 smb enable`)
- WinRM must be configured and enabled, with the following commands:
  - `winrm quickconfig` (answer y to both questions)
  - `winrm set winrm/config/service/Auth @{Basic="true"}`
  - `winrm set winrm/config/service @{AllowUnencrypted="true"}`
  - `winrm set winrm/config/winrs @{MaxMemoryPerShellMB="1024"}`
- a fixed administrator password (there's no way for the plugin
  to figure out the random password of the base EC2 Windows AMI)

This changeset enhance the Slave Template configuration to specify a
Windows only settings (like windows administrator password of the configured 
remote user). Unix only settings have been grouped into their own Unix section.

Note: the current WinRM implementation is not running onto encrypted
transport, nor use encrypted payloads. This will come in a subsequent
patch on this pull request (or a new one).

Note2: the current WinRM implementation is very roughly based on Xebialabs'
Overthere and WinRB ruby implementation. All credits goes to them. If you're asking
why this patch doesn't use Overthere directly: for the short story latest overthere version
requires Guava 14 which is not backward compatible with the Guava required by Jenkins itself. 
The other reason being that jenkins sends binary data to the slave process, which wasn't well
supported in Overthere way to setup the WinRM shell. Also, Overthere is much more than a WinRM 
implementation which we don't need in this case.

This support is considered experimental, even though it has been
successfully tested.

Please review and comment, I'm open to any suggestion and enhancements!
