### PR TITLE
Fix an argument of launching a slave

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
@@ -30,11 +30,11 @@ import com.amazonaws.services.ec2.model.*;
 public final class EC2OndemandSlave extends EC2AbstractSlave {
 	
     public EC2OndemandSlave(String instanceId, String description, String remoteFS, int sshPort, int numExecutors, String labelString, Mode mode, String initScript, String remoteAdmin, String rootCommandPrefix, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName,int launchTimeout) throws FormException, IOException {
-    	this(description + " (" + instanceId + ")", instanceId, description, remoteFS, sshPort, numExecutors, labelString, Mode.NORMAL, initScript, Collections.<NodeProperty<?>>emptyList(), remoteAdmin, rootCommandPrefix, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, false, launchTimeout);
+    	this(description + " (" + instanceId + ")", instanceId, description, remoteFS, sshPort, numExecutors, labelString, mode, initScript, Collections.<NodeProperty<?>>emptyList(), remoteAdmin, rootCommandPrefix, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, false, launchTimeout);
     }
     
     public EC2OndemandSlave(String instanceId, String description, String remoteFS, int sshPort, int numExecutors, String labelString, Mode mode, String initScript, String remoteAdmin, String rootCommandPrefix, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout) throws FormException, IOException {
-    	this(description + " (" + instanceId + ")", instanceId, description, remoteFS, sshPort, numExecutors, labelString, Mode.NORMAL, initScript, Collections.<NodeProperty<?>>emptyList(), remoteAdmin, rootCommandPrefix, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, usePrivateDnsName, launchTimeout);
+    	this(description + " (" + instanceId + ")", instanceId, description, remoteFS, sshPort, numExecutors, labelString, mode, initScript, Collections.<NodeProperty<?>>emptyList(), remoteAdmin, rootCommandPrefix, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, usePrivateDnsName, launchTimeout);
     } 	 
 
     @DataBoundConstructor

--- a/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
@@ -1,0 +1,16 @@
+package hudson.plugins.ec2;
+
+import hudson.model.Node;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+public class EC2OndemandSlaveTest extends HudsonTestCase {
+
+    public void testSpecifyMode() throws Exception {
+        EC2OndemandSlave slaveNormal = new EC2OndemandSlave("instanceId", "description", "remoteFS", 22, 1, "labelString", Node.Mode.NORMAL, "initScript", "remoteAdmin", "rootCommandPrefix", "jvmopts", false, "idleTerminationMinutes", "publicDNS", "privateDNS", null, "cloudName", false, 0);
+        assertEquals(Node.Mode.NORMAL, slaveNormal.getMode());
+
+        EC2OndemandSlave slaveExclusive = new EC2OndemandSlave("instanceId", "description", "remoteFS", 22, 1, "labelString", Node.Mode.EXCLUSIVE, "initScript", "remoteAdmin", "rootCommandPrefix", "jvmopts", false, "idleTerminationMinutes", "publicDNS", "privateDNS", null, "cloudName", false, 0);
+        assertEquals(Node.Mode.EXCLUSIVE, slaveExclusive.getMode());
+    }
+
+}


### PR DESCRIPTION
In launching On-Demand instances, EC2 plugin always launches instances with "Utilize this slave as much as possible", even if you specify "Leave this machine for tied jobs only".
