### PR TITLE
FIXED JENKINS-19943 but credit should go to Nathan Kinder

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -220,10 +220,9 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 if (computer.getNode().usePrivateDnsName) {
                     host = instance.getPrivateDnsName();
                 } else {
-                    /* VPC hosts don't have public DNS names, so we need to use an IP address instead */
-                    if (vpc_id == null || vpc_id.equals("")) {
-                        host = instance.getPublicDnsName();
-                    } else {
+                    host = instance.getPublicDnsName();
+                    // If we fail to get a public DNS name, use the private IP.
+                    if (host == null || host.equals("")) {
                         host = instance.getPrivateIpAddress();
                     }
                 }


### PR DESCRIPTION
To fix https://issues.jenkins-ci.org/browse/JENKINS-19943 which duplicates https://issues.jenkins-ci.org/browse/JENKINS-21182

Credit should go to Nathan Kinder, as I just used his patch and tested.
