### PR TITLE
Make sure the node is removed even when isAlive() throws an Exception

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
@@ -68,9 +68,11 @@ public final class EC2OndemandSlave extends EC2AbstractSlave {
                 ec2.terminateInstances(request);
                 LOGGER.info("Terminated EC2 instance (terminated): "+getInstanceId());
             }
-            Hudson.getInstance().removeNode(this);
         } catch (AmazonClientException e) {
             LOGGER.log(Level.WARNING,"Failed to terminate EC2 instance: "+getInstanceId(),e);
+        }
+        try {
+            Hudson.getInstance().removeNode(this);
         } catch (IOException e) {
             LOGGER.log(Level.WARNING,"Failed to terminate EC2 instance: "+getInstanceId(),e);
         }


### PR DESCRIPTION
Hi,

So this fixes a potential bug that can be replicated by doing the following:
- Create a slave provisioned by an EC2 instance (on demand)
- Manually terminate the EC2 instance and wait one hour until the "Terminated" entry disappears from the list (and from the API)
- Try to delete the slave from jenkins: it will fail as isAlive() will never return (because describeInstances will throw the exception:

WARNING: Failed to terminate EC2 instance: i-21eba6aa
com.amazonaws.AmazonServiceException: Status Code: 400, AWS Service: AmazonEC2, AWS Request ID: c62c2606-1cf0-4fd3-856b-494e84020ca4, AWS Error Code: InvalidInstanceID.NotFound, AWS Error Message: The instance ID 'i-21eba6aa' does not exist
    at com.amazonaws.http.AmazonHttpClient.handleErrorResponse(AmazonHttpClient.java:773)
    at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:417)
    at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:229)
    at com.amazonaws.services.ec2.AmazonEC2Client.invoke(AmazonEC2Client.java:8504)
    at com.amazonaws.services.ec2.AmazonEC2Client.describeInstances(AmazonEC2Client.java:3928)
    at hudson.plugins.ec2.EC2AbstractSlave.getInstance(EC2AbstractSlave.java:188)
    at hudson.plugins.ec2.EC2AbstractSlave.fetchLiveInstanceData(EC2AbstractSlave.java:309)
    at hudson.plugins.ec2.EC2AbstractSlave.isAlive(EC2AbstractSlave.java:292)
    at hudson.plugins.ec2.EC2OndemandSlave.terminate(EC2OndemandSlave.java:63)
    at hudson.plugins.ec2.EC2Computer.doDoDelete(EC2Computer.java:168)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    )
