### PR TITLE
updates retention stategy to support negative values

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/EC2Computer/help-idleTerminationMinutes.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Computer/help-idleTerminationMinutes.html
@@ -24,6 +24,8 @@ THE SOFTWARE.
 <div>
     Determines how long slaves can remain idle before being stopped or terminated (see the Stop/Disconnect on Idle Timeout setting).
     <p>
-    Times are expressed in minutes, and a value of 0 (or an empty string) indicates that idle slaves should
-    never be stopped/terminated.
+    Times are expressed in minutes.
+    A value of 0 (or an empty string) indicates that idle slaves should never be stopped/terminated.
+    A negative value indicates that the instance should idle up to the billing hour, minus the idle minute time. For example, a value of 
+    -2 means that if an instance will be retained if checked less than 58 minutes into the billing hour, but stopped or terminated if checked between the 58th and 60th active minute.  This strategy keeps slaves alive and available for additional work during already paid for period.
 </div>

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -1,0 +1,78 @@
+package hudson.plugins.ec2;
+
+import com.amazonaws.AmazonClientException;
+import hudson.slaves.NodeProperty;
+import jenkins.model.Jenkins;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class EC2RetentionStrategyTest extends HudsonTestCase {
+
+    final AtomicBoolean idleTimeoutCalled = new AtomicBoolean(false);
+
+    public void testOnBillingHourRetention() throws Exception {
+        EC2RetentionStrategy rs = new EC2RetentionStrategy("-2");
+        List<int[]> upTime = new ArrayList<int[]>();
+        List<Boolean> expected = new ArrayList<Boolean>();
+        upTime.add(new int[]{58,0});
+        expected.add(true);
+        upTime.add(new int[]{57,59});
+        expected.add(false);
+        upTime.add(new int[]{59,00});
+        expected.add(true);
+        upTime.add(new int[]{59,30});
+        expected.add(true);
+        upTime.add(new int[]{60,00});
+        expected.add(false);
+
+        for (int i = 0; i < upTime.size(); i++) {
+            int[] t = upTime.get(i);
+            EC2Computer computer = computerWithIdleTime(t[0], t[1]);
+            rs.check(computer);
+            assertEquals("Expected " + t[0] + "m" + t[1] + "s to be " + expected.get(i), (boolean)expected.get(i), idleTimeoutCalled.get());
+            // reset the assumption
+            idleTimeoutCalled.set(false);
+        }
+    }
+
+    private EC2Computer computerWithIdleTime(final int minutes, final int seconds) throws Exception {
+        final EC2AbstractSlave slave = new EC2AbstractSlave("name","id","description","fs",22,1,null,"label",null,null,"init", new ArrayList<NodeProperty<?>>(),"remote","root","jvm",false,"idle",null,"cloud",false,Integer.MAX_VALUE ) {
+            @Override
+            public void terminate() {
+            }
+
+            @Override
+            public String getEc2Type() {
+                return null;
+            }
+
+            @Override
+            void idleTimeout() {
+                idleTimeoutCalled.set(true);
+            }
+        };
+        EC2Computer computer = new EC2Computer(slave) {
+
+            @Override
+            public EC2AbstractSlave getNode() {
+                return slave;
+            }
+
+            @Override
+            public long getUptime() throws AmazonClientException, InterruptedException {
+                return ((minutes * 60L) + seconds)  * 1000L;
+            }
+
+            @Override
+            public boolean isOffline() {
+                return false;
+            }
+        };
+        assertTrue(computer.isIdle());
+        assertTrue(computer.isOnline());
+        return computer;
+    }
+}


### PR DESCRIPTION
Negative values in the retention strategy means that the instance will
continue to remain idle during the already charged billing period.

For instance, if a slave comes online, runs a 5 minute build, and then
terminates after 20 minutes, the instance was shutdown with 35 minutes
still available in the billing period.  If another build were to be
requested 10 minutes later, another hour would be charged.  This strategy
helps keep slaves alive for as long as possible, but terminates them
before they incur additional cost.
