### PR TITLE
[JENKINS-19880] Pass region specified in web interface to the key generation Java method.

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
@@ -42,6 +42,6 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
   </f:advanced>
-  <f:validateButton title="${%Generate Key}" progress="${%Generate...}" method="generateKey" with="secretKey,accessId" />
+  <f:validateButton title="${%Generate Key}" progress="${%Generate...}" method="generateKey" with="region,secretKey,accessId" />
   <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="region,secretKey,accessId,privateKey" />
 </j:jelly>


### PR DESCRIPTION
The [code](https://github.com/jenkinsci/ec2-plugin/blob/ec2-1.21/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java#L152-L155) that is responsible for key generation requires region to be set. Unfortunately web UI has a bug that does not set that key.

This PR finally fixes the issue and get working.
