### PR TITLE
Don't tag a spot instance request

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -569,14 +569,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 				throw new AmazonClientException("Spot instance request is null");
 			}
 
-			/* Now that we have our Spot request, we can set tags on it */
-			if (inst_tags != null) {
-				updateRemoteTags(ec2, inst_tags, spotInstReq.getSpotInstanceRequestId());
-
-				// That was a remote request - we should also update our local instance data.
-				spotInstReq.setTags(inst_tags);
-			}
-
 			logger.println("Spot instance id in provision: " + spotInstReq.getSpotInstanceRequestId());
 
 			return newSpotSlave(spotInstReq, slaveName);


### PR DESCRIPTION
Same as #85, there is a problem when a spot instance request is tagged. But I think tagging the spot instance request is not so important that I have removed the tagging code.

This pull request is not needed if #85 is included in the main repository. Please choose #85 or this.
