### PR TITLE
Be more explicit about what "private DNS" means in help

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/EC2Computer/help-usePrivateDnsName.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Computer/help-usePrivateDnsName.html
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <div>
-    Connect using the private DNS name instead of the public name.
+    Connect to slaves using the slave's private DNS name instead of the public name.
     <p>
     Note that for VPC instances, there is no public DNS name, and so this becomes a choice between using the
     private DNS name or the private IP address


### PR DESCRIPTION
The help for ec2-plugin's "use private DNS" option doesn't make it clear that it really only affects the master connecting to slaves.

Amend.
