### PR TITLE
Add block device mapping configuration

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -34,6 +34,7 @@ import hudson.model.Hudson;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
+import hudson.plugins.ec2.util.DeviceMappingParser;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 
@@ -80,6 +81,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public final String idleTerminationMinutes;
     public final String iamInstanceProfile;
     public final boolean useEphemeralDevices;
+    public final String customDeviceMapping;
     public int instanceCap;
     public final boolean stopOnTerminate;
     private final List<EC2Tag> tags;
@@ -96,7 +98,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
 
     @DataBoundConstructor
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS, String sshPort, InstanceType type, String labelString, Node.Mode mode, String description, String initScript, String userData, String numExecutors, String remoteAdmin, String rootCommandPrefix, String jvmopts, boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, boolean usePrivateDnsName, String instanceCapStr, String iamInstanceProfile, boolean useEphemeralDevices, boolean useDedicatedTenancy, String launchTimeoutStr, boolean associatePublicIp) {
+    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+                         String sshPort, InstanceType type, String labelString, Node.Mode mode, String description,
+                         String initScript, String userData, String numExecutors, String remoteAdmin,
+                         String rootCommandPrefix, String jvmopts, boolean stopOnTerminate, String subnetId,
+                         List<EC2Tag> tags, String idleTerminationMinutes, boolean usePrivateDnsName,
+                         String instanceCapStr, String iamInstanceProfile, boolean useEphemeralDevices,
+                         boolean useDedicatedTenancy, String launchTimeoutStr, boolean associatePublicIp,
+                         String customDeviceMapping) {
         this.ami = ami;
         this.zone = zone;
         this.spotConfig = spotConfig;
@@ -135,6 +144,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         this.iamInstanceProfile = iamInstanceProfile;
         this.useEphemeralDevices = useEphemeralDevices;
+        this.customDeviceMapping = customDeviceMapping;
 
         readResolve(); // initialize
     }
@@ -278,7 +288,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             RunInstancesRequest riRequest = new RunInstancesRequest(ami, 1, 1);
             InstanceNetworkInterfaceSpecification net = new InstanceNetworkInterfaceSpecification();
 
-            setupDeviceMapping(riRequest);
+            if (useEphemeralDevices) {
+                setupEphemeralDeviceMapping(riRequest);
+            }
+            else {
+                setupCustomDeviceMapping(riRequest);
+            }
 
             List<Filter> diFilters = new ArrayList<Filter>();
             diFilters.add(new Filter("image-id").withValues(ami));
@@ -407,9 +422,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
     }
 
-    private void setupDeviceMapping(RunInstancesRequest riRequest) {
-
-        if (!useEphemeralDevices) return;
+    private void setupEphemeralDeviceMapping(RunInstancesRequest riRequest) {
 
         final List<BlockDeviceMapping> oldDeviceMapping = getAmiBlockDeviceMappings();
 
@@ -457,6 +470,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
 
         throw new AmazonClientException("Unable to get AMI device mapping for " + ami);
+    }
+
+    private void setupCustomDeviceMapping(RunInstancesRequest riRequest) {
+        if (StringUtils.isNotBlank(customDeviceMapping)) {
+            riRequest.setBlockDeviceMappings(DeviceMappingParser.parse(customDeviceMapping));
+        }
     }
 
     /**

--- a/src/main/java/hudson/plugins/ec2/util/DeviceMappingParser.java
+++ b/src/main/java/hudson/plugins/ec2/util/DeviceMappingParser.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.ec2.util;
+
+import com.amazonaws.services.ec2.model.BlockDeviceMapping;
+import com.amazonaws.services.ec2.model.EbsBlockDevice;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeviceMappingParser {
+    public static List<BlockDeviceMapping> parse(String customDeviceMapping) {
+
+        List<BlockDeviceMapping> deviceMappings = new ArrayList<BlockDeviceMapping>();
+
+        for (String mapping: customDeviceMapping.split(",")) {
+            String[] mappingPair = mapping.split("=");
+            String device = mappingPair[0];
+            String blockDevice = mappingPair[1];
+
+            BlockDeviceMapping deviceMapping = new BlockDeviceMapping().withDeviceName(device);
+
+            if (blockDevice.equals("none")) {
+                deviceMapping.setNoDevice("none");
+            }
+            else if (blockDevice.startsWith("ephemeral")) {
+                deviceMapping.setVirtualName(blockDevice);
+            }
+            else {
+                deviceMapping.setEbs(parseEbs(blockDevice));
+            }
+
+            deviceMappings.add(deviceMapping);
+        }
+
+        return deviceMappings;
+    }
+
+    // [<snapshot-id>]:[<size>]:[<delete-on-termination>]:[<type>]:[<iops>]:[encrypted]
+    private static EbsBlockDevice parseEbs(String blockDevice) {
+
+        String[] parts = blockDevice.split(":");
+
+        EbsBlockDevice ebs = new EbsBlockDevice();
+        if (StringUtils.isNotBlank(getOrEmpty(parts, 0))) {
+            ebs.setSnapshotId(parts[0]);
+        }
+        if (StringUtils.isNotBlank(getOrEmpty(parts, 1))) {
+            ebs.setVolumeSize(Integer.valueOf(parts[1]));
+        }
+        if (StringUtils.isNotBlank(getOrEmpty(parts, 2))) {
+            ebs.setDeleteOnTermination(Boolean.valueOf(parts[2]));
+        }
+        if (StringUtils.isNotBlank(getOrEmpty(parts, 3))) {
+            ebs.setVolumeType(parts[3]);
+        }
+        if (StringUtils.isNotBlank(getOrEmpty(parts, 4))) {
+            ebs.setIops(Integer.valueOf(parts[4]));
+        }
+        if (StringUtils.isNotBlank(getOrEmpty(parts, 5))) {
+            ebs.setEncrypted(parts[5].equals("encrypted"));
+        }
+
+        return ebs;
+    }
+
+    private static String getOrEmpty(String[] arr, int idx) {
+        if (idx < arr.length) {
+            return arr[idx];
+        }
+        else {
+            return "";
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -39,7 +39,7 @@ THE SOFTWARE.
   </f:entry>
 
   <f:entry title="${%Availability Zone}" field="zone">
-    <!-- this is preferred but there is a problem with making it work FRU 22 Feb 12 
+    <!-- this is preferred but there is a problem with making it work FRU 22 Feb 12
          See: https://groups.google.com/group/jenkinsci-dev/t/af37fa7fe2769b0c -->
     <!-- <f:select/>-->
     <f:textbox/>
@@ -52,13 +52,13 @@ THE SOFTWARE.
     </f:description>
     <f:description>Slaves designated as Spot slaves will initially show up as disconnected. The state
     will change to connecting when a Spot request has been fulfilled. </f:description>
-    
+
     <f:validateButton title="${%Check Current Spot Price}" progress="${%Checking...}" method="currentSpotPrice" with="accessId,secretKey,region,type,zone" />
-    
+
     <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice">
       <f:textbox />
     </f:entry>
-    
+
     <f:entry field="bidType" title="Choose Bid Type">
       <f:select />
     </f:entry>
@@ -88,7 +88,7 @@ THE SOFTWARE.
 
   <f:entry title="${%Idle termination time}" field="idleTerminationMinutes">
     <f:textbox default="30" />
-  </f:entry>  
+  </f:entry>
 
   <f:entry title="${%Init script}" field="initScript">
     <f:textarea />
@@ -119,7 +119,7 @@ THE SOFTWARE.
     <f:entry title="${%Subnet ID for VPC}" field="subnetId">
        <f:textbox />
     </f:entry>
-    
+
     <f:entry title="${%Use dedicated tenancy}" field="useDedicatedTenancy">
       <f:checkbox />
     </f:entry>
@@ -144,6 +144,10 @@ THE SOFTWARE.
 
     <f:entry title="${%Use ephemeral devices}" field="useEphemeralDevices">
       <f:checkbox />
+    </f:entry>
+
+    <f:entry title="${%Block device mapping}" field="customDeviceMapping">
+      <f:textbox />
     </f:entry>
 
     <f:entry title="${%Launch Timeout in seconds}" field="launchTimeoutStr">

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-customDeviceMapping.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-customDeviceMapping.html
@@ -1,0 +1,44 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<div>
+    Specify the mapping of block devices. Has effect only when <b>Use ephemeral devices</b> is NOT checked. Format:
+    <pre>
+        &lt;device&gt;=&lt;block-device&gt;[,&lt;device&gt;=&lt;block-device&gt;]*
+    </pre>
+
+    Where block-device format is:
+    <pre>
+        [&lt;snapshot-id&gt;]:[&lt;size&gt;]:[&lt;delete-on-termination&gt;]:[&lt;type&gt;]:[&lt;iops&gt;]:[encrypted]
+    </pre>
+
+    Examples:
+    <pre>
+        /dev/sdb=snap-7eb96d16
+        /dev/sdc=snap-7eb96d16:80:false
+        /dev/sdc=snap-7eb96d16:80:false:io1:100
+        /dev/sdd=:120
+        /dev/sdd=:120::::encrypted
+        /dev/sdd=:120::::encrypted,/dev/sdc=:120
+    </pre>
+</div>

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -59,7 +59,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         tags.add( tag1 );
         tags.add( tag2 );
 
-	    SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, description, "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", tags, null, false, null, "", true, false, "", false);
+	    SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, description, "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", tags, null, false, null, "", true, false, "", false, "");
 
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
@@ -82,7 +82,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         tags.add( tag1 );
         tags.add( tag2 );
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, description, "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", tags, null, true, null, "", false, false, "", false);
+        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, description, "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", tags, null, true, null, "", false, false, "", false, "");
 
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
@@ -112,7 +112,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
 
         SpotConfiguration spotConfig = new SpotConfiguration(".05", SpotInstanceType.OneTime.toString());
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, spotConfig, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", tags, null, true, null, "", false, false, "", false);
+        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, spotConfig, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", tags, null, true, null, "", false, false, "", false, "");
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
@@ -126,7 +126,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
 
     /**
      * Test to make sure the IAM Role is set properly.
-     * 
+     *
      * @throws Exception
      */
     public void testConfigRoundtripIamRole() throws Exception {
@@ -139,7 +139,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         tags.add( tag1 );
         tags.add( tag2 );
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, description, "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", tags, null, false, null, "iamInstanceProfile", false, false, "", false);
+        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, description, "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", tags, null, false, null, "iamInstanceProfile", false, false, "", false, "");
 
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
@@ -154,27 +154,27 @@ public class SlaveTemplateTest extends HudsonTestCase {
 
 
     public void testNullTimeoutShouldReturnMaxInt(){
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, false);
+        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
     public void test0TimeoutShouldReturnMaxInt(){
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "0", false);
+        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "0", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
     public void testNegativeTimeoutShouldReturnMaxInt(){
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "-1", false);
+        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "-1", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
     public void testNonNumericTimeoutShouldReturnMaxInt(){
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "NotANumber", false);
+        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "NotANumber", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
     public void testAssociatePublicIpSetting(){
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true);
+        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true, "");
         assertEquals(true, st.getAssociatePublicIp());
     }
 

--- a/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
+++ b/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
@@ -51,7 +51,7 @@ public class TemplateLabelsTest extends HudsonTestCase{
 		tags.add( tag1 );
 		tags.add( tag2 );
 
-		SlaveTemplate template = new SlaveTemplate("ami", "foo", null, "default", "zone", "22", InstanceType.M1Large, label, mode,"foo ami", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", true, "subnet 456", tags, null, false, null, "", false, false, null, false);
+		SlaveTemplate template = new SlaveTemplate("ami", "foo", null, "default", "zone", "22", InstanceType.M1Large, label, mode,"foo ami", "bar", "aaa", "10", "rrr", "fff", "-Xmx1g", true, "subnet 456", tags, null, false, null, "", false, false, null, false, "");
 		List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
 		templates.add(template);
 

--- a/src/test/java/hudson/plugins/ec2/util/DeviceMappingParserTest.java
+++ b/src/test/java/hudson/plugins/ec2/util/DeviceMappingParserTest.java
@@ -1,0 +1,146 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.ec2.util;
+
+import com.amazonaws.services.ec2.model.BlockDeviceMapping;
+import com.amazonaws.services.ec2.model.EbsBlockDevice;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeviceMappingParserTest  extends HudsonTestCase {
+
+    public void testParserWithAmi() throws Exception {
+        List<BlockDeviceMapping> expected = new ArrayList<BlockDeviceMapping>();
+        expected.add(
+                new BlockDeviceMapping().
+                        withDeviceName("/dev/sdb").
+                        withEbs(
+                                new EbsBlockDevice().
+                                        withSnapshotId("snap-7eb96d16")
+                        )
+        );
+
+        String customDeviceMappings = "/dev/sdb=snap-7eb96d16";
+        List<BlockDeviceMapping> actual = DeviceMappingParser.parse(customDeviceMappings);
+        assertEquals(expected, actual);
+    }
+
+    public void testParserWithTermination() throws Exception {
+        List<BlockDeviceMapping> expected = new ArrayList<BlockDeviceMapping>();
+        expected.add(
+                new BlockDeviceMapping().
+                        withDeviceName("/dev/sdc").
+                        withEbs(
+                                new EbsBlockDevice().
+                                        withSnapshotId("snap-7eb96d16").
+                                        withVolumeSize(80).
+                                        withDeleteOnTermination(false)
+                        )
+        );
+
+        String customDeviceMappings = "/dev/sdc=snap-7eb96d16:80:false";
+        List<BlockDeviceMapping> actual = DeviceMappingParser.parse(customDeviceMappings);
+        assertEquals(expected, actual);
+    }
+
+    public void testParserWithIo() throws Exception {
+        List<BlockDeviceMapping> expected = new ArrayList<BlockDeviceMapping>();
+        expected.add(
+                new BlockDeviceMapping().
+                        withDeviceName("/dev/sdc").
+                        withEbs(
+                                new EbsBlockDevice().
+                                        withSnapshotId("snap-7eb96d16").
+                                        withVolumeSize(80).
+                                        withDeleteOnTermination(false).
+                                        withVolumeType("io1").
+                                        withIops(100)
+                        )
+        );
+
+        String customDeviceMappings = "/dev/sdc=snap-7eb96d16:80:false:io1:100";
+        List<BlockDeviceMapping> actual = DeviceMappingParser.parse(customDeviceMappings);
+        assertEquals(expected, actual);
+    }
+
+    public void testParserWithSize() throws Exception {
+        List<BlockDeviceMapping> expected = new ArrayList<BlockDeviceMapping>();
+        expected.add(
+                new BlockDeviceMapping().
+                        withDeviceName("/dev/sdd").
+                        withEbs(
+                                new EbsBlockDevice().
+                                        withVolumeSize(120)
+                        )
+        );
+
+        String customDeviceMappings = "/dev/sdd=:120";
+        List<BlockDeviceMapping> actual = DeviceMappingParser.parse(customDeviceMappings);
+        assertEquals(expected, actual);
+    }
+
+    public void testParserWithEncrypted() throws Exception {
+        List<BlockDeviceMapping> expected = new ArrayList<BlockDeviceMapping>();
+        expected.add(
+                new BlockDeviceMapping().
+                        withDeviceName("/dev/sdd").
+                        withEbs(
+                                new EbsBlockDevice().
+                                        withVolumeSize(120).
+                                        withEncrypted(true)
+                        )
+        );
+
+        String customDeviceMappings = "/dev/sdd=:120::::encrypted";
+        List<BlockDeviceMapping> actual = DeviceMappingParser.parse(customDeviceMappings);
+        assertEquals(expected, actual);
+    }
+
+    public void testParserWithMultiple() throws Exception {
+        List<BlockDeviceMapping> expected = new ArrayList<BlockDeviceMapping>();
+        expected.add(
+                new BlockDeviceMapping().
+                        withDeviceName("/dev/sdd").
+                        withEbs(
+                                new EbsBlockDevice().
+                                        withVolumeSize(120).
+                                        withEncrypted(true)
+                        )
+        );
+        expected.add(
+                new BlockDeviceMapping().
+                        withDeviceName("/dev/sdc").
+                        withEbs(
+                                new EbsBlockDevice().
+                                        withVolumeSize(120)
+                        )
+        );
+
+        String customDeviceMappings = "/dev/sdd=:120::::encrypted,/dev/sdc=:120";
+        List<BlockDeviceMapping> actual = DeviceMappingParser.parse(customDeviceMappings);
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Add new option to set block device mapping. This is very useful when default root image size is too small. 
