### PR TITLE
Workaround AWS bug that hides stopped slaves

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -319,7 +319,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                /* No subnet: we can use standard security groups by name */
                 riRequest.setSecurityGroups(securityGroupSet);
                 if (securityGroupSet.size() > 0)
-                    diFilters.add(new Filter("group-name").withValues(securityGroupSet));
+                    diFilters.add(new Filter("instance.group-name").withValues(securityGroupSet));
             }
 
             String userDataString = Base64.encodeBase64String(userData.getBytes());


### PR DESCRIPTION
Use instance.group-name instead of group-name as the describeInstances
filter when searching for stopped slaves to restart.

Some EC2 regions are incorrectly returning empty describeInstances
results when the group-name filter is used. This causes jenkins to start
new slaves instead of restarting stopped instances.

instance.group-name is functionally identical and seems to work
consistently.

Fixes https://issues.jenkins-ci.org/browse/JENKINS-23850
