### PR TITLE
Prevent nodes that are still starting up from being idle-stopped

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -81,6 +81,14 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
         	return 1;
         }
 
+        /*
+         * Don't idle-out instances that're offline, per JENKINS-23792. This
+         * prevents a node from being idled down while it's still starting up.
+         */
+        if (c.isOffline()) {
+            return 1;
+        }
+
         if (c.isIdle() && !disabled) {
             if (idleTerminationMinutes > 0) {
                 // TODO: really think about the right strategy here


### PR DESCRIPTION
Per [JENKINS-23792](https://issues.jenkins-ci.org/browse/JENKINS-23792), the EC2 plugin will shut down nodes that're still starting up if the idle timeout is shorter than the time the node takes to go from launch request to successfully starting its first job on an executor.

To prevent this, don't perform idle shutdown on a node that is marked offline. When it comes online, executors will be created and the new idle time will become the executor creation time, effectively resetting the timer.
