### PR TITLE
Report "pending" not "stopping" for pending nodes in logs

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
@@ -59,10 +59,11 @@ public abstract class EC2ComputerLauncher extends ComputerLauncher {
             while(true) {
                 switch (computer.getState()) {
                     case PENDING:
+                        msg = baseMsg + " is still pending/launching, waiting 5s";
                     case STOPPING:
+                        msg = baseMsg + " is still stopping, waiting 5s";
                         Thread.sleep(5000); // check every 5 secs
                         // and report to system log and console
-                        msg = baseMsg + " is still stopping, waiting 5s";
                         LOGGER.finest(msg);
                         logger.println(msg);
                         continue OUTER;


### PR DESCRIPTION
Fixup for 8a9a885 (github pull #101): correct a case fall-through that
resulted in the wrong log message being emitted for starting nodes.

Amendment for https://github.com/jenkinsci/ec2-plugin/pull/101
