### PR TITLE
Fixed bug that caused infinite loop of NullPointerExceptions

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -377,6 +377,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 }
             }
             if (!hasCustomTypeTag) {
+                if (inst_tags == null){
+                    inst_tags = new HashSet<Tag>();
+                }
             	inst_tags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "demand"));
             }
 


### PR DESCRIPTION
Fixed bug that caused infinite loop of NullPointerExceptions during provisioning of windows instances.

Signed-off-by: Stefan C. Mueller scm@smurn.org
