### PR TITLE
Modified the copying of java.jar to the home DIR

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -158,10 +158,10 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
 
             logger.println("Copying slave.jar");
             scp.put(Hudson.getInstance().getJnlpJars("slave.jar").readFully(),
-                    "slave.jar","/tmp");
+                    "slave.jar","~");
 
             String jvmopts = computer.getNode().jvmopts;
-            String launchString = "java " + (jvmopts != null ? jvmopts : "") + " -jar /tmp/slave.jar";
+            String launchString = "java " + (jvmopts != null ? jvmopts : "") + " -jar ~/slave.jar";
             logger.println("Launching slave agent: " + launchString);
             final Session sess = conn.openSession();
             sess.execCommand(launchString);


### PR DESCRIPTION
This fix allows for using the Unix setup to connect to a windows machine with OpenSSH and Cygwin installed. "~" home directory shortcut is common between windows and linux platforms
