### PR TITLE
Resolve [JENKINS-25693] pending spot instance launch blocks launch of non-spot instances.

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -368,7 +368,7 @@ public abstract class EC2Cloud extends Cloud {
 			for(EC2SpotSlave n : NodeIterator.nodes(EC2SpotSlave.class)){
 				// If the slave is online then it is already counted by Jenkins
 				// We only want to count potential additional Spot instance slaves
-				if (n.getComputer().isOffline()){
+				if (n.getComputer().isOffline() && label.matches(n.getAssignedLabels())){
 					DescribeSpotInstanceRequestsRequest dsir =
 							new DescribeSpotInstanceRequestsRequest().withSpotInstanceRequestIds(n.getSpotInstanceRequestId());
 


### PR DESCRIPTION
In fact, a pending spot instance for one kind of slave would block future provisioning of any other kind of slave. Resolved by counting only those pending spot instances which would satisfy the requested label.
