### PR TITLE
fixing zombie workers

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -195,18 +195,22 @@ public abstract class EC2AbstractSlave extends Slave {
     }
 
     public static Instance getInstance(String instanceId, EC2Cloud cloud) {
-        DescribeInstancesRequest request = new DescribeInstancesRequest();
-    	request.setInstanceIds(Collections.<String>singletonList(instanceId));
-        if (cloud == null)
-        	return null;
-        AmazonEC2 ec2 = cloud.connect();
-    	List<Reservation> reservations = ec2.describeInstances(request).getReservations();
         Instance i = null;
-    	if (reservations.size() > 0) {
-    		List<Instance> instances = reservations.get(0).getInstances();
-    		if (instances.size() > 0)
-    			i = instances.get(0);
-    	}
+        try {
+            DescribeInstancesRequest request = new DescribeInstancesRequest();
+            request.setInstanceIds(Collections.<String>singletonList(instanceId));
+            if (cloud == null)
+                return null;
+            AmazonEC2 ec2 = cloud.connect();
+            List<Reservation> reservations = ec2.describeInstances(request).getReservations();
+            if (reservations.size() > 0) {
+                List<Instance> instances = reservations.get(0).getInstances();
+                if (instances.size() > 0)
+                    i = instances.get(0);
+            }
+        } catch (AmazonClientException e) {
+            LOGGER.log(Level.WARNING,"Failed to fetch EC2 instance: "+instanceId,e);
+        }
     	return i;
     }
 

--- a/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
@@ -69,11 +69,10 @@ public final class EC2OndemandSlave extends EC2AbstractSlave {
                 ec2.terminateInstances(request);
                 LOGGER.info("Terminated EC2 instance (terminated): "+getInstanceId());
             }
+            Hudson.getInstance().removeNode(this);
+            LOGGER.info("Removed EC2 instance from jenkins master: "+getInstanceId());
         } catch (AmazonClientException e) {
             LOGGER.log(Level.WARNING,"Failed to terminate EC2 instance: "+getInstanceId(),e);
-        }
-        try {
-            Hudson.getInstance().removeNode(this);
         } catch (IOException e) {
             LOGGER.log(Level.WARNING,"Failed to terminate EC2 instance: "+getInstanceId(),e);
         }


### PR DESCRIPTION
- if AWS api wasn't reachable node where delete from jenkins, but was still existing/running in AWS.
- PR #79  introduce this cause.
- Now node will only delete from jenkins when AWS request was successfully.
- EC2AbstractSlave.getInstance - is real fix for #79 - if instance doesn't exist in AWS, catch the AmazonClientException and return null
