### PR TITLE
Allow multiple clouds per region

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.8.3</version>
+      <version>1.8.4</version>
       <exclusions>
         <exclusion>
           <groupId>commons-codec</groupId>

--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -69,7 +69,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
     
     @DataBoundConstructor
     public AmazonEC2Cloud(String accessId, String secretKey, String region, String privateKey, String instanceCapStr, List<? extends SlaveTemplate> templates) {
-        super(CLOUD_ID_PREFIX + region, accessId, secretKey, privateKey, instanceCapStr, templates);
+        super(CLOUD_ID_PREFIX +accessId+"-"+region, accessId, secretKey, privateKey, instanceCapStr, templates);
         this.region = region;
     }
 
@@ -134,8 +134,6 @@ public class AmazonEC2Cloud extends EC2Cloud {
 				List<Region> regionList = regions.getRegions();
 				for (Region r : regionList) {
 					String name = r.getRegionName();
-					if ((region == null || !region.equals(name)) && cloudRegions.contains(name))
-						continue;
 					model.add(name, name);
 				}
 			}


### PR DESCRIPTION
This is a quick hack to allow multiple clouds per region. I know it should've been done better, but it works. Downside: it will break your existing configuration.
Also, new AWS SDK version introduced to get new instance types