### PR TITLE
Allow multiple clouds per region

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.8.3</version>
+      <version>1.8.4</version>
       <exclusions>
         <exclusion>
           <groupId>commons-codec</groupId>

--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -70,7 +70,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
     
     @DataBoundConstructor
     public AmazonEC2Cloud(boolean useInstanceProfileForCredentials, String accessId, String secretKey, String region, String privateKey, String instanceCapStr, List<? extends SlaveTemplate> templates) {
-        super(CLOUD_ID_PREFIX + region, useInstanceProfileForCredentials, accessId, secretKey, privateKey, instanceCapStr, templates);
+        super(CLOUD_ID_PREFIX + accessId + "-" + region, useInstanceProfileForCredentials, accessId, secretKey, privateKey, instanceCapStr, templates);
         this.region = region;
     }
 
@@ -135,8 +135,6 @@ public class AmazonEC2Cloud extends EC2Cloud {
 				List<Region> regionList = regions.getRegions();
 				for (Region r : regionList) {
 					String name = r.getRegionName();
-					if ((region == null || !region.equals(name)) && cloudRegions.contains(name))
-						continue;
 					model.add(name, name);
 				}
 			}


### PR DESCRIPTION
Allow multiple clouds per region
Also, new AWS SDK to get new instance types

Please don't merge, it is a quick hack and it should've been done better. We have multiple AWS accounts per region and therefore need it.

Anyone who has a good understanding of the plugin and could direct to the right way is welcome.