### PR TITLE
JENKINS-20742: Handle correct AWS error when updating tags

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -426,7 +426,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                             updateRemoteTags(ec2, inst_tags, inst.getInstanceId());
                             break;
                         } catch (AmazonServiceException e) {
-                            if (e.getErrorCode().equals("InvalidInstanceRequestID.NotFound")) {
+                            if (e.getErrorCode().equals("InvalidInstanceID.NotFound")) {
                                 Thread.sleep(5000);
                                 continue;
                             }


### PR DESCRIPTION
As per the AWS API [documentation](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html) the error code ```InvalidInstanceRequestID.NotFound``` does not exist. I believe this was a copy/paste mistake when adding retry support for updating tags for on-demand instances, as evidence by the following commits: https://github.com/jenkinsci/ec2-plugin/commit/ccf31c36a10e324472bf6218f9387287679359a2, https://github.com/jenkinsci/ec2-plugin/commit/9a596f0577b29a3e1835143f5d51520babdd7c1f.

I've changed the error code to now handle the correct error code, ```InvalidInstanceID.NotFound``` which is the same error code that [```EC2Computer._describeInstance()```](https://github.com/jenkinsci/ec2-plugin/blob/ec2-1.26/src/main/java/hudson/plugins/ec2/EC2Computer.java#L143) handles when retrying.