### PR TITLE
JENKINS-26854: Fix for not being able to start EC2 slaves after several hours

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ THE SOFTWARE.
   </parent>
   
   <artifactId>ec2</artifactId>
-  <version>1.27-SNAPSHOT</version>
+  <version>1.26-JENKINS-26854</version>
   <packaging>hpi</packaging>
   <name>Amazon EC2 plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.8.3</version>
+      <version>1.8.11</version>
       <exclusions>
         <exclusion>
           <groupId>commons-codec</groupId>

--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -69,8 +69,8 @@ public class AmazonEC2Cloud extends EC2Cloud {
     
     
     @DataBoundConstructor
-    public AmazonEC2Cloud(boolean useInstanceProfileForCredentials, String accessId, String secretKey, String region, String privateKey, String instanceCapStr, List<? extends SlaveTemplate> templates) {
-        super(CLOUD_ID_PREFIX + region, useInstanceProfileForCredentials, accessId, secretKey, privateKey, instanceCapStr, templates);
+    public AmazonEC2Cloud(boolean useInstanceProfileForCredentials, boolean useSignerOverride, String accessId, String secretKey, String region, String privateKey, String instanceCapStr, List<? extends SlaveTemplate> templates) {
+        super(CLOUD_ID_PREFIX + region, useInstanceProfileForCredentials, useSignerOverride, accessId, secretKey, privateKey, instanceCapStr, templates);
         this.region = region;
     }
 
@@ -114,6 +114,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
         }
 
 		public ListBoxModel doFillRegionItems(@QueryParameter boolean useInstanceProfileForCredentials,
+		        @QueryParameter boolean useSignerOverride,
 				@QueryParameter String accessId, @QueryParameter String secretKey,
 				@QueryParameter String region) throws IOException, ServletException {
 			ListBoxModel model = new ListBoxModel();
@@ -130,7 +131,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
 				}
 				
 				AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, false, accessId, secretKey);
-				AmazonEC2 client = connect(credentialsProvider, new URL("http://ec2.amazonaws.com"));
+				AmazonEC2 client = connect(credentialsProvider, new URL("http://ec2.amazonaws.com"), useSignerOverride);
 				DescribeRegionsResult regions = client.describeRegions();
 				List<Region> regionList = regions.getRegions();
 				for (Region r : regionList) {
@@ -146,6 +147,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
         public FormValidation doTestConnection(
                  @QueryParameter String region,
                  @QueryParameter boolean useInstanceProfileForCredentials,
+                 @QueryParameter boolean useSignerOverride,
                  @QueryParameter String accessId,
                  @QueryParameter String secretKey,
                  @QueryParameter String privateKey) throws IOException, ServletException {
@@ -154,15 +156,16 @@ public class AmazonEC2Cloud extends EC2Cloud {
                 region = DEFAULT_EC2_HOST;
             }
 
-            return super.doTestConnection(getEc2EndpointUrl(region), useInstanceProfileForCredentials, accessId, secretKey, privateKey);
+            return super.doTestConnection(getEc2EndpointUrl(region), useInstanceProfileForCredentials, useSignerOverride, accessId, secretKey, privateKey);
         }
 
         public FormValidation doGenerateKey(StaplerResponse rsp,
                 @QueryParameter String region,
                 @QueryParameter boolean useInstanceProfileForCredentials,
+                @QueryParameter boolean useSignerOverride,
                 @QueryParameter String accessId,
                 @QueryParameter String secretKey) throws IOException, ServletException {
-            return super.doGenerateKey(rsp, getEc2EndpointUrl(region), useInstanceProfileForCredentials, accessId, secretKey);
+            return super.doGenerateKey(rsp, getEc2EndpointUrl(region), useInstanceProfileForCredentials, useSignerOverride, accessId, secretKey);
         }
     }
 }

--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -129,7 +129,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
 					cloudRegions.add(c.name.substring(prefixLen));
 				}
 				
-				AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, accessId, secretKey);
+				AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, false, accessId, secretKey);
 				AmazonEC2 client = connect(credentialsProvider, new URL("http://ec2.amazonaws.com"));
 				DescribeRegionsResult regions = client.describeRegions();
 				List<Region> regionList = regions.getRegions();

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -478,7 +478,7 @@ public abstract class EC2AbstractSlave extends Slave {
 
 		public ListBoxModel doFillZoneItems(@QueryParameter boolean useInstanceProfileForCredentials,
 				@QueryParameter String accessId, @QueryParameter String secretKey, @QueryParameter String region) {
-			AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, accessId, secretKey);
+			AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, false, accessId, secretKey);
 			return fillZoneItems(credentialsProvider, region);
 		}
 		

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -442,7 +442,7 @@ public abstract class EC2AbstractSlave extends Slave {
         return amiType.isWindows() ? ((WindowsData)amiType).getBootDelayInMillis() : 0;
     }
 
-    public static ListBoxModel fillZoneItems(AWSCredentialsProvider credentialsProvider, String region) {
+    public static ListBoxModel fillZoneItems(AWSCredentialsProvider credentialsProvider, String region, boolean useSignerOverride) {
 		ListBoxModel model = new ListBoxModel();
 		if (AmazonEC2Cloud.testMode) {
 			model.add(TEST_ZONE);
@@ -450,7 +450,7 @@ public abstract class EC2AbstractSlave extends Slave {
 		}
 
 		if (!StringUtils.isEmpty(region)) {
-			AmazonEC2 client = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
+			AmazonEC2 client = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region), useSignerOverride);
 			DescribeAvailabilityZonesResult zones = client.describeAvailabilityZones();
 			List<AvailabilityZone> zoneList = zones.getAvailabilityZones();
 			model.add("<not specified>", "");
@@ -477,9 +477,10 @@ public abstract class EC2AbstractSlave extends Slave {
 		}
 
 		public ListBoxModel doFillZoneItems(@QueryParameter boolean useInstanceProfileForCredentials,
+		        @QueryParameter boolean useSignerOverride,
 				@QueryParameter String accessId, @QueryParameter String secretKey, @QueryParameter String region) {
 			AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, false, accessId, secretKey);
-			return fillZoneItems(credentialsProvider, region);
+			return fillZoneItems(credentialsProvider, region, useSignerOverride);
 		}
 		
 		public List<Descriptor<AMITypeData>> getAMITypeDescriptors()

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -432,21 +432,23 @@ public abstract class EC2Cloud extends Cloud {
     }
 
     private AWSCredentialsProvider createCredentialsProvider() {
-        return createCredentialsProvider(useInstanceProfileForCredentials, accessId, secretKey);
+        return createCredentialsProvider(useInstanceProfileForCredentials, true, accessId, secretKey);
     }
 
     public static AWSCredentialsProvider createCredentialsProvider(
             final boolean useInstanceProfileForCredentials,
+            final boolean regularlyUpdateInstanceProfileCredentials,
             final String accessId, final String secretKey) {
-        return createCredentialsProvider(useInstanceProfileForCredentials, accessId.trim(), Secret.fromString(secretKey.trim()));
+        return createCredentialsProvider(useInstanceProfileForCredentials, regularlyUpdateInstanceProfileCredentials, accessId.trim(), Secret.fromString(secretKey.trim()));
     }
 
     public static AWSCredentialsProvider createCredentialsProvider(
             final boolean useInstanceProfileForCredentials,
+            final boolean regularlyUpdateInstanceProfileCredentials,
             final String accessId, final Secret secretKey) {
 
         if (useInstanceProfileForCredentials) {
-            return new InstanceProfileCredentialsProvider();
+            return new InstanceProfileCredentialsProvider(regularlyUpdateInstanceProfileCredentials);
         }
 
         BasicAWSCredentials credentials = new BasicAWSCredentials(accessId, Secret.toString(secretKey));
@@ -584,7 +586,7 @@ public abstract class EC2Cloud extends Cloud {
         protected FormValidation doTestConnection( URL ec2endpoint,
                 boolean useInstanceProfileForCredentials, String accessId, String secretKey, String privateKey) throws IOException, ServletException {
                try {
-                AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, accessId, secretKey);
+                AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, false, accessId, secretKey);
                 AmazonEC2 ec2 = connect(credentialsProvider, ec2endpoint);
                 ec2.describeInstances();
 
@@ -608,7 +610,7 @@ public abstract class EC2Cloud extends Cloud {
         public FormValidation doGenerateKey(StaplerResponse rsp, URL ec2EndpointUrl, boolean useInstanceProfileForCredentials, String accessId, String secretKey)
         		throws IOException, ServletException {
             try {
-                AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, accessId, secretKey);
+                AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, false, accessId, secretKey);
                 AmazonEC2 ec2 = connect(credentialsProvider, ec2EndpointUrl);
                 List<KeyPairInfo> existingKeys = ec2.describeKeyPairs().getKeyPairs();
 

--- a/src/main/java/hudson/plugins/ec2/Eucalyptus.java
+++ b/src/main/java/hudson/plugins/ec2/Eucalyptus.java
@@ -64,8 +64,8 @@ public class Eucalyptus extends EC2Cloud {
     public final URL s3endpoint;
 
     @DataBoundConstructor
-    public Eucalyptus(URL ec2endpoint, URL s3endpoint, boolean useInstanceProfileForCredentials, String accessId, String secretKey, String privateKey, String instanceCapStr, List<SlaveTemplate> templates) throws IOException {
-        super("eucalyptus", useInstanceProfileForCredentials, accessId, secretKey, privateKey, instanceCapStr, templates);
+    public Eucalyptus(URL ec2endpoint, URL s3endpoint, boolean useInstanceProfileForCredentials, boolean useSignerOverride, String accessId, String secretKey, String privateKey, String instanceCapStr, List<SlaveTemplate> templates) throws IOException {
+        super("eucalyptus", useInstanceProfileForCredentials, useSignerOverride, accessId, secretKey, privateKey, instanceCapStr, templates);
         this.ec2endpoint = ec2endpoint;
         this.s3endpoint = s3endpoint;
     }
@@ -91,15 +91,16 @@ public class Eucalyptus extends EC2Cloud {
 		public FormValidation doTestConnection(
                 @QueryParameter URL ec2endpoint,
                 @QueryParameter boolean useInstanceProfileForCredentials,
+                @QueryParameter boolean useSignerOverride,
                 @QueryParameter String accessId,
                 @QueryParameter String secretKey,
                 @QueryParameter String privateKey) throws IOException, ServletException {
-            return super.doTestConnection(ec2endpoint, useInstanceProfileForCredentials, accessId, secretKey, privateKey);
+            return super.doTestConnection(ec2endpoint, useInstanceProfileForCredentials, useSignerOverride, accessId, secretKey, privateKey);
         }
 
 		public FormValidation doGenerateKey(
-                StaplerResponse rsp, @QueryParameter URL url, @QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String accessId, @QueryParameter String secretKey) throws IOException, ServletException {
-            return super.doGenerateKey(rsp, url, useInstanceProfileForCredentials, accessId, secretKey);
+                StaplerResponse rsp, @QueryParameter URL url, @QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter boolean useSignerOverride, @QueryParameter String accessId, @QueryParameter String secretKey) throws IOException, ServletException {
+            return super.doGenerateKey(rsp, url, useInstanceProfileForCredentials, useSignerOverride, accessId, secretKey);
         }
     }
 }

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -883,15 +883,16 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
          */
         public FormValidation doValidateAmi(
                 @QueryParameter boolean useInstanceProfileForCredentials,
+                @QueryParameter boolean useSignerOverride,
                 @QueryParameter String accessId, @QueryParameter String secretKey,
                 @QueryParameter String ec2endpoint,  @QueryParameter String region,
                 final @QueryParameter String ami) throws IOException {
             AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, false, accessId, secretKey);
             AmazonEC2 ec2;
             if (region != null) {
-                ec2 = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
+                ec2 = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region), useSignerOverride);
             } else {
-                ec2 = EC2Cloud.connect(credentialsProvider, new URL(ec2endpoint));
+                ec2 = EC2Cloud.connect(credentialsProvider, new URL(ec2endpoint), useSignerOverride);
             }
             if(ec2!=null) {
                 try {
@@ -957,13 +958,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
 
         public ListBoxModel doFillZoneItems( @QueryParameter boolean useInstanceProfileForCredentials,
+                                             @QueryParameter boolean useSignerOverride,
                                              @QueryParameter String accessId,
                                              @QueryParameter String secretKey,
                                              @QueryParameter String region)
                                              throws IOException, ServletException
         {
             AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, false, accessId, secretKey);
-            return EC2AbstractSlave.fillZoneItems(credentialsProvider, region);
+            return EC2AbstractSlave.fillZoneItems(credentialsProvider, region, useSignerOverride);
         }
 
         /* Validate the Spot Max Bid Price to ensure that it is a floating point number >= .001 */
@@ -1001,6 +1003,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         /* Check the current Spot price of the selected instance type for the selected region */
         public FormValidation doCurrentSpotPrice( @QueryParameter boolean useInstanceProfileForCredentials,
+                @QueryParameter boolean useSignerOverride,
                 @QueryParameter String accessId, @QueryParameter String secretKey,
                 @QueryParameter String region, @QueryParameter String type,
                 @QueryParameter String zone ) throws IOException, ServletException {
@@ -1010,7 +1013,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             // Connect to the EC2 cloud with the access id, secret key, and region queried from the created cloud
             AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, false, accessId, secretKey);
-            AmazonEC2 ec2 = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
+            AmazonEC2 ec2 = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region), useSignerOverride);
 
             if(ec2!=null) {
 

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -886,7 +886,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 @QueryParameter String accessId, @QueryParameter String secretKey,
                 @QueryParameter String ec2endpoint,  @QueryParameter String region,
                 final @QueryParameter String ami) throws IOException {
-            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, accessId, secretKey);
+            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, false, accessId, secretKey);
             AmazonEC2 ec2;
             if (region != null) {
                 ec2 = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
@@ -962,7 +962,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                                              @QueryParameter String region)
                                              throws IOException, ServletException
         {
-            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, accessId, secretKey);
+            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, false, accessId, secretKey);
             return EC2AbstractSlave.fillZoneItems(credentialsProvider, region);
         }
 
@@ -1009,7 +1009,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             String zoneStr = "";
 
             // Connect to the EC2 cloud with the access id, secret key, and region queried from the created cloud
-            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, accessId, secretKey);
+            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, false, accessId, secretKey);
             AmazonEC2 ec2 = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
 
             if(ec2!=null) {

--- a/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Use query string signer}" field="useSignerOverride">
+    <f:checkbox />
+  </f:entry>
   <f:entry title="${%Access Key ID}" field="accessId">
     <f:textbox />
   </f:entry>
@@ -45,6 +48,6 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
   </f:advanced>
-  <f:validateButton title="${%Generate Key}" progress="${%Generate...}" method="generateKey" with="region,useInstanceProfileForCredentials,secretKey,accessId" />
-  <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="region,useInstanceProfileForCredentials,secretKey,accessId,privateKey" />
+  <f:validateButton title="${%Generate Key}" progress="${%Generate...}" method="generateKey" with="region,useInstanceProfileForCredentials,useSignerOverride,secretKey,accessId" />
+  <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="region,useInstanceProfileForCredentials,useSignerOverride,secretKey,accessId,privateKey" />
 </j:jelly>

--- a/src/main/resources/hudson/plugins/ec2/Eucalyptus/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/Eucalyptus/config-entries.jelly
@@ -28,6 +28,9 @@ THE SOFTWARE.
   <f:entry title="${%Eucalyptus S3 URL}" field="s3endpoint">
     <f:textbox />
   </f:entry>
+  <f:entry title="${%Use query string signer}" field="useSignerOverride">
+    <f:checkbox />
+  </f:entry>
   <f:entry title="${%Access ID}" field="accessId">
     <f:textbox />
   </f:entry>
@@ -45,6 +48,6 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
   </f:advanced>
-  <f:validateButton title="${%Generate Key}" progress="${%Generate...}" method="generateKey" with="ec2endpoint,useInstanceProfileForCredentials,secretKey,accessId" />
-  <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="ec2endpoint,useInstanceProfileForCredentials,secretKey,accessId,privateKey" />
+  <f:validateButton title="${%Generate Key}" progress="${%Generate...}" method="generateKey" with="ec2endpoint,useInstanceProfileForCredentials,useSignerOverride,secretKey,accessId" />
+  <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="ec2endpoint,useInstanceProfileForCredentials,useSignerOverride,secretKey,accessId,privateKey" />
 </j:jelly>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
     <f:textbox />
   </f:entry>
 
-  <f:validateButton title="${%Check AMI}" progress="${%Checking...}" method="validateAmi" with="secretKey,accessId,region,ec2endpoint,ami" />
+  <f:validateButton title="${%Check AMI}" progress="${%Checking...}" method="validateAmi" with="useInstanceProfileForCredentials,useSignerOverride,secretKey,accessId,region,ec2endpoint,ami" />
 
   <f:entry title="${%Instance Type}" field="type">
     <f:enum>${it.name()}</f:enum>
@@ -53,7 +53,7 @@ THE SOFTWARE.
     <f:description>Slaves designated as Spot slaves will initially show up as disconnected. The state
     will change to connecting when a Spot request has been fulfilled. </f:description>
 
-    <f:validateButton title="${%Check Current Spot Price}" progress="${%Checking...}" method="currentSpotPrice" with="accessId,secretKey,region,type,zone" />
+    <f:validateButton title="${%Check Current Spot Price}" progress="${%Checking...}" method="currentSpotPrice" with="useInstanceProfileForCredentials,useSignerOverride,accessId,secretKey,region,type,zone" />
 
     <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice">
       <f:textbox />

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
@@ -43,12 +43,12 @@ public class AmazonEC2CloudTest extends HudsonTestCase {
 	}
 
 	public void testConfigRoundtrip() throws Exception {
-		AmazonEC2Cloud orig = new AmazonEC2Cloud(true, "abc", "def", "us-east-1",
+		AmazonEC2Cloud orig = new AmazonEC2Cloud(true, true, "abc", "def", "us-east-1",
 				"ghi", "3", Collections.<SlaveTemplate> emptyList());
 		hudson.clouds.add(orig);
 		submit(createWebClient().goTo("configure").getFormByName("config"));
 
 		assertEqualBeans(orig, hudson.clouds.iterator().next(),
-				"region,useInstanceProfileForCredentials,accessId,secretKey,privateKey,instanceCap");
+				"region,useInstanceProfileForCredentials,useSignerOverride,accessId,secretKey,privateKey,instanceCap");
 	}
 }

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -63,7 +63,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, false, "abc", "def", "us-east-1", "ghi", "3", templates);
         hudson.clouds.add(ac);
 
         submit(createWebClient().goTo("configure").getFormByName("config"));
@@ -86,7 +86,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, false, "abc", "def", "us-east-1", "ghi", "3", templates);
         hudson.clouds.add(ac);
 
         submit(createWebClient().goTo("configure").getFormByName("config"));
@@ -115,7 +115,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, false, "abc", "def", "us-east-1", "ghi", "3", templates);
         hudson.clouds.add(ac);
 
         submit(createWebClient().goTo("configure").getFormByName("config"));
@@ -143,7 +143,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, false, "abc", "def", "us-east-1", "ghi", "3", templates);
         hudson.clouds.add(ac);
 
         submit(createWebClient().goTo("configure").getFormByName("config"));
@@ -199,7 +199,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, false, "abc", "def", "us-east-1", "ghi", "3", templates);
         hudson.clouds.add(ac);
 
         submit(createWebClient().goTo("configure").getFormByName("config"));
@@ -222,7 +222,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, false, "abc", "def", "us-east-1", "ghi", "3", templates);
         hudson.clouds.add(ac);
 
         submit(createWebClient().goTo("configure").getFormByName("config"));

--- a/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
+++ b/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
@@ -55,7 +55,7 @@ public class TemplateLabelsTest extends HudsonTestCase{
 		List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
 		templates.add(template);
 
-		ac = new AmazonEC2Cloud(false, "us-east-1", "abc", "def", "ghi", "3", templates);
+		ac = new AmazonEC2Cloud(false, false, "us-east-1", "abc", "def", "ghi", "3", templates);
 	}
 
 	public void testLabelAtom() throws Exception{


### PR DESCRIPTION
Minimal improvement to ensure EC2 instance profile credentials are refreshed so that after the credentials expire the new rotated credentials made available by the EC2 metadata service are automatically fetched. Upgrades the AWS Java SDK to v1.8.11, the first stable version after the background refresh of instance profile credentials was introduced in unstable v1.8.10.