### PR TITLE
JENKINS-24359: Overcoming limit of one cloud per region.

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Name}" field="cloudName">
+    <f:textbox />
+  </f:entry>
   <f:entry title="${%Access Key ID}" field="accessId">
     <f:textbox />
   </f:entry>
@@ -31,8 +34,7 @@ THE SOFTWARE.
   <f:entry title="${%Use EC2 instance profile to obtain credentials}" field="useInstanceProfileForCredentials">
     <f:checkbox />
   </f:entry>
-  <f:description>The regions will be populated once the keys above are entered. Since at most one cloud can be defined per
-  region, region names which are associated with other clouds are not shown here.
+  <f:description>The regions will be populated once the keys above are entered.
   </f:description>
   <f:entry title="${%Region}" field="region">
     <f:select/>

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/computerSet.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/computerSet.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
       <td />
       <td colspan="${monitors.size()+1}">
         <f:form action="${rootURL}/cloud/${it.name}/provision" method="post" name="provision">
-          <input type="submit" class="ec2-provision-button" value="${%Provision via EC2}" />
+          <input type="submit" class="ec2-provision-button" value="${%Provision via} ${it.displayName}" />
           <select name="template">
             <j:forEach var="t" items="${it.templates}">
               <option value="${t.description}">${t.displayName}</option>

--- a/src/main/resources/hudson/plugins/ec2/Messages.properties
+++ b/src/main/resources/hudson/plugins/ec2/Messages.properties
@@ -10,3 +10,4 @@ EC2SpotSlave.AmazonEC2SpotInstance=Amazon EC2 Spot Instance
 EC2SpotSlave.Spot1=Spot $
 EC2SpotSlave.Spot2= max bid price
 
+AmazonEC2Cloud.NonUniqName=Cloud name must be unique across EC2 clouds

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
@@ -32,23 +32,25 @@ import java.util.Collections;
  */
 public class AmazonEC2CloudTest extends HudsonTestCase {
 
-	protected void setUp() throws Exception {
-		super.setUp();
-		AmazonEC2Cloud.testMode = true;
-	}
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        AmazonEC2Cloud.testMode = true;
+    }
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		AmazonEC2Cloud.testMode = false;
-	}
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        AmazonEC2Cloud.testMode = false;
+    }
 
-	public void testConfigRoundtrip() throws Exception {
-		AmazonEC2Cloud orig = new AmazonEC2Cloud(true, "abc", "def", "us-east-1",
-				"ghi", "3", Collections.<SlaveTemplate> emptyList());
-		hudson.clouds.add(orig);
-		submit(createWebClient().goTo("configure").getFormByName("config"));
+    public void testConfigRoundtrip() throws Exception {
+        AmazonEC2Cloud orig = new AmazonEC2Cloud("us-east-1", true, "abc", "def", "us-east-1",
+                "ghi", "3", Collections.<SlaveTemplate> emptyList());
+        hudson.clouds.add(orig);
+        submit(createWebClient().goTo("configure").getFormByName("config"));
 
-		assertEqualBeans(orig, hudson.clouds.iterator().next(),
-				"region,useInstanceProfileForCredentials,accessId,secretKey,privateKey,instanceCap");
-	}
+        assertEqualBeans(orig, hudson.clouds.iterator().next(),
+                "cloudName,region,useInstanceProfileForCredentials,accessId,secretKey,privateKey,instanceCap");
+    }
 }

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -38,11 +38,13 @@ import com.amazonaws.services.ec2.model.SpotInstanceType;
  */
 public class SlaveTemplateTest extends HudsonTestCase {
 
+    @Override
     protected void setUp() throws Exception {
         super.setUp();
         AmazonEC2Cloud.testMode = true;
     }
 
+    @Override
     protected void tearDown() throws Exception {
         super.tearDown();
         AmazonEC2Cloud.testMode = false;
@@ -63,7 +65,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
         hudson.clouds.add(ac);
 
         submit(createWebClient().goTo("configure").getFormByName("config"));
@@ -86,7 +88,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
         hudson.clouds.add(ac);
 
         submit(createWebClient().goTo("configure").getFormByName("config"));
@@ -115,7 +117,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
         hudson.clouds.add(ac);
 
         submit(createWebClient().goTo("configure").getFormByName("config"));
@@ -143,7 +145,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
         hudson.clouds.add(ac);
 
         submit(createWebClient().goTo("configure").getFormByName("config"));
@@ -199,7 +201,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
         hudson.clouds.add(ac);
 
         submit(createWebClient().goTo("configure").getFormByName("config"));
@@ -222,7 +224,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
         hudson.clouds.add(ac);
 
         submit(createWebClient().goTo("configure").getFormByName("config"));

--- a/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
+++ b/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
@@ -55,7 +55,7 @@ public class TemplateLabelsTest extends HudsonTestCase{
 		List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
 		templates.add(template);
 
-		ac = new AmazonEC2Cloud(false, "us-east-1", "abc", "def", "ghi", "3", templates);
+		ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
 	}
 
 	public void testLabelAtom() throws Exception{


### PR DESCRIPTION
Originally cloud id was derived from the region, which prevented
creating more than one cloud per region.

With this patch I made cloud name visible and configurable,
effectively allowing multiple clouds per region.

Also, "Provision via EC2" buttons in /computer view now have
cloud name instead of "EC2"

All changes are backwards compatible