### PR TITLE
Spot Instance Device Mapping

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -511,6 +511,39 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         riRequest.withBlockDeviceMappings(newDeviceMapping);
     }
 
+    private void setupEphemeralDeviceMapping(LaunchSpecification launchSpecification) {
+
+        final List<BlockDeviceMapping> oldDeviceMapping = getAmiBlockDeviceMappings();
+
+        final Set<String> occupiedDevices = new HashSet<String>();
+        for (final BlockDeviceMapping mapping: oldDeviceMapping ) {
+
+            occupiedDevices.add(mapping.getDeviceName());
+        }
+
+        final List<String> available = new ArrayList<String>(Arrays.asList(
+                "ephemeral0", "ephemeral1", "ephemeral2", "ephemeral3"
+        ));
+
+        final List<BlockDeviceMapping> newDeviceMapping = new ArrayList<BlockDeviceMapping>(4);
+        for (char suffix = 'b'; suffix <= 'z' && !available.isEmpty(); suffix++) {
+
+            final String deviceName = String.format("/dev/xvd%s", suffix);
+
+            if (occupiedDevices.contains(deviceName)) continue;
+
+            final BlockDeviceMapping newMapping = new BlockDeviceMapping()
+                    .withDeviceName(deviceName)
+                    .withVirtualName(available.get(0))
+            ;
+
+            newDeviceMapping.add(newMapping);
+            available.remove(0);
+        }
+
+        launchSpecification.withBlockDeviceMappings(newDeviceMapping);
+    }
+
     private List<BlockDeviceMapping> getAmiBlockDeviceMappings() {
 
         /*
@@ -531,6 +564,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     private void setupCustomDeviceMapping(RunInstancesRequest riRequest) {
         if (StringUtils.isNotBlank(customDeviceMapping)) {
             riRequest.setBlockDeviceMappings(DeviceMappingParser.parse(customDeviceMapping));
+        }
+    }
+    private void setupCustomDeviceMapping(LaunchSpecification launchSpecification) {
+        if (StringUtils.isNotBlank(customDeviceMapping)) {
+            launchSpecification.setBlockDeviceMappings(DeviceMappingParser.parse(customDeviceMapping));
         }
     }
 
@@ -562,6 +600,13 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             launchSpecification.setImageId(ami);
             launchSpecification.setInstanceType(type);
+
+            if (useEphemeralDevices) {
+                setupEphemeralDeviceMapping(launchSpecification);
+            }
+            else {
+                setupCustomDeviceMapping(launchSpecification);
+            }
 
             if (StringUtils.isNotBlank(getZone())) {
                 SpotPlacement placement = new SpotPlacement(getZone());


### PR DESCRIPTION
- Spot instances can now map block devices and have the instance ephemeral storage devices mapped automatically just like On Demand instances can.
- Overloaded the methods to provide support for the ephemeral storage and block device mapping on the LaunchSpecification object types.