### PR TITLE
JENKINS-27193 Use proper error code to detect not-yet-started slave.

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -426,7 +426,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                             updateRemoteTags(ec2, inst_tags, inst.getInstanceId());
                             break;
                         } catch (AmazonServiceException e) {
-                            if (e.getErrorCode().equals("InvalidInstanceRequestID.NotFound")) {
+                            if (e.getErrorCode().equals("InvalidInstanceID.NotFound")) {
                                 Thread.sleep(5000);
                                 continue;
                             }


### PR DESCRIPTION
"InvalidInstanceRequestID.NotFound" is not available in
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html .
"InvalidInstanceID.NotFound" matches both this doc and what actually appears
in Jenkins log.