### PR TITLE
[JENKINS-27260] SPNEGO for Windows in EC2 Plugin

### DIFF
--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -30,7 +30,7 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
 
         try {
             String initScript = computer.getNode().initScript;
-            String tmpDir = (computer.getNode().tmpDir != null ? computer.getNode().tmpDir : "C:\\Windows\\Temp\\");
+            String tmpDir = (computer.getNode().tmpDir != null && !computer.getNode().tmpDir.equals("") ? computer.getNode().tmpDir : "C:\\Windows\\Temp\\");
             
             logger.println("Creating tmp directory if it does not exist");
             connection.execute("if not exist " + tmpDir + " mkdir " + tmpDir);

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
@@ -200,7 +200,7 @@ public class WinRMClient {
     private DefaultHttpClient buildHTTPClient()
     {
         DefaultHttpClient httpclient = new DefaultHttpClient();
-        httpclient.getAuthSchemes().unregister(AuthPolicy.SPNEGO);
+        //httpclient.getAuthSchemes().unregister(AuthPolicy.SPNEGO);
         httpclient.setCredentialsProvider(credsProvider);
         httpclient.getParams().setParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, 5000);
         //httpclient.setHttpRequestRetryHandler(new WinRMRetryHandler());


### PR DESCRIPTION
As per [Jenkins-27260](https://issues.jenkins-ci.org/browse/JENKINS-27260):

JENKINS-25385 and JENKINS-4995 both have comments complaining about infinite loops when creating Windows slaves. Because SPNEGO is unregistered for, the httpclient throws an exception that is silently
caught and causes the infinite loop. 

I was able to connect to WinRM, but I had to re enable SPNEGO. I'm not sure what repercussions that will have otherwise, I'm hoping someone can comment on that. 

I also found that the tmpDir was getting set to "", causing a failure, so I added in a case for that.