### PR TITLE
[WiP] Launch slave agent via ssh client process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-      <version>1.447</version>
+      <version>1.554.1</version>  <!-- What version does maintainer want here? I added to get @DataBoundSetter -->
   </parent>
   
   <artifactId>ec2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-      <version>1.554.1</version>  <!-- What version does maintainer want here? I added to get @DataBoundSetter -->
+      <version>1.447</version>
   </parent>
   
   <artifactId>ec2</artifactId>

--- a/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
@@ -104,7 +104,7 @@ public abstract class EC2ComputerLauncher extends ComputerLauncher {
                 logger.println(msg);
             }
 
-            launch(computer, logger, computer.describeInstance());
+            launch(computer, listener, computer.describeInstance());
         } catch (AmazonClientException e) {
             e.printStackTrace(listener.error(e.getMessage()));
         } catch (IOException e) {
@@ -118,7 +118,7 @@ public abstract class EC2ComputerLauncher extends ComputerLauncher {
     /**
      * Stage 2 of the launch. Called after the EC2 instance comes up.
      */
-    protected abstract void launch(EC2Computer computer, PrintStream logger, Instance inst)
+    protected abstract void launch(EC2Computer computer, TaskListener listener, Instance inst)
             throws AmazonClientException, IOException, InterruptedException;
 
     private static final Logger LOGGER = Logger.getLogger(EC2ComputerLauncher.class.getName());

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -50,7 +50,6 @@ import jenkins.slaves.iterators.api.NodeIterator;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import com.amazonaws.AmazonClientException;
@@ -108,7 +107,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 	public transient String rootCommandPrefix;
 
     @DataBoundConstructor
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS, InstanceType type, String labelString, Node.Mode mode, String description, String initScript, String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts, boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, boolean usePrivateDnsName, String instanceCapStr, String iamInstanceProfile, boolean useEphemeralDevices, boolean useDedicatedTenancy, String launchTimeoutStr, boolean associatePublicIp, String customDeviceMapping) {
+    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS, InstanceType type, String labelString, Node.Mode mode, String description, String initScript, String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts, boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, boolean usePrivateDnsName, String instanceCapStr, String iamInstanceProfile, boolean useEphemeralDevices, boolean useDedicatedTenancy, String launchTimeoutStr, boolean associatePublicIp, String customDeviceMapping, boolean connectBySSHProcess) {
         this.ami = ami;
         this.zone = zone;
         this.spotConfig = spotConfig;
@@ -132,6 +131,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.usePrivateDnsName = usePrivateDnsName;
         this.associatePublicIp = associatePublicIp;
         this.useDedicatedTenancy = useDedicatedTenancy;
+        this.connectBySSHProcess = connectBySSHProcess;
 
         if (null == instanceCapStr || instanceCapStr.equals("")) {
             this.instanceCap = Integer.MAX_VALUE;
@@ -152,6 +152,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         readResolve(); // initialize
     }
 
+    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS, InstanceType type, String labelString, Node.Mode mode, String description, String initScript, String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts, boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, boolean usePrivateDnsName, String instanceCapStr, String iamInstanceProfile, boolean useEphemeralDevices, boolean useDedicatedTenancy, String launchTimeoutStr, boolean associatePublicIp, String customDeviceMapping) {
+    	this(ami, zone, spotConfig, securityGroups, remoteFS, type, labelString, mode, description, initScript, tmpDir, userData, numExecutors, remoteAdmin, amiType, jvmopts, stopOnTerminate, subnetId, tags, idleTerminationMinutes, usePrivateDnsName, instanceCapStr, iamInstanceProfile, useEphemeralDevices, useDedicatedTenancy, launchTimeoutStr, associatePublicIp, customDeviceMapping, false);
+    }
+
     /**
      * Backward compatible constructor for reloading previous version data
      */
@@ -163,12 +167,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public boolean isConnectBySSHProcess() {
         // See src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-connectBySSHProcess.html
         return connectBySSHProcess;
-    }
-
-    @DataBoundSetter
-    public void setConnectBySSHProcess(boolean connectBySSHProcess) {
-        // See src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-connectBySSHProcess.html
-        this.connectBySSHProcess = connectBySSHProcess;
     }
 
     public EC2Cloud getParent() {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -50,6 +50,7 @@ import jenkins.slaves.iterators.api.NodeIterator;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import com.amazonaws.AmazonClientException;
@@ -92,6 +93,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public final boolean useDedicatedTenancy;
     public AMITypeData amiType;
     public int launchTimeout;
+    public boolean connectBySSHProcess;
 
     private transient /*almost final*/ Set<LabelAtom> labelSet;
 	private transient /*almost final*/ Set<String> securityGroupSet;
@@ -157,7 +159,18 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     {
     	this(ami, zone, spotConfig, securityGroups, remoteFS, type, labelString, mode, description, initScript, tmpDir, userData, numExecutors, remoteAdmin, new UnixData(rootCommandPrefix, sshPort), jvmopts, stopOnTerminate, subnetId, tags, idleTerminationMinutes, usePrivateDnsName, instanceCapStr, iamInstanceProfile, useEphemeralDevices, false, launchTimeoutStr, false, null); 
     }
-    
+
+    public boolean isConnectBySSHProcess() {
+        // See src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-connectBySSHProcess.html
+        return connectBySSHProcess;
+    }
+
+    @DataBoundSetter
+    public void setConnectBySSHProcess(boolean connectBySSHProcess) {
+        // See src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-connectBySSHProcess.html
+        this.connectBySSHProcess = connectBySSHProcess;
+    }
+
     public EC2Cloud getParent() {
         return parent;
     }

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -196,7 +196,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                             String.format("ssh -o StrictHostKeyChecking=no -i %s %s@%s -p %d %s",
                                     identityKeyFile.getAbsolutePath(),
                                     node.remoteAdmin,
-                                    getEC2HostName(computer, inst),
+                                    getEC2HostAddress(computer, inst),
                                     node.getSshPort(),
                                     launchString);
 
@@ -288,7 +288,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                     throw new AmazonClientException("Timed out after "+ (waitTime / 1000) + " seconds of waiting for ssh to become available. (maximum timeout configured is "+ (timeout / 1000) + ")" );
                 }
                 Instance instance = computer.updateInstanceDescription();
-                String host = getEC2HostName(computer, instance);
+                String host = getEC2HostAddress(computer, instance);
 
                 if ("0.0.0.0".equals(host)) {
                     logger.println("Invalid host 0.0.0.0, your host is most likely waiting for an ip address.");
@@ -328,7 +328,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
         }
     }
 
-    private String getEC2HostName(EC2Computer computer, Instance inst) {
+    private String getEC2HostAddress(EC2Computer computer, Instance inst) {
         if (computer.getNode().usePrivateDnsName) {
             return inst.getPrivateDnsName();
         } else {

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -45,6 +45,7 @@ import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URL;
+import java.util.List;
 
 import jenkins.model.Jenkins;
 
@@ -179,9 +180,13 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
             // TODO: I don't get these templates. How are they named/labeled and when will there be multiples?
             // Need to find out how to map this stuff onto the EC2AbstractSlave instance as it seems to have
             // some of the same props.
-            SlaveTemplate slaveTemplate = computer.getCloud().getTemplates().get(0);
+            List<SlaveTemplate> templates = computer.getCloud().getTemplates();
+            SlaveTemplate slaveTemplate = null;
+            if (templates != null && !templates.isEmpty()) {
+                slaveTemplate = templates.get(0);
+            }
 
-            if (slaveTemplate.isConnectBySSHProcess()) {
+            if (slaveTemplate != null && slaveTemplate.isConnectBySSHProcess()) {
                 EC2AbstractSlave node = computer.getNode();
                 File identityKeyFile = createIdentityKeyFile(computer);
 

--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -2,6 +2,7 @@ package hudson.plugins.ec2.win;
 
 import hudson.model.Descriptor;
 import hudson.model.Hudson;
+import hudson.model.TaskListener;
 import hudson.plugins.ec2.EC2Computer;
 import hudson.plugins.ec2.EC2ComputerLauncher;
 import hudson.plugins.ec2.win.winrm.WindowsProcess;
@@ -24,8 +25,9 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
     final long sleepBetweenAttemps = TimeUnit.SECONDS.toMillis(10);
     
     @Override
-    protected void launch(EC2Computer computer, PrintStream logger, Instance inst) throws IOException, AmazonClientException,
+    protected void launch(EC2Computer computer, TaskListener listener, Instance inst) throws IOException, AmazonClientException,
     InterruptedException {
+        final PrintStream logger = listener.getLogger();
         final WinConnection connection = connectToWinRM(computer, logger);
 
         try {

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -156,6 +156,10 @@ THE SOFTWARE.
       <f:checkbox />
     </f:entry>
 
+    <f:entry title="${%Connect by SSH Process}" field="connectBySSHProcess">
+      <f:checkbox />
+    </f:entry>
+
   </f:advanced>
 
   <f:entry title="">

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-connectBySSHProcess.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-connectBySSHProcess.html
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+Copyright (c) 2015, CloudBees, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-connectBySSHProcess.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-connectBySSHProcess.html
@@ -1,0 +1,34 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<div>
+    Connect to the Jenkins Slave Agent through an external SSH client process.
+    <p/>
+    <strong>NOTE</strong>: The Jenkins Master must have an installed SSH Client.
+    <p/>
+    By default, the plugin connects to the slave agent using an in-process Java SSH client.
+    By checking this configuration option, you are telling the plugin to launch an external
+    local SSH client process and to use that instead to connect to the Jenkins Slave Agent
+    running on the EC2 instance. This option has proven to produce a more stable connection
+    in some environments.
+</div>


### PR DESCRIPTION
We (at CloudBees) encountered a situation where the SSH connection would be mysteriously lost between the master and a slave agent running on EC2. This usually happened during long running jobs but we were unable to track down the root cause of the problem. How we worked around it was to make a change to the EC2 plugin (the changes in this PR) such that the plugin would connect to the slave agent via an external ssh client process that the plugin would launch (Vs using the Trilead lib).

Things that probably need to be resolved:

* This new option will only work where the master has an SSH client installed. Is it OK to just call this out as a limitation in `help-connectBySSHProcess.html`, or should we perform some runtime checks before offering it. The later would obviously be best but might not be easy to do it reliably.
* The only way I could see to get the config option in was to put it on the `SlaveTemplate`. The only way I could get at "a" `SlaveTemplate` in `EC2UnixLauncher` was via `computer.getCloud().getTemplates().get(0);`. This feels all wrong to me though. 

Added config option (checkbox in the advanced section) to allow switching between original in-process SSH and this external SSH process.