### PR TITLE
JENKINS-26797 - Zombie instance created by the EC2 plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@ THE SOFTWARE.
 
   <dependencies>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <!-- we only use this to handle key fingerprint. should be able to replace this with trilead -->
       <groupId>bouncycastle</groupId>
       <artifactId>bcprov-jdk15</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,23 @@ THE SOFTWARE.
     <tag>HEAD</tag>
   </scm>
 
+  <properties>
+      <powermock.version>1.6.2</powermock.version>
+  </properties>
+
   <dependencies>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -711,7 +711,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @param params
      * @throws InterruptedException
      */
-    protected void updateRemoteTags(AmazonEC2 ec2, Collection<Tag> inst_tags, String catchErrorCode, String... params) throws InterruptedException {
+    private void updateRemoteTags(AmazonEC2 ec2, Collection<Tag> inst_tags, String catchErrorCode, String... params) throws InterruptedException {
         for (int i = 0; i < 5; i++) {
             try {
                 CreateTagsRequest tag_request = new CreateTagsRequest();

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URL;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
@@ -421,18 +422,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
                 /* Now that we have our instance, we can set tags on it */
                 if (inst_tags != null) {
-                    for (int i = 0; i < 5; i++) {
-                        try {
-                            updateRemoteTags(ec2, inst_tags, inst.getInstanceId());
-                            break;
-                        } catch (AmazonServiceException e) {
-                            if (e.getErrorCode().equals("InvalidInstanceRequestID.NotFound")) {
-                                Thread.sleep(5000);
-                                continue;
-                            }
-                            throw e;
-                        }
-                    }
+                    updateRemoteTags(ec2, inst_tags, "InvalidInstanceID.NotFound", inst.getInstanceId());
 
                     // That was a remote request - we should also update our local instance data.
                     inst.setTags(inst_tags);
@@ -676,18 +666,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             /* Now that we have our Spot request, we can set tags on it */
             if (inst_tags != null) {
-                for (int i = 0; i < 5; i++) {
-                    try {
-                        updateRemoteTags(ec2, inst_tags, spotInstReq.getSpotInstanceRequestId());
-                        break;
-                    } catch (AmazonServiceException e) {
-                        if (e.getErrorCode().equals("InvalidSpotInstanceRequestID.NotFound")) {
-                            Thread.sleep(5000);
-                            continue;
-                        }
-                        throw e;
-                    }
-                }
+                updateRemoteTags(ec2, inst_tags, "InvalidSpotInstanceRequestID.NotFound", spotInstReq.getSpotInstanceRequestId());
 
                 // That was a remote request - we should also update our local instance data.
                 spotInstReq.setTags(inst_tags);
@@ -724,12 +703,29 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     /**
-     * Update the tags stored in EC2 with the specified information
+     * Update the tags stored in EC2 with the specified information.
+     * Re-try 5 times if instances isn't up by catchErrorCode - e.g. InvalidSpotInstanceRequestID.NotFound or InvalidInstanceRequestID.NotFound
+     * @param ec2
+     * @param inst_tags
+     * @param catchErrorCode
+     * @param params
+     * @throws InterruptedException
      */
-    private void updateRemoteTags(AmazonEC2 ec2, Collection<Tag> inst_tags, String... params) {
-        CreateTagsRequest tag_request = new CreateTagsRequest();
-        tag_request.withResources(params).setTags(inst_tags);
-        ec2.createTags(tag_request);
+    protected void updateRemoteTags(AmazonEC2 ec2, Collection<Tag> inst_tags, String catchErrorCode, String... params) throws InterruptedException {
+        for (int i = 0; i < 5; i++) {
+            try {
+                CreateTagsRequest tag_request = new CreateTagsRequest();
+                tag_request.withResources(params).setTags(inst_tags);
+                ec2.createTags(tag_request);
+                break;
+            } catch (AmazonServiceException e) {
+                if (e.getErrorCode().equals(catchErrorCode)) {
+                    Thread.sleep(5000);
+                    continue;
+                }
+                LOGGER.log(Level.SEVERE, e.getErrorMessage(), e);
+            }
+        }
     }
 
     /**

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
@@ -1,0 +1,139 @@
+package hudson.plugins.ec2;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.InstanceType;
+import com.amazonaws.services.ec2.model.Tag;
+import hudson.model.Node;
+import junit.framework.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/**
+ * Created by christophbeckmann on 3/17/15.
+ */
+public class SlaveTemplateUnitTest {
+
+    Logger logger;
+    TestHandler handler;
+
+    @Before
+    public void setUp() throws Exception {
+        AmazonEC2Cloud.testMode = true;
+
+        handler = new TestHandler();
+        logger = Logger.getLogger(SlaveTemplate.class.getName());
+        logger.addHandler(handler);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        AmazonEC2Cloud.testMode = false;
+    }
+
+    @Test
+    public void testUpdateRemoteTags() throws Exception {
+        AmazonEC2 ec2 = new AmazonEC2Client() {
+            @Override
+            public void createTags(com.amazonaws.services.ec2.model.CreateTagsRequest createTagsRequest) {
+
+            }
+        };
+
+        String ami = "ami1";
+        String description = "foo ami";
+
+        EC2Tag tag1 = new EC2Tag("name1", "value1");
+        EC2Tag tag2 = new EC2Tag("name2", "value2");
+        List<EC2Tag> tags = new ArrayList<EC2Tag>();
+        tags.add(tag1);
+        tags.add(tag2);
+        String instanceId = "123";
+
+        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, false, null, "", true, false, "", false, "") {
+            @Override
+            protected Object readResolve() {
+                return null;
+            }
+        };
+
+        ArrayList<Tag> awsTags = new ArrayList<Tag>();
+        awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "value1"));
+        awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "value2"));
+
+        orig.updateRemoteTags(ec2, awsTags, "InvalidInstanceRequestID.NotFound", instanceId);
+        Assert.assertEquals(0, handler.getRecords().size());
+    }
+
+    @Test
+    public void testUpdateRemoteTagsInstanceNotFound() throws Exception {
+        AmazonEC2 ec2 = new AmazonEC2Client() {
+            @Override
+            public void createTags(com.amazonaws.services.ec2.model.CreateTagsRequest createTagsRequest) {
+                AmazonServiceException e = new AmazonServiceException("Instance not found - InvalidInstanceRequestID.NotFound");
+                e.setErrorCode("InvalidInstanceRequestID.NotFound");
+                throw e;
+            }
+        };
+
+        String ami = "ami1";
+        String description = "foo ami";
+
+        EC2Tag tag1 = new EC2Tag("name1", "value1");
+        EC2Tag tag2 = new EC2Tag("name2", "value2");
+        List<EC2Tag> tags = new ArrayList<EC2Tag>();
+        tags.add(tag1);
+        tags.add(tag2);
+        String instanceId = "123";
+
+        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, false, null, "", true, false, "", false, "") {
+            @Override
+            protected Object readResolve() {
+                return null;
+            }
+        };
+
+        ArrayList<Tag> awsTags = new ArrayList<Tag>();
+        awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "value1"));
+        awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "value2"));
+
+        orig.updateRemoteTags(ec2, awsTags, "InvalidSpotInstanceRequestID.NotFound", instanceId);
+        Assert.assertEquals(5, handler.getRecords().size());
+
+        Iterator<LogRecord> logs = handler.getRecords().iterator();
+        while (logs.hasNext()) {
+            String log = logs.next().getMessage();
+            Assert.assertTrue(log.contains("Instance not found - InvalidInstanceRequestID.NotFound"));
+        }
+
+    }
+}
+
+class TestHandler extends Handler {
+    private List<LogRecord> records = new LinkedList<LogRecord>();
+
+    @Override
+    public void close() throws SecurityException {
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void publish(LogRecord record) {
+        records.add(record);
+    }
+
+    public List<LogRecord> getRecords() {
+        return records;
+    }
+}
+

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
@@ -6,19 +6,23 @@ import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.InstanceType;
 import com.amazonaws.services.ec2.model.Tag;
 import hudson.model.Node;
-import junit.framework.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
-/**
- * Created by christophbeckmann on 3/17/15.
- */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
 public class SlaveTemplateUnitTest {
 
     Logger logger;
@@ -68,8 +72,9 @@ public class SlaveTemplateUnitTest {
         awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "value1"));
         awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "value2"));
 
-        orig.updateRemoteTags(ec2, awsTags, "InvalidInstanceRequestID.NotFound", instanceId);
-        Assert.assertEquals(0, handler.getRecords().size());
+        final Object params[] = {ec2, awsTags, "InvalidInstanceRequestID.NotFound", instanceId};
+        Whitebox.invokeMethod(orig, "updateRemoteTags", params);
+        assertEquals(0, handler.getRecords().size());
     }
 
     @Test
@@ -104,13 +109,15 @@ public class SlaveTemplateUnitTest {
         awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "value1"));
         awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "value2"));
 
-        orig.updateRemoteTags(ec2, awsTags, "InvalidSpotInstanceRequestID.NotFound", instanceId);
-        Assert.assertEquals(5, handler.getRecords().size());
+        final Object params[] = {ec2, awsTags, "InvalidSpotInstanceRequestID.NotFound", instanceId};
+        Whitebox.invokeMethod(orig, "updateRemoteTags", params);
+
+        assertEquals(5, handler.getRecords().size());
 
         Iterator<LogRecord> logs = handler.getRecords().iterator();
         while (logs.hasNext()) {
             String log = logs.next().getMessage();
-            Assert.assertTrue(log.contains("Instance not found - InvalidInstanceRequestID.NotFound"));
+            assertTrue(log.contains("Instance not found - InvalidInstanceRequestID.NotFound"));
         }
 
     }


### PR DESCRIPTION
* fixing error code for provisionOndemand - InvalidInstanceID.NotFound
* refactoring updateRemoteTags - no code duplication
* no exception throwing if remote tagging fails - only logging
** otherwise we got zombie instances which are not shown
* adding unit testing

https://issues.jenkins-ci.org/browse/JENKINS-26797