### PR TITLE
JENKINS-26414 - Add support for new C4 instance types

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -474,6 +474,7 @@ public abstract class EC2Cloud extends Cloud {
     public synchronized static AmazonEC2 connect(AWSCredentialsProvider credentialsProvider, URL endpoint) {
         awsCredentialsProvider = credentialsProvider;
         ClientConfiguration config = new ClientConfiguration();
+        config.setSignerOverride("QueryStringSignerType");
         ProxyConfiguration proxyConfig = Jenkins.getInstance().proxy;
         Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(endpoint.getHost());
         if (! proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {


### PR DESCRIPTION
* fixing AmazonServiceException: AWS was not able to validate the provided access credentials
** https://github.com/jenkinsci/ec2-plugin/pull/141#issuecomment-83869346