### PR TITLE
Add more logging to ssh launcher

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -260,6 +260,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                         proxyData = new HTTPProxyData(address.getHostName(), address.getPort());
                     }
                     conn.setProxyData(proxyData);
+                    logger.println("Using HTTP Proxy Configuration");
                 }
                 // currently OpenSolaris offers no way of verifying the host certificate, so just accept it blindly,
                 // hoping that no man-in-the-middle attack is going on.
@@ -272,6 +273,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 return conn; // successfully connected
             } catch (IOException e) {
                 // keep retrying until SSH comes up
+                logger.println("Failed to connect via ssh: " + e.getMessage());
                 logger.println("Waiting for SSH to come up. Sleeping 5.");
                 Thread.sleep(5000);
             }


### PR DESCRIPTION
When there is a ssh connection issue currently there is not any `e.getMessage()` which shows more information about the issue.

Also, it might be nice to explicitly say that you are using the Proxy HTTP settings since there is not any documentation at level user which says that it will work in this way. It will also provide some hints to troubleshooting in case there is a ssh issue with EC2.