### PR TITLE
Fix java download/install

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -151,12 +151,12 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 String path = "/hudson-ci/jdk/linux-i586/" + jdk + ".tgz";
 
                 URL url = computer.getCloud().buildPresignedURL(path);
-                if(conn.exec("wget -nv -O " + tmpDir + jdk + ".tgz '" + url + "'", logger) !=0) {
+                if(conn.exec("wget -nv -O " + tmpDir + "/" + jdk + ".tgz '" + url + "'", logger) !=0) {
                     logger.println("Failed to download Java");
                     return;
                 }
 
-                if(conn.exec(buildUpCommand(computer, "tar xz -C /usr -f " + tmpDir + jdk + ".tgz"), logger) !=0) {
+                if(conn.exec(buildUpCommand(computer, "tar xz -C /usr -f " + tmpDir + "/" + jdk + ".tgz"), logger) !=0) {
                     logger.println("Failed to install Java");
                     return;
                 }


### PR DESCRIPTION
The configurable tmpdir (https://github.com/jenkinsci/ec2-plugin/commit/716497f3df642a3e0df097ce05364213179bbb88) broke automatic java download and install because it omitted a slash between /tmp and the jdk name.  The result was permission denied:

```
Creating tmp directory (/tmp) if it does not exist
Verifying that java exists
bash: java: command not found
Installing Java
/tmpjava1.6.0_12.tgz: Permission denied
Failed to download Java
```

By the looks of it, https://github.com/jenkinsci/ec2-plugin/commit/716497f3df642a3e0df097ce05364213179bbb88 may have done the same thing on Windows.