### PR TITLE
Masking BouncyCastle for when the system verison is incompatiable with the required version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,16 @@ THE SOFTWARE.
   </pluginRepositories>
   
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <pluginFirstClassLoader>true</pluginFirstClassLoader>
+          <maskClasses>org.bouncycastle.</maskClasses>
+        </configuration>
+      </plugin>
+    </plugins>
   	<pluginManagement>
   		<plugins>
   			<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->


### PR DESCRIPTION
I am running Jenkins 1.609 on Fedora 21 with ec2-plugin 1.27. Fedora includes BouncyCastle 1.50, which drops the org.bouncycastle.openssl classes required by ec2-plugin 1.27. ec2-plugins includes the older version of BouncyCastle, 1.40, but the system version overrides it. So I set maven to include plugin libraries and classes in the Classpath version during compile. Along with explicitly masking org.bouncycastle.

This fixes the issue I had where it would error on use of the "Test Connection" button in "Configure System". It would try to load "org/bouncycastle/asn1/DERObject" for the "EC2 Key Pair's Private Key".