### PR TITLE
JENKINS-26854: Fixing 'RequestExpired'

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -486,7 +486,7 @@ public abstract class EC2Cloud extends Cloud {
                 config.setProxyPassword(proxyConfig.getPassword());
             }
         }
-        AmazonEC2 client = new AmazonEC2Client(credentialsProvider.getCredentials(), config);
+        AmazonEC2 client = new AmazonEC2Client(credentialsProvider, config);
         client.setEndpoint(endpoint.toString());
         return client;
     }


### PR DESCRIPTION
Creates an AmazonEC2Client with an AWSCredentialsProvider instead of the AWSCredentials directly. This is done so the credentials will refresh instead of expire. Resolves JENKINS-26854.

At the moment, in EC2Cloud we create an AmazonEC2Client by passing in the credentials directly. This creates a StaticCredentialsProvider using the given credentials. StaticCredentialsProvider never refreshes its credentials, leading to expiration. Instead, you can create an AmazonEC2Client with a credentials provider directly. This refreshes the credentials as needed.

See http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-roles.html for more information.