### PR TITLE
Don't hide connection errors

### DIFF
--- a/src/main/java/hudson/plugins/ec2/win/WinConnection.java
+++ b/src/main/java/hudson/plugins/ec2/win/WinConnection.java
@@ -119,6 +119,7 @@ public class WinConnection {
             test.connect();
             return true;
         } catch (Exception e) {
+            log.log(Level.WARNING, "Failed to verify connectivity to Windows slave", e);
             return false;
         }
     }


### PR DESCRIPTION
The configuration for Windows OnDemand slaves in EC2 is very fragile (security groups have to be configured *just right* in both the master and slaves, firewalls need to be set up correctly, etc). 

The ping implementation in WinConncetion basically hides the errors it sees, even though these may be critical to understanding connection problems.