### PR TITLE
Add the ability to programatically update the AMI ID using Groovy

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -64,7 +64,7 @@ import com.amazonaws.services.ec2.model.*;
  * @author Kohsuke Kawaguchi
  */
 public class SlaveTemplate implements Describable<SlaveTemplate> {
-    public final String ami;
+    public String ami;
     public final String description;
     public final String zone;
     public final SpotConfiguration spotConfig;
@@ -263,6 +263,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public Set<LabelAtom> getLabelSet(){
         return labelSet;
+    }
+
+    public String getAmi() {
+        return ami;
+    }
+
+    public void setAmi(String ami) {
+        this.ami = ami;
     }
 
     public int getInstanceCap() {

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -159,6 +159,15 @@ public class SlaveTemplateTest extends HudsonTestCase {
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
+    public void testUpdateAmi(){
+        SlaveTemplate st = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "0", false, "");
+        assertEquals("ami1", st.getAmi());
+        st.setAmi("ami2");
+        assertEquals("ami2", st.getAmi());
+        st.ami = "ami3";
+        assertEquals("ami3", st.getAmi());
+    }
+
     public void test0TimeoutShouldReturnMaxInt(){
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "0", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());


### PR DESCRIPTION
This is a proposed fix for JENKINS-28268

#### Our Use Case
At FreshBooks, we have multiple Packer jobs that build new Jenkins build workers as and when the underlying repos are updated. The problem with this approach (currently) is that after this is done, someone needs to go in and manually update the Jenkins configuration to point to the new AMI ID.

#### Proposed Fix
With this approach, we could trigger a post-build Groovy script to automatically go in and update the relevant AMI ID without us having to do this manually.

#### Groovy Example
Here is an example Groovy script that demonstrates getting and setting the AMI ID programatically:

```
import jenkins.model.*;
import hudson.plugins.ec2.*;

Jenkins.instance.clouds.each {
  if (it.displayName == 'test-cloud') {
    it.getTemplates().each {
      println(it.displayName)
      println("Print current AMI id : " + it.getAmi())
      it.setAmi("ami-4567")
      println("Print current AMI id : " + it.getAmi())
    }
  }
}

Jenkins.instance.save()
```

#### Reference
https://issues.jenkins-ci.org/browse/JENKINS-28268


#### Local Test Results
```
Results :

Tests run: 54, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:19 min
[INFO] Finished at: 2015-07-05T11:57:36-04:00
[INFO] Final Memory: 39M/588M
[INFO] ------------------------------------------------------------------------
```