### PR TITLE
Magic file preventing from init script launch

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-initScript.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-initScript.html
@@ -1,0 +1,5 @@
+<div>
+  Init script specifies commands to be ran after very first slave connection to Jenkins.
+  Once finished, it created <tt>~/.hudson-run-init</tt> file to prevent Jenkins from running
+  it within each reconnection.
+</div>


### PR DESCRIPTION
Hello,

Today I've spent quite a much time on debugging, why my init script does not work for certain EC2 build slaves. After reading the code  I've found magic happening with ` ~/.hudson-run-init`, which I could not find in documentation. And true, I've built that AMIs from instance already containing `.hudson-run-init` file.

I guess that this might be handy when slave reconnecting happens, but on the other hand, I'd rather expect such a provisioning script to be idempotent.

It's not like I'm forcing my solution with removal here, but for sure this magic file presence should be either covered in documentation or handled from UI (`do not run within reconnect` flag under init script text field)...

Please let me know what do you think, I'd be happy to collaborate on handling this!
