### PR TITLE
Fix JENKINS-26800 by retrying more times on throttled requests

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -474,6 +474,8 @@ public abstract class EC2Cloud extends Cloud {
     public synchronized static AmazonEC2 connect(AWSCredentialsProvider credentialsProvider, URL endpoint) {
         awsCredentialsProvider = credentialsProvider;
         ClientConfiguration config = new ClientConfiguration();
+        config.setMaxErrorRetry(16); // Default retry limit (3) is low and often cause problems. Raise it a bit.
+        // See: https://issues.jenkins-ci.org/browse/JENKINS-26800
         config.setSignerOverride("QueryStringSignerType");
         ProxyConfiguration proxyConfig = Jenkins.getInstance().proxy;
         Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(endpoint.getHost());


### PR DESCRIPTION
In our production environment we get throttled by EC2 quite a lot. This can cause number of issues (e.g. slaves are not starting properly).

The default settings (3 retries, first wait 500 ms, second 1000ms) are fairly low for this use case. 

Extending retry to 16 (by default we have exponential wait times, with 20s maximum wait). It's better to slow down than to fail.