### PR TITLE
fix for instance caps which are calculated solely based on AMI ID

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -99,6 +99,8 @@ public abstract class EC2Cloud extends Cloud {
 
     public static final String DEFAULT_EC2_HOST = "us-east-1";
     public static final String EC2_URL_HOST = "ec2.amazonaws.com";
+    public static final String EC2_SLAVE_TYPE_SPOT = "spot";
+    public static final String EC2_SLAVE_TYPE_DEMAND = "demand";
 
     private final boolean useInstanceProfileForCredentials;
     private final String accessId;
@@ -248,10 +250,11 @@ public abstract class EC2Cloud extends Cloud {
                 if (StringUtils.equals(tag.getKey(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE)) {
                 	if (ami == null || templateDesc == null) {
                 		return true;
-                	} else if (StringUtils.equals(tag.getValue(), "demand") || StringUtils.equals(tag.getValue(), "spot")) {
+                	} else if (StringUtils.equals(tag.getValue(), EC2Cloud.EC2_SLAVE_TYPE_DEMAND) || StringUtils.equals(tag.getValue(), EC2Cloud.EC2_SLAVE_TYPE_SPOT)) {
                 		// To handle cases where description is null and also upgrade cases for existing slave nodes.
                 		return true;
-                	} else if (StringUtils.equals(tag.getValue(), "demand_"+templateDesc) || StringUtils.equals(tag.getValue(), "spot_"+templateDesc)) {
+                	} else if (StringUtils.equals(tag.getValue(), getSlaveTypeTagValue(EC2Cloud.EC2_SLAVE_TYPE_DEMAND, templateDesc)) || 
+                			StringUtils.equals(tag.getValue(), getSlaveTypeTagValue(EC2Cloud.EC2_SLAVE_TYPE_SPOT, templateDesc))) {
                 		return true;
                 	} else {
                 		return false;
@@ -448,6 +451,10 @@ public abstract class EC2Cloud extends Cloud {
 
     public static AWSCredentialsProvider createCredentialsProvider(final boolean useInstanceProfileForCredentials, final String accessId, final String secretKey) {
         return createCredentialsProvider(useInstanceProfileForCredentials, accessId.trim(), Secret.fromString(secretKey.trim()));
+    }
+    
+    public static String getSlaveTypeTagValue(String slaveType, String templateDescription) {
+    	return templateDescription != null ? slaveType+"_"+templateDescription : slaveType;
     }
 
     public static AWSCredentialsProvider createCredentialsProvider(final boolean useInstanceProfileForCredentials, final String accessId, final Secret secretKey) {

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -24,7 +24,6 @@
 package hudson.plugins.ec2;
 
 import com.amazonaws.ClientConfiguration;
-
 import hudson.ProxyConfiguration;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
@@ -303,15 +302,12 @@ public abstract class EC2Cloud extends Cloud {
     }
 
     /**
-<<<<<<< HEAD
      * Check for the count of EC2 slaves and determine if a new slave can be added. Takes into account both what Amazon
      * reports as well as an internal count of slaves currently being "provisioned".
-=======
      * Check for the count of EC2 slaves and determine if a new slave can be added.
      * Takes into account both what Amazon reports as well as an internal count
      * of slaves currently being "provisioned".
      * @param templateDesc 
->>>>>>> fix for instance caps which are calculated solely based on AMI as of now.
      */
     private boolean addProvisionedSlave(String ami, int amiCap, String templateDesc) throws AmazonClientException {
         int estimatedTotalSlaves = countCurrentEC2Slaves(null, null);

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -463,7 +463,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                     inst_tags = new HashSet<Tag>();
                 }
                 // Append template description as well to identify slaves provisioned per template
-                inst_tags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, description != null ? "demand_"+description : "demand"));
+                inst_tags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, EC2Cloud.getSlaveTypeTagValue(EC2Cloud.EC2_SLAVE_TYPE_DEMAND, description)));
             }
 
             DescribeInstancesRequest diRequest = new DescribeInstancesRequest();
@@ -725,7 +725,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             }
             if (!hasCustomTypeTag) {
                 if (inst_tags != null)
-            	    inst_tags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, description != null ? "spot_"+description : "spot"));
+            	    inst_tags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, EC2Cloud.getSlaveTypeTagValue(EC2Cloud.EC2_SLAVE_TYPE_SPOT, description)));
             }
 
             if (StringUtils.isNotBlank(getIamInstanceProfile())) {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -462,7 +462,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 if (inst_tags == null) {
                     inst_tags = new HashSet<Tag>();
                 }
-                inst_tags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "demand"));
+                // Append template description as well to identify slaves provisioned per template
+                inst_tags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, description != null ? "demand_"+description : "demand"));
             }
 
             DescribeInstancesRequest diRequest = new DescribeInstancesRequest();
@@ -724,7 +725,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             }
             if (!hasCustomTypeTag) {
                 if (inst_tags != null)
-                    inst_tags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "spot"));
+            	    inst_tags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, description != null ? "spot_"+description : "spot"));
             }
 
             if (StringUtils.isNotBlank(getIamInstanceProfile())) {


### PR DESCRIPTION
Currently instance caps are calculated solely based on AMI, not based on template. So, if there are two types of slaves based on a common AMI 
but intended for different purpose, if the instance cap is low on one type, it may never get provisioned if the other type has many outstanding instances.

Fixed the issue by appending template description as well to tag 'jenkins_slave_type' so that number of instances per template can be identified.

If you want to track using a new tag instead of appending template description to tag 'jenkins_slave_type', please let me know.