### PR TITLE
Depend on the aws-java-sdk plugin to limit aws sdk duplication in classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,18 +80,12 @@ THE SOFTWARE.
       <artifactId>bcprov-jdk15</artifactId>
       <version>140</version>
     </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>1.10.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-codec</groupId>
-          <artifactId>commons-codec</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
+  	<dependency>
+	  <groupId>org.jenkins-ci.plugins</groupId>
+	  <artifactId>aws-java-sdk</artifactId>
+	  <version>1.10.2.1</version>
+	</dependency>
+  	<dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>node-iterator-api</artifactId>
       <version>1.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ THE SOFTWARE.
   	<dependency>
 	  <groupId>org.jenkins-ci.plugins</groupId>
 	  <artifactId>aws-java-sdk</artifactId>
-	  <version>1.10.2.1</version>
+	  <version>1.10.16</version>
 	</dependency>
   	<dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
I've noticed that the aws sdk is getting used in various Jenkins plugins so I created a library plugin to host it and prevent duplicating the classpath. This pull request just unbundles the library from the ec2-plugin.

@reviewbybees 