### PR TITLE
Fix NullPointerException when deleting already terminated slave

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -27,6 +27,7 @@ import hudson.model.Descriptor;
 import hudson.slaves.RetentionStrategy;
 import hudson.util.TimeUnit2;
 
+import java.lang.NullPointerException;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
 
@@ -110,6 +111,9 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
                     // We'll just retry next time we test for idleness.
                     LOGGER.fine("Interrupted while checking host uptime for " + c.getName()
                             + ", will retry next check. Interrupted by: " + e);
+                    return 1;
+                } catch (NullPointerException e) {
+                    LOGGER.fine("NPE while checking host uptime for " + c.getName() + ", will retry next check. " + e);
                     return 1;
                 }
                 final int freeSecondsLeft = (60 * 60)

--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -45,44 +45,52 @@ public final class EC2SpotSlave extends EC2AbstractSlave {
      */
     @Override
     public void terminate() {
-        // Cancel the spot request
-        AmazonEC2 ec2 = getCloud().connect();
+		try {
+			// Cancel the spot request
+			AmazonEC2 ec2 = getCloud().connect();
 
-        String instanceId = getInstanceId();
-        List<String> requestIds = Collections.singletonList(spotInstanceRequestId);
-        CancelSpotInstanceRequestsRequest cancelRequest = new CancelSpotInstanceRequestsRequest(requestIds);
-        try {
-            ec2.cancelSpotInstanceRequests(cancelRequest);
-            LOGGER.info("Canceled Spot request: " + spotInstanceRequestId);
+			String instanceId = getInstanceId();
+			List<String> requestIds = Collections.singletonList(spotInstanceRequestId);
+			CancelSpotInstanceRequestsRequest cancelRequest = new CancelSpotInstanceRequestsRequest(requestIds);
+			try {
+				ec2.cancelSpotInstanceRequests(cancelRequest);
+				LOGGER.info("Canceled Spot request: " + spotInstanceRequestId);
 
-            // Terminate the slave if it is running
-            if (instanceId != null && !instanceId.equals("")) {
-                if (!isAlive(true)) {
-                    /*
-                     * The node has been killed externally, so we've nothing to do here
-                     */
-                    LOGGER.info("EC2 instance already terminated: " + instanceId);
-                } else {
-                    TerminateInstancesRequest request = new TerminateInstancesRequest(Collections.singletonList(instanceId));
-                    ec2.terminateInstances(request);
-                    LOGGER.info("Terminated EC2 instance (terminated): " + instanceId);
-                }
+				// Terminate the slave if it is running
+				if (instanceId != null && !instanceId.equals("")) {
+					if (!isAlive(true)) {
+						/*
+						 * The node has been killed externally, so we've nothing to do here
+						 */
+						LOGGER.info("EC2 instance already terminated: " + instanceId);
+					} else {
+						TerminateInstancesRequest request = new TerminateInstancesRequest(Collections.singletonList(instanceId));
+						ec2.terminateInstances(request);
+						LOGGER.info("Terminated EC2 instance (terminated): " + instanceId);
+					}
 
-            }
+				}
 
-        } catch (AmazonServiceException e) {
-            // Spot request is no longer valid
-            LOGGER.log(Level.WARNING, "Failed to terminated instance and cancel Spot request: " + spotInstanceRequestId, e);
-        } catch (AmazonClientException e) {
-            // Spot request is no longer valid
-            LOGGER.log(Level.WARNING, "Failed to terminated instance and cancel Spot request: " + spotInstanceRequestId, e);
-        }
-
-        try {
-            Hudson.getInstance().removeNode(this);
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to remove slave: " + name, e);
-        }
+			} catch (AmazonServiceException e) {
+				// Spot request is no longer valid
+				LOGGER.log(Level.WARNING, "Failed to terminated instance and cancel Spot request: " + spotInstanceRequestId, e);
+			} catch (AmazonClientException e) {
+				// Spot request is no longer valid
+				LOGGER.log(Level.WARNING, "Failed to terminated instance and cancel Spot request: " + spotInstanceRequestId, e);
+			}
+		} catch (Exception e) {
+			LOGGER.log(Level.WARNING,"Failed to remove slave: ", e);
+		} finally {
+			// Remove the instance even if deletion failed, otherwise it will hang around forever in
+			// the nodes page. One way for this to occur is that an instance was terminated
+			// manually or a spot instance was killed due to pricing. If we don't remove the node,
+			// we screw up auto-scaling, since it will continue to count against the quota.
+			try {
+				Hudson.getInstance().removeNode(this);
+			} catch (IOException e) {
+				LOGGER.log(Level.WARNING, "Failed to remove slave: " + name, e);
+			}
+		}
     }
 
     /**


### PR DESCRIPTION
Fixes an issue where checking for uptime of a deleted node would cause an NPE.

Also fixes an issue when terminating spot instances. The new behavior will remove the node from Jenkins even if EC2 termination failed. One way for this issue to occur is that an instance was terminated manually or a spot instance was killed due to pricing. In these cases termination will fail, but the node will hang around in Jenkins forever. If we don't remove the node, we screw up auto-scaling, since it will continue to count against the quota.
