### PR TITLE
NTLM with SPNEGO

### DIFF
--- a/src/main/java/hudson/plugins/ec2/win/winrm/NegotiateNTLMSchemaFactory.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/NegotiateNTLMSchemaFactory.java
@@ -1,0 +1,44 @@
+package hudson.plugins.ec2.win.winrm;
+
+import org.apache.http.Header;
+import org.apache.http.HttpRequest;
+import org.apache.http.auth.*;
+import org.apache.http.client.params.AuthPolicy;
+import org.apache.http.impl.auth.NTLMScheme;
+import org.apache.http.message.BufferedHeader;
+import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.CharArrayBuffer;
+
+public class NegotiateNTLMSchemaFactory implements AuthSchemeFactory, AuthSchemeProvider {
+
+    public AuthScheme newInstance(HttpParams params) {
+        return new NegotiateNTLM();
+    }
+
+    public AuthScheme create(HttpContext context) {
+        return new NegotiateNTLM();
+    }
+
+    public static class NegotiateNTLM extends NTLMScheme {
+        @Override
+        public String getSchemeName() {
+            return AuthPolicy.SPNEGO;
+        }
+
+        @Override
+        public Header authenticate(Credentials credentials, HttpRequest request) throws AuthenticationException {
+            Credentials ntCredentials = credentials;
+            if (!(credentials instanceof NTCredentials)) {
+                ntCredentials = new NTCredentials(credentials.getUserPrincipal().getName() + ":" + credentials.getPassword());
+            }
+            Header header = super.authenticate(ntCredentials, request);
+            //need replace NTLM with Negotiate
+            CharArrayBuffer buffer = new CharArrayBuffer(512);
+            buffer.append(header.getName());
+            buffer.append(": ");
+            buffer.append(header.getValue().replaceFirst("NTLM", "Negotiate"));
+            return new BufferedHeader(buffer);
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
@@ -176,7 +176,10 @@ public class WinRMClient {
 
     private DefaultHttpClient buildHTTPClient() {
         DefaultHttpClient httpclient = new DefaultHttpClient();
-        // httpclient.getAuthSchemes().unregister(AuthPolicy.SPNEGO);
+        if(! (username.contains("\\")|| username.contains("/"))){
+            //user is not a domain user
+            httpclient.getAuthSchemes().register(AuthPolicy.SPNEGO,new NegotiateNTLMSchemaFactory());
+        }
         httpclient.setCredentialsProvider(credsProvider);
         httpclient.getParams().setParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, 5000);
         // httpclient.setHttpRequestRetryHandler(new WinRMRetryHandler());

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
@@ -172,18 +172,6 @@ public class WinRMClient {
     private void setupHTTPClient() {
         credsProvider = new BasicCredentialsProvider();
         credsProvider.setCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT), new UsernamePasswordCredentials(username, password));
-
-        if (useHTTPS) {
-            SSLSocketFactory socketFactory;
-            try {
-                socketFactory = new SSLSocketFactory(new TrustSelfSignedStrategy(), new AllowAllHostnameVerifier());
-                httpsScheme = new Scheme("https", 443, socketFactory);
-            } catch (KeyManagementException e) {
-            } catch (UnrecoverableKeyException e) {
-            } catch (NoSuchAlgorithmException e) {
-            } catch (KeyStoreException e) {
-            }
-        }
     }
 
     private DefaultHttpClient buildHTTPClient() {
@@ -303,5 +291,18 @@ public class WinRMClient {
 
     public void setUseHTTPS(boolean useHTTPS) {
         this.useHTTPS = useHTTPS;
+        if (useHTTPS) {
+            SSLSocketFactory socketFactory;
+            try {
+                socketFactory = new SSLSocketFactory(new TrustSelfSignedStrategy(), new AllowAllHostnameVerifier());
+                httpsScheme = new Scheme("https", 443, socketFactory);
+            } catch (KeyManagementException e) {
+            } catch (UnrecoverableKeyException e) {
+            } catch (NoSuchAlgorithmException e) {
+            } catch (KeyStoreException e) {
+            }
+        }else{
+            httpsScheme=null;
+        }
     }
 }

--- a/src/test/java/hudson/plugins/ec2/win/WinConnectionTest.java
+++ b/src/test/java/hudson/plugins/ec2/win/WinConnectionTest.java
@@ -1,0 +1,25 @@
+package hudson.plugins.ec2.win;
+
+import hudson.plugins.ec2.win.winrm.WindowsProcess;
+import org.codehaus.plexus.util.IOUtil;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assume.assumeThat;
+
+public class WinConnectionTest {
+
+    @Test
+    public void testExecute() throws Exception {
+        assumeThat(System.getProperty("winrm.host"), is(notNullValue()));
+        WinConnection connect = new WinConnection(System.getProperty("winrm.host"),
+                System.getProperty("winrm.username","Administrator"), System.getProperty("winrm.password"));
+        connect.setUseHTTPS(true);
+        WindowsProcess process = connect.execute("dir c:\\");
+        process.waitFor();
+        String cmdResult = IOUtil.toString(process.getStdout());
+        assertTrue(cmdResult.contains("Users"));
+    }
+}


### PR DESCRIPTION
The Default SPNEGO implementation in Httpclient is Kerbose, we can not use it on  Windows workstation which haven't joined Domain yet. the pull request enables NTLM response with the Integrated Authentication (WWW-Authenticate: Negotiate)