### PR TITLE
Create block device mappings for both ondemand and spot slaves

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -554,7 +554,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
     }
 
-    private void setupEphemeralDeviceMapping(RunInstancesRequest riRequest) {
+    private List<BlockDeviceMapping> getNewEphemeralDeviceMapping() {
 
         final List<BlockDeviceMapping> oldDeviceMapping = getAmiBlockDeviceMappings();
 
@@ -580,7 +580,15 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             available.remove(0);
         }
 
-        riRequest.withBlockDeviceMappings(newDeviceMapping);
+        return newDeviceMapping;
+    }
+
+    private void setupEphemeralDeviceMapping(RunInstancesRequest riRequest) {
+        riRequest.withBlockDeviceMappings(getNewEphemeralDeviceMapping());
+    }
+
+    private void setupEphemeralDeviceMapping(LaunchSpecification launchSpec) {
+        launchSpec.withBlockDeviceMappings(getNewEphemeralDeviceMapping());
     }
 
     private List<BlockDeviceMapping> getAmiBlockDeviceMappings() {
@@ -603,6 +611,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     private void setupCustomDeviceMapping(RunInstancesRequest riRequest) {
         if (StringUtils.isNotBlank(customDeviceMapping)) {
             riRequest.setBlockDeviceMappings(DeviceMappingParser.parse(customDeviceMapping));
+        }
+    }
+
+    private void setupCustomDeviceMapping(LaunchSpecification launchSpec) {
+        if (StringUtils.isNotBlank(customDeviceMapping)) {
+            launchSpec.setBlockDeviceMappings(DeviceMappingParser.parse(customDeviceMapping));
         }
     }
 
@@ -743,6 +757,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             if (StringUtils.isNotBlank(getIamInstanceProfile())) {
                 launchSpecification.setIamInstanceProfile(new IamInstanceProfileSpecification().withArn(getIamInstanceProfile()));
+            }
+
+            if (useEphemeralDevices) {
+                setupEphemeralDeviceMapping(launchSpecification);
+            } else {
+                setupCustomDeviceMapping(launchSpecification);
             }
 
             spotRequest.setLaunchSpecification(launchSpecification);


### PR DESCRIPTION
Sorry if this isn't the right process, and happy to take direction about what to do better. I just noticed that choosing the "useEphemeralDrives" checkbox for my spot instances wasn't having the effect I expected. I was seeing only a single ephemeral volume being automounted.