### PR TITLE
Use new EC2 API endpoint hostnames (JIRA-26493)

### DIFF
--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -96,7 +96,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
 
     public static URL getEc2EndpointUrl(String region) {
         try {
-            return new URL("https://" + region + "." + EC2_URL_HOST + "/");
+            return new URL("https://ec2." + region + "." + AWS_URL_HOST + "/");
         } catch (MalformedURLException e) {
             throw new Error(e); // Impossible
         }

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -98,7 +98,7 @@ import static javax.servlet.http.HttpServletResponse.*;
 public abstract class EC2Cloud extends Cloud {
 
     public static final String DEFAULT_EC2_HOST = "us-east-1";
-    public static final String EC2_URL_HOST = "ec2.amazonaws.com";
+    public static final String AWS_URL_HOST = "amazonaws.com";
     public static final String EC2_SLAVE_TYPE_SPOT = "spot";
     public static final String EC2_SLAVE_TYPE_DEMAND = "demand";
 
@@ -526,7 +526,7 @@ public abstract class EC2Cloud extends Cloud {
         if (ec2HostName == null || ec2HostName.length() == 0)
             ec2HostName = DEFAULT_EC2_HOST;
         if (!ec2HostName.contains("."))
-            ec2HostName = ec2HostName + "." + EC2_URL_HOST;
+            ec2HostName = "ec2." + ec2HostName + "." + AWS_URL_HOST;
         return ec2HostName;
     }
 

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-ec2EndpointUrl.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-ec2EndpointUrl.html
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 <div>
     This field is optional. It controls what EC2 API endpoint to connect to. 
-    By default https://us-east-1.ec2.amazonaws.com/ is used. To use other 
+    By default https://ec2.us-east-1.amazonaws.com/ is used. To use other 
     Amazon AWS zones, change this appropriately.
     
     When using Ubuntu Enterprise Cloud (Eucalyptus) a url like


### PR DESCRIPTION
Every region seems to support the format ec2.<region>.amazonaws.com:
http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region

Disclaimer: I did not compile or test this change.