### PR TITLE
Use AWS4SignerType instead of QueryStringSignerType

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ THE SOFTWARE.
   	<dependency>
 	  <groupId>org.jenkins-ci.plugins</groupId>
 	  <artifactId>aws-java-sdk</artifactId>
-	  <version>1.10.16</version>
+	  <version>1.10.26</version>
 	</dependency>
   	<dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -502,7 +502,7 @@ public abstract class EC2Cloud extends Cloud {
         config.setMaxErrorRetry(16); // Default retry limit (3) is low and often
                                      // cause problems. Raise it a bit.
         // See: https://issues.jenkins-ci.org/browse/JENKINS-26800
-        config.setSignerOverride("QueryStringSignerType");
+        config.setSignerOverride("AWS4SignerType");
         ProxyConfiguration proxyConfig = Jenkins.getInstance().proxy;
         Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(endpoint.getHost());
         if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {


### PR DESCRIPTION
This solved the authorization problem with the eu-central-1 region.
Have also bumped the AWS SDK version.