### PR TITLE
Upgrade jenkins-core dependency to 1.580

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-      <version>1.447</version>
+      <version>1.580</version>
   </parent>
 
   <artifactId>ec2</artifactId>
@@ -52,7 +52,7 @@ THE SOFTWARE.
   </scm>
 
   <properties>
-      <powermock.version>1.6.2</powermock.version>
+      <powermock.version>1.6.3</powermock.version>
   </properties>
 
   <dependencies>
@@ -67,12 +67,36 @@ THE SOFTWARE.
       <artifactId>powermock-api-mockito</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-all</artifactId>
+				</exclusion>
+			</exclusions>
     </dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>hamcrest-core</artifactId>
+					<groupId>org.hamcrest</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.11</version>
       <scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>hamcrest-core</artifactId>
+					<groupId>org.hamcrest</groupId>
+				</exclusion>
+			</exclusions>
     </dependency>
     <dependency>
       <!-- we only use this to handle key fingerprint. should be able to replace this with trilead -->
@@ -88,7 +112,7 @@ THE SOFTWARE.
   	<dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>node-iterator-api</artifactId>
-      <version>1.1</version>
+      <version>1.5</version>
 		</dependency>
     <dependency>
 	    <groupId>jcifs</groupId>

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.ec2;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import hudson.util.Secret;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringUtils;
@@ -119,7 +121,6 @@ public abstract class EC2AbstractSlave extends Slave {
 
     public static final String TEST_ZONE = "testZone";
 
-    @DataBoundConstructor
     public EC2AbstractSlave(String name, String instanceId, String description, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy<EC2Computer> retentionStrategy, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
 
@@ -499,8 +500,9 @@ public abstract class EC2AbstractSlave extends Slave {
         return usePrivateDnsName;
     }
 
-    public String getAdminPassword() {
-        return amiType.isWindows() ? ((WindowsData) amiType).getPassword() : "";
+    @CheckForNull
+    public Secret getAdminPassword() {
+        return amiType.isWindows() ? ((WindowsData) amiType).getPassword() : null;
     }
 
     public boolean isUseHTTPS() {

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -164,8 +164,8 @@ public abstract class EC2Cloud extends Cloud {
         return accessId;
     }
 
-    public String getSecretKey() {
-        return secretKey.getEncryptedValue();
+    public Secret getSecretKey() {
+        return secretKey;
     }
 
     public EC2PrivateKey getPrivateKey() {

--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -23,7 +23,9 @@
  */
 package hudson.plugins.ec2;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Util;
+import hudson.model.Node;
 import hudson.slaves.SlaveComputer;
 import java.io.IOException;
 import java.util.Collections;
@@ -172,9 +174,12 @@ public class EC2Computer extends SlaveComputer {
     /**
      * What username to use to run root-like commands
      *
+     * @return remote admin or {@code null} if the associated {@link Node} is {@code null}
      */
+    @CheckForNull
     public String getRemoteAdmin() {
-        return getNode().getRemoteAdmin();
+        EC2AbstractSlave node = getNode();
+        return node == null ? null : node.getRemoteAdmin();
     }
 
     public int getSshPort() {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -27,6 +27,8 @@ import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.util.Secret;
 import jenkins.slaves.iterators.api.NodeIterator;
 
 import org.apache.commons.codec.binary.Base64;
@@ -981,8 +983,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return amiType.isUnix();
     }
 
-    public String getAdminPassword() {
-        return amiType.isWindows() ? ((WindowsData) amiType).getPassword() : "";
+    @CheckForNull
+    public Secret getAdminPassword() {
+        return amiType.isWindows() ? ((WindowsData) amiType).getPassword() : null;
     }
 
     public boolean isUseHTTPS() {

--- a/src/main/java/hudson/plugins/ec2/WindowsData.java
+++ b/src/main/java/hudson/plugins/ec2/WindowsData.java
@@ -5,17 +5,18 @@ import java.util.concurrent.TimeUnit;
 import hudson.Extension;
 import hudson.model.Descriptor;
 
+import hudson.util.Secret;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class WindowsData extends AMITypeData {
 
-    private final String password;
+    private final Secret password;
     private final boolean useHTTPS;
     private final String bootDelay;
 
     @DataBoundConstructor
     public WindowsData(String password, boolean useHTTPS, String bootDelay) {
-        this.password = password;
+        this.password = Secret.fromString(password);
         this.useHTTPS = useHTTPS;
         this.bootDelay = bootDelay;
     }
@@ -28,7 +29,7 @@ public class WindowsData extends AMITypeData {
         return false;
     }
 
-    public String getPassword() {
+    public Secret getPassword() {
         return password;
     }
 

--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.concurrent.TimeUnit;
 
+import hudson.util.Secret;
 import org.apache.commons.io.IOUtils;
 
 import com.amazonaws.AmazonClientException;
@@ -124,7 +125,8 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
 
                 logger.println("Connecting to " + host + "(" + ip + ") with WinRM as " + computer.getNode().remoteAdmin);
 
-                WinConnection connection = new WinConnection(ip, computer.getNode().remoteAdmin, computer.getNode().getAdminPassword());
+                Secret password = computer.getNode().getAdminPassword();
+                WinConnection connection = new WinConnection(ip, computer.getNode().remoteAdmin, Secret.toString(password) );
                 connection.setUseHTTPS(computer.getNode().isUseHTTPS());
                 if (!connection.ping()) {
                     logger.println("Waiting for WinRM to come up. Sleeping 10s.");

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
@@ -23,32 +23,39 @@
  */
 package hudson.plugins.ec2;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import hudson.slaves.Cloud;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Collections;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class AmazonEC2CloudTest extends HudsonTestCase {
+public class AmazonEC2CloudTest {
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Before
+    public void setUp() throws Exception {
         AmazonEC2Cloud.testMode = true;
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+    @After
+    public void tearDown() throws Exception {
         AmazonEC2Cloud.testMode = false;
     }
 
+    @After
     public void testConfigRoundtrip() throws Exception {
         AmazonEC2Cloud orig = new AmazonEC2Cloud("us-east-1", true, "abc", "def", "us-east-1", "ghi", "3", Collections.<SlaveTemplate> emptyList());
-        hudson.clouds.add(orig);
-        submit(createWebClient().goTo("configure").getFormByName("config"));
+        r.jenkins.clouds.add(orig);
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
 
-        assertEqualBeans(orig, hudson.clouds.iterator().next(), "cloudName,region,useInstanceProfileForCredentials,accessId,secretKey,privateKey,instanceCap");
+        Cloud actual = r.jenkins.clouds.iterator().next();
+        r.assertEqualBeans(orig, actual, "cloudName,region,useInstanceProfileForCredentials,accessId,privateKey,instanceCap");
     }
 }

--- a/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
@@ -1,14 +1,22 @@
 package hudson.plugins.ec2;
 
 import hudson.slaves.NodeProperty;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.ArrayList;
 
-public class EC2AbstractSlaveTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+
+public class EC2AbstractSlaveTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     int timeoutInSecs = Integer.MAX_VALUE;
 
+    @Test
     public void testGetLaunchTimeoutInMillisShouldNotOverflow() throws Exception {
         EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "root", "jvm", false, "idle", null, "cloud", false, false, Integer.MAX_VALUE, new UnixData("remote", "22")) {
             @Override

--- a/src/test/java/hudson/plugins/ec2/EC2InstanceTypesTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2InstanceTypesTest.java
@@ -23,11 +23,12 @@
  */
 package hudson.plugins.ec2;
 
-import org.jvnet.hudson.test.HudsonTestCase;
-
 import com.amazonaws.services.ec2.model.InstanceType;
+import org.junit.Test;
 
-public class EC2InstanceTypesTest extends HudsonTestCase {
+public class EC2InstanceTypesTest {
+
+    @Test
     public void testListTypes() throws Exception {
         System.out.println("EC2 Instance Types available:");
         for (InstanceType t : InstanceType.values()) {

--- a/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
@@ -1,10 +1,18 @@
 package hudson.plugins.ec2;
 
 import hudson.model.Node;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
-public class EC2OndemandSlaveTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
 
+public class EC2OndemandSlaveTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
     public void testSpecifyMode() throws Exception {
         EC2OndemandSlave slaveNormal = new EC2OndemandSlave("instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.NORMAL, "initScript", "tmpDir", "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", null, "cloudName", false, false, 0, new UnixData("a", "b"));
         assertEquals(Node.Mode.NORMAL, slaveNormal.getMode());

--- a/src/test/java/hudson/plugins/ec2/EC2PrivateKeyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2PrivateKeyTest.java
@@ -23,14 +23,18 @@
  */
 package hudson.plugins.ec2;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Test;
 
 import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class EC2PrivateKeyTest extends HudsonTestCase {
+public class EC2PrivateKeyTest {
+
+    @Test
     public void testFingerprint() throws IOException {
         EC2PrivateKey k = new EC2PrivateKey("-----BEGIN RSA PRIVATE KEY-----\n"
                 + "MIIEowIBAAKCAQEAlpK/pGxCRoHpbIObxYW53fl4qA+EQNHuSveNyxt+6m/HAdRLhEMGHe7/b7dR\n"
@@ -58,6 +62,7 @@ public class EC2PrivateKeyTest extends HudsonTestCase {
         assertEquals("3c:ee:c2:12:57:5f:d0:73:79:38:d6:aa:ef:91:0a:b8:2c:5f:47:65", k.getFingerprint());
     }
 
+    @Test
     public void testPublicFingerprint() throws IOException {
         EC2PrivateKey k = new EC2PrivateKey("-----BEGIN RSA PRIVATE KEY-----\n"
                 + "MIIEowIBAAKCAQEAlpK/pGxCRoHpbIObxYW53fl4qA+EQNHuSveNyxt+6m/HAdRLhEMGHe7/b7dR\n"

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -2,16 +2,25 @@ package hudson.plugins.ec2;
 
 import com.amazonaws.AmazonClientException;
 import hudson.slaves.NodeProperty;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class EC2RetentionStrategyTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EC2RetentionStrategyTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     final AtomicBoolean idleTimeoutCalled = new AtomicBoolean(false);
 
+    @Test
     public void testOnBillingHourRetention() throws Exception {
         EC2RetentionStrategy rs = new EC2RetentionStrategy("-2");
         List<int[]> upTime = new ArrayList<int[]>();

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -26,30 +26,38 @@ package hudson.plugins.ec2;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import com.amazonaws.services.ec2.model.InstanceType;
 import com.amazonaws.services.ec2.model.SpotInstanceType;
 
 import hudson.model.Node;
+import org.jvnet.hudson.test.JenkinsRule;
 
 /**
  * Basic test to validate SlaveTemplate.
  */
-public class SlaveTemplateTest extends HudsonTestCase {
+public class SlaveTemplateTest {
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Before
+    public void setUp() throws Exception {
         AmazonEC2Cloud.testMode = true;
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+    @After
+    public void tearDown() throws Exception {
         AmazonEC2Cloud.testMode = false;
     }
 
+    @Test
     public void testConfigRoundtrip() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
@@ -66,13 +74,14 @@ public class SlaveTemplateTest extends HudsonTestCase {
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
-        hudson.clouds.add(ac);
+        r.jenkins.clouds.add(ac);
 
-        submit(createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) hudson.clouds.iterator().next()).getTemplate(description);
-        assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,usePrivateDnsName,useEphemeralDevices,useDedicatedTenancy");
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,usePrivateDnsName,useEphemeralDevices,useDedicatedTenancy");
     }
 
+    @Test
     public void testConfigRoundtripWithPrivateDns() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
@@ -89,11 +98,11 @@ public class SlaveTemplateTest extends HudsonTestCase {
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
-        hudson.clouds.add(ac);
+        r.jenkins.clouds.add(ac);
 
-        submit(createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) hudson.clouds.iterator().next()).getTemplate(description);
-        assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
     }
 
     /**
@@ -103,6 +112,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
      * @throws Exception
      *             - Exception that can be thrown by the Jenkins test harness
      */
+    @Test
     public void testConfigWithSpotBidPrice() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
@@ -120,11 +130,11 @@ public class SlaveTemplateTest extends HudsonTestCase {
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
-        hudson.clouds.add(ac);
+        r.jenkins.clouds.add(ac);
 
-        submit(createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) hudson.clouds.iterator().next()).getTemplate(description);
-        assertEqualBeans(orig, received, "ami,zone,spotConfig,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(orig, received, "ami,zone,spotConfig,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
     }
 
     /**
@@ -132,6 +142,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testConfigRoundtripIamRole() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
@@ -148,18 +159,20 @@ public class SlaveTemplateTest extends HudsonTestCase {
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
-        hudson.clouds.add(ac);
+        r.jenkins.clouds.add(ac);
 
-        submit(createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) hudson.clouds.iterator().next()).getTemplate(description);
-        assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,usePrivateDnsName,iamInstanceProfile");
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,usePrivateDnsName,iamInstanceProfile");
     }
 
+    @Test
     public void testNullTimeoutShouldReturnMaxInt() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
+    @Test
     public void testUpdateAmi() {
         SlaveTemplate st = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "0", false, "");
         assertEquals("ami1", st.getAmi());
@@ -169,36 +182,43 @@ public class SlaveTemplateTest extends HudsonTestCase {
         assertEquals("ami3", st.getAmi());
     }
 
+    @Test
     public void test0TimeoutShouldReturnMaxInt() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "0", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
+    @Test
     public void testNegativeTimeoutShouldReturnMaxInt() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "-1", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
+    @Test
     public void testNonNumericTimeoutShouldReturnMaxInt() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "NotANumber", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
+    @Test
     public void testAssociatePublicIpSetting() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true, "");
         assertEquals(true, st.getAssociatePublicIp());
     }
 
+    @Test
     public void testConnectUsingPublicIpSetting() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true, "", false, true);
         assertTrue(st.isConnectUsingPublicIp());
     }
 
+    @Test
     public void testConnectUsingPublicIpSettingWithDefaultSetting() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true, "");
         assertFalse(st.isConnectUsingPublicIp());
     }
 
+    @Test
     public void testBackwardCompatibleUnixData() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "rrr", "sudo", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, "NotANumber");
         assertFalse(st.isWindowsSlave());
@@ -206,6 +226,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         assertEquals("sudo", st.getRootCommandPrefix());
     }
 
+    @Test
     public void testWindowsConfigRoundTrip() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
@@ -222,13 +243,14 @@ public class SlaveTemplateTest extends HudsonTestCase {
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
-        hudson.clouds.add(ac);
+        r.jenkins.clouds.add(ac);
 
-        submit(createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) hudson.clouds.iterator().next()).getTemplate(description);
-        assertEqualBeans(orig, received, "amiType");
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(orig, received, "amiType");
     }
 
+    @Test
     public void testUnixConfigRoundTrip() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
@@ -245,10 +267,10 @@ public class SlaveTemplateTest extends HudsonTestCase {
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
-        hudson.clouds.add(ac);
+        r.jenkins.clouds.add(ac);
 
-        submit(createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) hudson.clouds.iterator().next()).getTemplate(description);
-        assertEqualBeans(orig, received, "amiType");
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(orig, received, "amiType");
     }
 }

--- a/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
+++ b/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
@@ -27,12 +27,19 @@ import com.amazonaws.services.ec2.model.InstanceType;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class TemplateLabelsTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+
+public class TemplateLabelsTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     private AmazonEC2Cloud ac;
     private final String LABEL1 = "label1";
@@ -56,6 +63,7 @@ public class TemplateLabelsTest extends HudsonTestCase {
         ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
     }
 
+    @Test
     public void testLabelAtom() throws Exception {
         setUpCloud(LABEL1 + " " + LABEL2);
 
@@ -65,6 +73,7 @@ public class TemplateLabelsTest extends HudsonTestCase {
         assertEquals(true, ac.canProvision(null));
     }
 
+    @Test
     public void testLabelExpression() throws Exception {
         setUpCloud(LABEL1 + " " + LABEL2);
 
@@ -76,12 +85,14 @@ public class TemplateLabelsTest extends HudsonTestCase {
         assertEquals(false, ac.canProvision(Label.parseExpression("aaa || bbb")));
     }
 
+    @Test
     public void testEmptyLabel() throws Exception {
         setUpCloud("");
 
         assertEquals(true, ac.canProvision(null));
     }
 
+    @Test
     public void testExclusiveMode() throws Exception {
         setUpCloud(LABEL1 + " " + LABEL2, Node.Mode.EXCLUSIVE);
 
@@ -91,6 +102,7 @@ public class TemplateLabelsTest extends HudsonTestCase {
         assertEquals(false, ac.canProvision(null));
     }
 
+    @Test
     public void testExclusiveModeEmptyLabel() throws Exception {
         setUpCloud("", Node.Mode.EXCLUSIVE);
 

--- a/src/test/java/hudson/plugins/ec2/util/DeviceMappingParserTest.java
+++ b/src/test/java/hudson/plugins/ec2/util/DeviceMappingParserTest.java
@@ -25,12 +25,13 @@ package hudson.plugins.ec2.util;
 
 import com.amazonaws.services.ec2.model.BlockDeviceMapping;
 import com.amazonaws.services.ec2.model.EbsBlockDevice;
-import org.jvnet.hudson.test.HudsonTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class DeviceMappingParserTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+
+public class DeviceMappingParserTest {
 
     public void testParserWithAmi() throws Exception {
         List<BlockDeviceMapping> expected = new ArrayList<BlockDeviceMapping>();


### PR DESCRIPTION
Can we bump jenkins-core dependency to 1.580 so that I can propose a Pull Request to use the aws-credentials plugin to manage the access keys in Jenkins credentials store?