### PR TITLE
bugfix: add minimum timeout for windows launching

### DIFF
--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -82,7 +82,11 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
 
     private WinConnection connectToWinRM(EC2Computer computer, PrintStream logger) throws AmazonClientException,
             InterruptedException {
-        final long timeout = computer.getNode().getLaunchTimeoutInMillis();
+        final long MIN_TIMEOUT = 3000;
+        long timeout = computer.getNode().getLaunchTimeoutInMillis(); // timeout is less than 0 when jenkins is booting up.
+        if (timeout < MIN_TIMEOUT) {
+            timeout = MIN_TIMEOUT;
+        }
         final long startTime = System.currentTimeMillis();
 
         logger.println(computer.getNode().getDisplayName() + " booted at " + computer.getNode().getCreatedTime());


### PR DESCRIPTION
Every time after Jenkins reboot the status of the Windows slave server's status is incorrect saying "Timed out after 0 seconds of waiting for winrm" and jobs are pending in the queue and cannot be executed.