### PR TITLE
Staging/collection.is empty() should be used to test for emptiness

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -272,10 +272,11 @@ public abstract class EC2AbstractSlave extends Slave {
             request.setInstanceIds(Collections.<String> singletonList(instanceId));
             AmazonEC2 ec2 = cloud.connect();
             List<Reservation> reservations = ec2.describeInstances(request).getReservations();
-            if (reservations.size() > 0) {
+            if (!reservations.isEmpty()) {
                 List<Instance> instances = reservations.get(0).getInstances();
-                if (instances.size() > 0)
+                if (!instances.isEmpty()) {
                     i = instances.get(0);
+                }
             }
         } catch (AmazonClientException e) {
             LOGGER.log(Level.WARNING, "Failed to fetch EC2 instance: " + instanceId, e);

--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -118,8 +118,9 @@ public final class EC2SpotSlave extends EC2AbstractSlave {
             LOGGER.log(Level.WARNING, "Failed to fetch spot instance request for requestId: " + spotRequestId);
         }
 
-        if (dsirResult == null || siRequests.size() <= 0)
+        if (dsirResult == null || siRequests.isEmpty()) {
             return null;
+        }
         return siRequests.get(0);
     }
 

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -483,8 +483,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             } else {
                 /* No subnet: we can use standard security groups by name */
                 riRequest.setSecurityGroups(securityGroupSet);
-                if (securityGroupSet.size() > 0)
+                if (!securityGroupSet.isEmpty()) {
                     diFilters.add(new Filter("instance.group-name").withValues(securityGroupSet));
+                }
             }
 
             String userDataString = Base64.encodeBase64String(userData.getBytes());
@@ -714,8 +715,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 }
             } else {
                 /* No subnet: we can use standard security groups by name */
-                if (securityGroupSet.size() > 0)
+                if (!securityGroupSet.isEmpty()) {
                     launchSpecification.setSecurityGroups(securityGroupSet);
+                }
             }
 
             // The slave must know the Jenkins server to register with as well
@@ -793,7 +795,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             RequestSpotInstancesResult reqResult = ec2.requestSpotInstances(spotRequest);
 
             List<SpotInstanceRequest> reqInstances = reqResult.getSpotInstanceRequests();
-            if (reqInstances.size() <= 0) {
+            if (reqInstances.isEmpty()) {
                 throw new AmazonClientException("No spot instances found");
             }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155
Please let me know if you have any questions.
M-Ezzat