### PR TITLE
squid:S2162 - equals methods should be symmetric and work for subclasses

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2PrivateKey.java
+++ b/src/main/java/hudson/plugins/ec2/EC2PrivateKey.java
@@ -164,7 +164,7 @@ public class EC2PrivateKey {
 
     @Override
     public boolean equals(Object that) {
-        return that instanceof EC2PrivateKey && this.privateKey.equals(((EC2PrivateKey) that).privateKey);
+        return this.getClass() == that.getClass() && this.privateKey.equals(((EC2PrivateKey) that).privateKey);
     }
 
     @Override

--- a/src/main/java/hudson/plugins/ec2/EC2Tag.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Tag.java
@@ -71,7 +71,7 @@ public class EC2Tag extends AbstractDescribableImpl<EC2Tag> {
     public boolean equals(Object o) {
         if (o == null)
             return false;
-        if (!(o instanceof EC2Tag))
+        if (this.getClass() != o.getClass())
             return false;
 
         EC2Tag other = (EC2Tag) o;

--- a/src/main/java/hudson/plugins/ec2/UnixData.java
+++ b/src/main/java/hudson/plugins/ec2/UnixData.java
@@ -54,7 +54,7 @@ public class UnixData extends AMITypeData {
             return true;
         if (obj == null)
             return false;
-        if (!(obj instanceof UnixData))
+        if (this.getClass() != obj.getClass())
             return false;
         UnixData other = (UnixData) obj;
         if (rootCommandPrefix == null) {

--- a/src/main/java/hudson/plugins/ec2/WindowsData.java
+++ b/src/main/java/hudson/plugins/ec2/WindowsData.java
@@ -71,7 +71,7 @@ public class WindowsData extends AMITypeData {
             return true;
         if (obj == null)
             return false;
-        if (!(obj instanceof WindowsData))
+        if (this.getClass() != obj.getClass())
             return false;
         WindowsData other = (WindowsData) obj;
         if (bootDelay == null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2162 - equals methods should be symmetric and work for subclasses
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162
Please let me know if you have any questions.
M-Ezzat