### PR TITLE
squid:S2259 - Null pointers should not be dereferenced

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Tag.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Tag.java
@@ -75,9 +75,9 @@ public class EC2Tag extends AbstractDescribableImpl<EC2Tag> {
             return false;
 
         EC2Tag other = (EC2Tag) o;
-        if ((name == null && other.name != null) || !name.equals(other.name))
+        if ((name == null && other.name != null) || (name != null && !name.equals(other.name)))
             return false;
-        if ((value == null && other.value != null) || !value.equals(other.value))
+        if ((value == null && other.value != null) || (value != null && !value.equals(other.value)))
             return false;
 
         return true;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - Null pointers should not be dereferenced

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2259

Please let me know if you have any questions.

M-Ezzat