### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -73,6 +73,8 @@ import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
  */
 @SuppressWarnings("serial")
 public abstract class EC2AbstractSlave extends Slave {
+    private static final Logger LOGGER = Logger.getLogger(EC2AbstractSlave.class.getName());
+
     protected String instanceId;
 
     /**
@@ -558,7 +560,5 @@ public abstract class EC2AbstractSlave extends Slave {
             return Hudson.getInstance().<AMITypeData, Descriptor<AMITypeData>> getDescriptorList(AMITypeData.class);
         }
     }
-
-    private static final Logger LOGGER = Logger.getLogger(EC2AbstractSlave.class.getName());
 
 }

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -111,6 +111,8 @@ public abstract class EC2Cloud extends Cloud {
 
     public static final String EC2_SLAVE_TYPE_DEMAND = "demand";
 
+    private static final SimpleFormatter sf = new SimpleFormatter();
+
     private final boolean useInstanceProfileForCredentials;
 
     private final String accessId;
@@ -675,8 +677,6 @@ public abstract class EC2Cloud extends Cloud {
             }
         }
     }
-
-    private static final SimpleFormatter sf = new SimpleFormatter();
 
     public static void log(Logger logger, Level level, TaskListener listener, String message) {
         log(logger, level, listener, message, null);

--- a/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
@@ -47,6 +47,8 @@ import com.amazonaws.services.ec2.model.StartInstancesResult;
  * @author Kohsuke Kawaguchi
  */
 public abstract class EC2ComputerLauncher extends ComputerLauncher {
+    private static final Logger LOGGER = Logger.getLogger(EC2ComputerLauncher.class.getName());
+
     @Override
     public void launch(SlaveComputer _computer, TaskListener listener) {
         try {
@@ -114,5 +116,4 @@ public abstract class EC2ComputerLauncher extends ComputerLauncher {
     protected abstract void launch(EC2Computer computer, TaskListener listener, Instance inst)
             throws AmazonClientException, IOException, InterruptedException;
 
-    private static final Logger LOGGER = Logger.getLogger(EC2ComputerLauncher.class.getName());
 }

--- a/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
@@ -29,6 +29,7 @@ import com.amazonaws.services.ec2.model.*;
  * @author Kohsuke Kawaguchi
  */
 public final class EC2OndemandSlave extends EC2AbstractSlave {
+    private static final Logger LOGGER = Logger.getLogger(EC2OndemandSlave.class.getName());
 
     public EC2OndemandSlave(String instanceId, String description, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
@@ -111,8 +112,6 @@ public final class EC2OndemandSlave extends EC2AbstractSlave {
             return Messages.EC2OndemandSlave_AmazonEC2();
         }
     }
-
-    private static final Logger LOGGER = Logger.getLogger(EC2OndemandSlave.class.getName());
 
     @Override
     public String getEc2Type() {

--- a/src/main/java/hudson/plugins/ec2/EC2PrivateKey.java
+++ b/src/main/java/hudson/plugins/ec2/EC2PrivateKey.java
@@ -55,6 +55,8 @@ import com.amazonaws.services.ec2.model.KeyPairInfo;
  * @author Kohsuke Kawaguchi
  */
 public class EC2PrivateKey {
+    private static final RuntimeException PRIVATE_KEY_WITH_PASSWORD = new RuntimeException();
+
     private final Secret privateKey;
 
     EC2PrivateKey(String privateKey) {
@@ -200,5 +202,4 @@ public class EC2PrivateKey {
         }
     }
 
-    private static final RuntimeException PRIVATE_KEY_WITH_PASSWORD = new RuntimeException();
 }

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -39,6 +39,10 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @author Kohsuke Kawaguchi
  */
 public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
+    private static final Logger LOGGER = Logger.getLogger(EC2RetentionStrategy.class.getName());
+
+    public static boolean disabled = Boolean.getBoolean(EC2RetentionStrategy.class.getName() + ".disabled");
+
     /**
      * Number of minutes of idleness before an instance should be terminated. A value of zero indicates that the
      * instance should never be automatically terminated. Negative values are times in remaining minutes before end of
@@ -154,7 +158,4 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
         return this;
     }
 
-    private static final Logger LOGGER = Logger.getLogger(EC2RetentionStrategy.class.getName());
-
-    public static boolean disabled = Boolean.getBoolean(EC2RetentionStrategy.class.getName() + ".disabled");
 }

--- a/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java
@@ -19,6 +19,7 @@ import com.amazonaws.AmazonClientException;
  */
 @Extension
 public class EC2SlaveMonitor extends AsyncPeriodicWork {
+    private static final Logger LOGGER = Logger.getLogger(EC2SlaveMonitor.class.getName());
 
     private Long recurrencePeriod;
 
@@ -58,7 +59,5 @@ public class EC2SlaveMonitor extends AsyncPeriodicWork {
             LOGGER.log(Level.WARNING, "Failed to remove node: " + ec2Slave.getInstanceId());
         }
     }
-
-    private static final Logger LOGGER = Logger.getLogger(EC2SlaveMonitor.class.getName());
 
 }

--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -23,6 +23,7 @@ import hudson.model.Descriptor.FormException;
 import hudson.slaves.NodeProperty;
 
 public final class EC2SpotSlave extends EC2AbstractSlave {
+    private static final Logger LOGGER = Logger.getLogger(EC2SpotSlave.class.getName());
 
     private final String spotInstanceRequestId;
 
@@ -156,8 +157,6 @@ public final class EC2SpotSlave extends EC2AbstractSlave {
             return Messages.EC2SpotSlave_AmazonEC2SpotInstance();
         }
     }
-
-    private static final Logger LOGGER = Logger.getLogger(EC2SpotSlave.class.getName());
 
     @Override
     public String getEc2Type() {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -55,6 +55,7 @@ import hudson.util.ListBoxModel;
  * @author Kohsuke Kawaguchi
  */
 public class SlaveTemplate implements Describable<SlaveTemplate> {
+    private static final Logger LOGGER = Logger.getLogger(SlaveTemplate.class.getName());
 
     public String ami;
 
@@ -1244,5 +1245,4 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
     }
 
-    private static final Logger LOGGER = Logger.getLogger(SlaveTemplate.class.getName());
 }

--- a/src/main/java/hudson/plugins/ec2/ebs/ZPoolMonitor.java
+++ b/src/main/java/hudson/plugins/ec2/ebs/ZPoolMonitor.java
@@ -42,6 +42,8 @@ import java.io.IOException;
  */
 @Extension
 public class ZPoolMonitor extends PeriodicWork {
+    private static Boolean isInsideEC2;
+
     @Override
     public long getRecurrencePeriod() {
         return TimeUnit2.HOURS.toMillis(1);
@@ -70,8 +72,6 @@ public class ZPoolMonitor extends PeriodicWork {
         ZPoolExpandNotice zen = AdministrativeMonitor.all().get(ZPoolExpandNotice.class);
         zen.activated = t / a > 10 && a < 1000L * 1000 * 1000;
     }
-
-    private static Boolean isInsideEC2;
 
     /**
      * Returns true if this JVM runs inside EC2.

--- a/src/main/java/hudson/plugins/ec2/ssh/HostKeyVerifierImpl.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/HostKeyVerifierImpl.java
@@ -29,6 +29,8 @@ import com.trilead.ssh2.ServerHostKeyVerifier;
 import com.trilead.ssh2.crypto.digest.MD5;
 
 public class HostKeyVerifierImpl implements ServerHostKeyVerifier {
+    private static final Logger LOGGER = Logger.getLogger(HostKeyVerifierImpl.class.getName());
+
     private final String console;
 
     public HostKeyVerifierImpl(String console) {
@@ -65,5 +67,4 @@ public class HostKeyVerifierImpl implements ServerHostKeyVerifier {
         return matches;
     }
 
-    private static final Logger LOGGER = Logger.getLogger(HostKeyVerifierImpl.class.getName());
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat