### PR TITLE
JENKINS-26371 - Ensure instance initiated shutdown behaviour is consistent with stopOnTerminate flag

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -448,6 +448,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 setupCustomDeviceMapping(riRequest);
             }
 
+            if(stopOnTerminate){
+                riRequest.setInstanceInitiatedShutdownBehavior(ShutdownBehavior.Stop);
+                logProvisionInfo(logger, "Setting Instance Initiated Shutdown Behavior : ShutdownBehavior.Stop");
+            }else{
+                riRequest.setInstanceInitiatedShutdownBehavior(ShutdownBehavior.Terminate);
+                 logProvisionInfo(logger, "Setting Instance Initiated Shutdown Behavior : ShutdownBehavior.Terminate");
+            }
+            
             List<Filter> diFilters = new ArrayList<Filter>();
             diFilters.add(new Filter("image-id").withValues(ami));
 


### PR DESCRIPTION
Rather than create another variable to set the instance initiated shutdown behaviour I reused the stopOnTerminate flag - which I think ensures consistency and a simpler solution.

I believe this fixes JENKINS-26371

Mark