### PR TITLE
Jenkins 32915

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -89,6 +89,7 @@ public abstract class EC2AbstractSlave extends Slave {
     public final String idleTerminationMinutes;
     public final boolean usePrivateDnsName;
     public final boolean useDedicatedTenancy;
+    public boolean isConnected = false;
     public List<EC2Tag> tags;
     public final String cloudName;
     public AMITypeData amiType;
@@ -386,7 +387,7 @@ public abstract class EC2AbstractSlave extends Slave {
      * Called when the slave is connected to Jenkins
      */
     public void onConnected() {
-        // Do nothing by default.
+        isConnected = true;
     }
 
     protected boolean isAlive(boolean force) {

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -426,31 +426,32 @@ public abstract class EC2Cloud extends Cloud {
         try {
             List<PlannedNode> r = new ArrayList<PlannedNode>();
             final SlaveTemplate t = getTemplate(label);
-            LOGGER.log(Level.FINE, "Attempting provision, excess workload: " + excessWorkload);
+            LOGGER.log(Level.INFO, "Attempting provision, excess workload: " + excessWorkload);
             if (label == null) {
-                LOGGER.log(Level.WARNING, "Label is null");
+                LOGGER.log(Level.WARNING, String.format("Label is null - can't caculate how many executors slave will have. Using %s number of executors", t.getNumExecutors()));
             }
-            boolean canTakeTask = itCanTakeTask();
-            while (excessWorkload > 0 && label != null && !canTakeTask) {
+            while (excessWorkload > 0) {
                 final EC2AbstractSlave slave = provisionSlaveIfPossible(t);
                 // Returned null if a new node could not be created
                 if (slave == null)
                     break;
-                Hudson.getInstance().addNode(slave);
+                LOGGER.log(Level.INFO, String.format("We have now %s computers", Jenkins.getInstance().getComputers().length));
+                Jenkins.getInstance().addNode(slave);
+                LOGGER.log(Level.INFO, String.format("Added node named: %s, We have now %s computers", slave.getNodeName(), Jenkins.getInstance().getComputers().length));
                 r.add(new PlannedNode(t.getDisplayName(), Computer.threadPoolForRemoting.submit(new Callable<Node>() {
 
                     public Node call() throws Exception {
-                        try {
-                            slave.toComputer().connect(false).get();
-                        } catch (Exception e) {
-                            if (t.spotConfig != null) {
-                                LOGGER.log(Level.INFO, "Expected - Spot instance " + slave.getInstanceId()
-                                        + " failed to connect on initial provision");
-                                return slave;
+                        long startTime = System.currentTimeMillis(); // fetch starting time
+                        while (false || (System.currentTimeMillis() - startTime) < slave.launchTimeout * 1000) {
+                            try {
+                                return tryToCallSlave(slave, t);
+
+                            } catch (Exception exception) {
+                                // ignore
                             }
-                            throw e;
                         }
-                        return slave;
+                        LOGGER.log(Level.WARNING, "Expected - Instance - failed to connect within launch timeout");
+                        return tryToCallSlave(slave, t);
                     }
                 }), t.getNumExecutors()));
 
@@ -466,17 +467,20 @@ public abstract class EC2Cloud extends Cloud {
             return Collections.emptyList();
         }
     }
-
-    private boolean itCanTakeTask() {
-        final Jenkins instance = Jenkins.getInstance();
-        for (final Node node : instance.getNodes()) {
-            final Computer computer = node.toComputer();
-            if (computer.isAcceptingTasks() && (computer.isIdle() || computer.isPartiallyIdle())
-                    && !instance.getQueue().getBuildableItems(computer).isEmpty()) {
-                return true;
+    
+    private EC2AbstractSlave tryToCallSlave(EC2AbstractSlave slave, SlaveTemplate template) throws Exception {
+    	try {
+            slave.toComputer().connect(false).get();
+        } catch (Exception e) {
+            if (template.spotConfig != null) {
+            	if(StringUtils.isNotEmpty(slave.getInstanceId()) && slave.isConnected) {
+            		LOGGER.log(Level.INFO, String.format("Instance id: %s for node: %s is connected now.", slave.getInstanceId(), slave.getNodeName()));
+            		return slave;
+            	}
             }
+            throw e;
         }
-        return false;
+    	return slave;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -430,7 +430,8 @@ public abstract class EC2Cloud extends Cloud {
             if (label == null) {
                 LOGGER.log(Level.WARNING, "Label is null");
             }
-            while (excessWorkload > 0 && label != null && !itCanTakeTask()) {
+            boolean canTakeTask = !itCanTakeTask();
+            while (excessWorkload > 0 && label != null && !canTakeTask) {
                 final EC2AbstractSlave slave = provisionSlaveIfPossible(t);
                 // Returned null if a new node could not be created
                 if (slave == null)

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -426,10 +426,11 @@ public abstract class EC2Cloud extends Cloud {
         try {
             List<PlannedNode> r = new ArrayList<PlannedNode>();
             final SlaveTemplate t = getTemplate(label);
-
-            while (excessWorkload > 0) {
-                LOGGER.log(Level.FINE, "Attempting provision, excess workload: " + excessWorkload);
-
+            LOGGER.log(Level.FINE, "Attempting provision, excess workload: " + excessWorkload);
+            if(label == null) {
+                LOGGER.log(Level.WARNING, "Label is null");
+            }
+            while (excessWorkload > 0 && label != null && !itCanTakeTask()) {
                 final EC2AbstractSlave slave = provisionSlaveIfPossible(t);
                 // Returned null if a new node could not be created
                 if (slave == null)

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -468,15 +468,15 @@ public abstract class EC2Cloud extends Cloud {
     }
 
     private boolean itCanTakeTask() {
-        List<Node> nodes = Jenkins.getInstance().getNodes();
-        boolean canTakeTask = false;
-        for (final Node node : nodes) {
-            if (node.toComputer().isAcceptingTasks() && (node.toComputer().isIdle() || node.toComputer().isPartiallyIdle())
-                    && !Jenkins.getInstance().getQueue().getBuildableItems(node.toComputer()).isEmpty()) {
-                canTakeTask = true;
+        final Jenkins instance = Jenkins.getInstance();
+        for (final Node node : instance.getNodes()) {
+            final Computer computer = node.toComputer();
+            if (computer.isAcceptingTasks() && (computer.isIdle() || computer.isPartiallyIdle())
+                    && !instance.getQueue().getBuildableItems(computer).isEmpty()) {
+                return true;
             }
         }
-        return canTakeTask;
+        return false;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -430,7 +430,7 @@ public abstract class EC2Cloud extends Cloud {
             if (label == null) {
                 LOGGER.log(Level.WARNING, "Label is null");
             }
-            boolean canTakeTask = !itCanTakeTask();
+            boolean canTakeTask = itCanTakeTask();
             while (excessWorkload > 0 && label != null && !canTakeTask) {
                 final EC2AbstractSlave slave = provisionSlaveIfPossible(t);
                 // Returned null if a new node could not be created

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -427,7 +427,7 @@ public abstract class EC2Cloud extends Cloud {
             List<PlannedNode> r = new ArrayList<PlannedNode>();
             final SlaveTemplate t = getTemplate(label);
             LOGGER.log(Level.FINE, "Attempting provision, excess workload: " + excessWorkload);
-            if(label == null) {
+            if (label == null) {
                 LOGGER.log(Level.WARNING, "Label is null");
             }
             while (excessWorkload > 0 && label != null && !itCanTakeTask()) {
@@ -464,6 +464,18 @@ public abstract class EC2Cloud extends Cloud {
             LOGGER.log(Level.WARNING, "Exception during provisioning", e);
             return Collections.emptyList();
         }
+    }
+
+    private boolean itCanTakeTask() {
+        List<Node> nodes = Jenkins.getInstance().getNodes();
+        boolean canTakeTask = false;
+        for (final Node node : nodes) {
+            if (node.toComputer().isAcceptingTasks() && (node.toComputer().isIdle() || node.toComputer().isPartiallyIdle())
+                    && !Jenkins.getInstance().getQueue().getBuildableItems(node.toComputer()).isEmpty()) {
+                canTakeTask = true;
+            }
+        }
+        return canTakeTask;
     }
 
     @Override


### PR DESCRIPTION
This pull addresses detected bug in self registering EC2 Slave spot instance.
https://issues.jenkins-ci.org/browse/JENKINS-32915
It was caused by the fact that we return a future that calls node instantly even before instance is ready and could not self deploy itself. I added a timeout that is respected and during that time it will retry connecting to that instance. While doing that promise wrapped in 'PlannedNode' looks like an instance that will be ready soon to take tasks from the queue and not an instant failure. By that Jenkins properly calculates and scales spot instances. And it had significant problem with it. I also noticed that if you do not provide a label to which ec2 cloud job is restricted it will have problems calculating default number of executors for the planned node which also affects excess workload calculation. I added a log message that addresses that. It can be 0 if you set you master server to use nodes only for doing jobs with number of executors to 0.

It is scaling properly in my company for at least a month now. We are scaling from 0 instances to ~20 during peaks and I did not notice any problems even with many cloud configurations.