### PR TITLE
JENKINS-33945 allow node provisioning when matching node is offline

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -1,16 +1,16 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
  * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
  * Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
  * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
@@ -404,7 +404,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 if (!node.toComputer().isPartiallyIdle()) {
                     logProvision(logger, " false - Node is not partially idle");
                     return false;
-                } else {
+                }
+                else if (node.toComputer().isOffline()) {
+                    logProvision(logger, " false - Node is offline");
+                    return false;
+                }
+                else {
                     logProvision(logger, " true - Node has capacity - can use it");
                     returnNode[0] = node;
                     return true;
@@ -823,7 +828,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     /**
      * Update the tags stored in EC2 with the specified information. Re-try 5 times if instances isn't up by
      * catchErrorCode - e.g. InvalidSpotInstanceRequestID.NotFound or InvalidInstanceRequestID.NotFound
-     * 
+     *
      * @param ec2
      * @param inst_tags
      * @param catchErrorCode
@@ -1111,7 +1116,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         /**
          * Populates the Bid Type Drop down on the slave template config.
-         * 
+         *
          * @return
          */
         public ListBoxModel doFillBidTypeItems() {


### PR DESCRIPTION
You can not provision a new node when an existing node from the template
is marked offline.  This change consults isOffline() to allow new node
provisioning.  Nodes can either be offline due to channel errors or user
interaction.  Either way, don't block new nodes.