### PR TITLE
add skipCheckInstance

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -378,6 +378,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     private boolean checkInstance(PrintStream logger, Instance existingInstance, EC2AbstractSlave[] returnNode) {
+
+        if (Boolean.getBoolean(SlaveTemplate.class.getName() + ".skipCheckInstance")) {
+            return false;
+        }
+
         logProvision(logger, "checkInstance: " + existingInstance);
         if (StringUtils.isNotBlank(getIamInstanceProfile())) {
             if (existingInstance.getIamInstanceProfile() != null) {


### PR DESCRIPTION
Setting `skipCheckInstance` to true allows the plugin to start instances even when there is idle capacity. This works because the [standard strategy](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/slaves/NodeProvisioner.java#L603) implemented by the NodeProvisioner already takes into account idle capacity and planned capacity.

Without this flag, it's impossible to start EC2 instances in parallel.