### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -21,7 +21,8 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.ec2.model.Instance;
 
 public class EC2WindowsLauncher extends EC2ComputerLauncher {
-
+    private static final String SLAVE_JAR = "slave.jar";
+    
     final long sleepBetweenAttemps = TimeUnit.SECONDS.toMillis(10);
 
     @Override
@@ -57,14 +58,14 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
                 logger.println("init script ran successfully");
             }
 
-            OutputStream slaveJar = connection.putFile(tmpDir + "slave.jar");
-            slaveJar.write(Jenkins.getInstance().getJnlpJars("slave.jar").readFully());
+            OutputStream slaveJar = connection.putFile(tmpDir + SLAVE_JAR);
+            slaveJar.write(Jenkins.getInstance().getJnlpJars(SLAVE_JAR).readFully());
 
             logger.println("slave.jar sent remotely. Bootstrapping it");
 
             final String jvmopts = computer.getNode().jvmopts;
             final WindowsProcess process = connection.execute("java " + (jvmopts != null ? jvmopts : "") + " -jar "
-                    + tmpDir + "slave.jar", 86400);
+                    + tmpDir + SLAVE_JAR, 86400);
             computer.setChannel(process.getStdout(), process.getStdin(), logger, new Listener() {
                 @Override
                 public void onClosed(Channel channel, IOException cause) {

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
@@ -52,6 +52,7 @@ import com.google.common.collect.Iterables;
 
 public class WinRMClient {
     private static final Logger log = Logger.getLogger(WinRMClient.class.getName());
+    private static final String APPLICATION_SOAP_XML = "application/soap+xml";
 
     private final URL url;
     private final String username;
@@ -211,7 +212,7 @@ public class WinRMClient {
         try {
             HttpPost post = new HttpPost(url.toURI());
 
-            HttpEntity entity = new StringEntity(request.asXML(), "application/soap+xml", "UTF-8");
+            HttpEntity entity = new StringEntity(request.asXML(), APPLICATION_SOAP_XML, "UTF-8");
             post.setEntity(entity);
 
             log.log(Level.FINEST, "Request:\nPOST " + url + "\n" + request.asXML());
@@ -223,7 +224,7 @@ public class WinRMClient {
                 // check for possible timeout
 
                 if (response.getStatusLine().getStatusCode() == 500
-                        && (responseEntity.getContentType() != null && entity.getContentType().getValue().startsWith("application/soap+xml"))) {
+                        && (responseEntity.getContentType() != null && entity.getContentType().getValue().startsWith(APPLICATION_SOAP_XML))) {
                     String respStr = EntityUtils.toString(responseEntity);
                     if (respStr.contains("TimedOut")) {
                         return DocumentHelper.parseText(respStr);
@@ -255,7 +256,7 @@ public class WinRMClient {
             }
 
             if (responseEntity.getContentType() == null
-                    || !entity.getContentType().getValue().startsWith("application/soap+xml")) {
+                    || !entity.getContentType().getValue().startsWith(APPLICATION_SOAP_XML)) {
                 throw new RuntimeException("Unexepected WinRM content type: " + entity.getContentType());
             }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1192 - String literals should not be duplicated

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1192

Please let me know if you have any questions.

M-Ezzat