### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/hudson/plugins/ec2/util/DeviceMappingParser.java
+++ b/src/main/java/hudson/plugins/ec2/util/DeviceMappingParser.java
@@ -31,6 +31,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class DeviceMappingParser {
+
+    private DeviceMappingParser() {
+    }
+
     public static List<BlockDeviceMapping> parse(String customDeviceMapping) {
 
         List<BlockDeviceMapping> deviceMappings = new ArrayList<BlockDeviceMapping>();

--- a/src/main/java/hudson/plugins/ec2/win/winrm/soap/Namespaces.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/soap/Namespaces.java
@@ -18,6 +18,9 @@ public class Namespaces {
     public static final Namespace NS_WIN_SHELL = Namespace.get("rsp", "http://schemas.microsoft.com/wbem/wsman/1/windows/shell");
     public static final Namespace NS_WSMAN_FAULT = Namespace.get("f", "http://schemas.microsoft.com/wbem/wsman/1/wsmanfault");
 
+    private Namespaces() {
+    }
+
     public static final List<Namespace> mostUsed() {
         return ImmutableList.of(NS_SOAP_ENV, NS_ADDRESSING, NS_WIN_SHELL, NS_WSMAN_DMTF, NS_WSMAN_MSFT);
     }

--- a/src/test/java/hudson/plugins/ec2/ListRegions.java
+++ b/src/test/java/hudson/plugins/ec2/ListRegions.java
@@ -27,6 +27,10 @@ package hudson.plugins.ec2;
  * @author Kohsuke Kawaguchi
  */
 public class ListRegions {
+
+    private ListRegions() {
+    }
+
     public static void main(String[] args) throws Exception {
         // Jec2 ec2 = new Jec2("...","...");
         // final List<RegionInfo> regions = ec2.describeRegions(null);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat