### PR TITLE
Use AWS credentials to manage the IAM access key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@ THE SOFTWARE.
   </scm>
 
   <properties>
-      <powermock.version>1.6.2</powermock.version>
+      <powermock.version>1.6.3</powermock.version>
   </properties>
 
   <dependencies>
@@ -68,12 +68,36 @@ THE SOFTWARE.
       <artifactId>powermock-api-mockito</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-all</artifactId>
+				</exclusion>
+			</exclusions>
     </dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>hamcrest-core</artifactId>
+					<groupId>org.hamcrest</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.11</version>
       <scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>hamcrest-core</artifactId>
+					<groupId>org.hamcrest</groupId>
+				</exclusion>
+			</exclusions>
     </dependency>
     <dependency>
       <!-- we only use this to handle key fingerprint. should be able to replace this with trilead -->

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,12 @@ THE SOFTWARE.
   </properties>
 
   <dependencies>
-    <dependency>
+	  <dependency>
+	  	<groupId>org.jenkins-ci.plugins</groupId>
+	  	<artifactId>aws-credentials</artifactId>
+	  	<version>1.11</version>
+	  </dependency>
+	  <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
       <version>${powermock.version}</version>
@@ -90,7 +95,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -66,8 +66,8 @@ public class AmazonEC2Cloud extends EC2Cloud {
     public static boolean testMode;
 
     @DataBoundConstructor
-    public AmazonEC2Cloud(String cloudName, boolean useInstanceProfileForCredentials, String accessId, String secretKey, String region, String privateKey, String instanceCapStr, List<? extends SlaveTemplate> templates) {
-        super(createCloudId(cloudName), useInstanceProfileForCredentials, accessId, secretKey, privateKey, instanceCapStr, templates);
+    public AmazonEC2Cloud(String cloudName, boolean useInstanceProfileForCredentials, String credentialsId, String region, String privateKey, String instanceCapStr, List<? extends SlaveTemplate> templates) {
+        super(createCloudId(cloudName), useInstanceProfileForCredentials, credentialsId, privateKey, instanceCapStr, templates);
         this.region = region;
     }
 
@@ -144,7 +144,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
             return FormValidation.ok();
         }
 
-        public ListBoxModel doFillRegionItems(@QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String accessId, @QueryParameter String secretKey, @QueryParameter String region)
+        public ListBoxModel doFillRegionItems(@QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String credentialsId)
                 throws IOException, ServletException {
             ListBoxModel model = new ListBoxModel();
             if (testMode) {
@@ -152,32 +152,31 @@ public class AmazonEC2Cloud extends EC2Cloud {
                 return model;
             }
 
-            if (useInstanceProfileForCredentials || (!StringUtils.isEmpty(accessId) && !StringUtils.isEmpty(secretKey))) {
-                AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, accessId, secretKey);
-                AmazonEC2 client = connect(credentialsProvider, new URL("http://ec2.amazonaws.com"));
-                DescribeRegionsResult regions = client.describeRegions();
-                List<Region> regionList = regions.getRegions();
-                for (Region r : regionList) {
-                    String name = r.getRegionName();
-                    model.add(name, name);
-                }
+            AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, credentialsId);
+            AmazonEC2 client = connect(credentialsProvider, new URL("http://ec2.amazonaws.com"));
+            DescribeRegionsResult regions = client.describeRegions();
+            List<Region> regionList = regions.getRegions();
+            for (Region r : regionList) {
+                String name = r.getRegionName();
+                model.add(name, name);
             }
             return model;
         }
 
-        public FormValidation doTestConnection(@QueryParameter String region, @QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String accessId, @QueryParameter String secretKey, @QueryParameter String privateKey)
+
+        public FormValidation doTestConnection(@QueryParameter String region, @QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String credentialsId, @QueryParameter String privateKey)
                 throws IOException, ServletException {
 
             if (Util.fixEmpty(region) == null) {
                 region = DEFAULT_EC2_HOST;
             }
 
-            return super.doTestConnection(getEc2EndpointUrl(region), useInstanceProfileForCredentials, accessId, secretKey, privateKey);
+            return super.doTestConnection(getEc2EndpointUrl(region), useInstanceProfileForCredentials, credentialsId, privateKey);
         }
 
-        public FormValidation doGenerateKey(StaplerResponse rsp, @QueryParameter String region, @QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String accessId, @QueryParameter String secretKey)
+        public FormValidation doGenerateKey(StaplerResponse rsp, @QueryParameter String region, @QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String credentialsId)
                 throws IOException, ServletException {
-            return super.doGenerateKey(rsp, getEc2EndpointUrl(region), useInstanceProfileForCredentials, accessId, secretKey);
+            return super.doGenerateKey(rsp, getEc2EndpointUrl(region), useInstanceProfileForCredentials, credentialsId);
         }
     }
 }

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.ec2;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.Descriptor;

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -553,8 +553,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return false;
         }
 
-        public ListBoxModel doFillZoneItems(@QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String accessId, @QueryParameter String secretKey, @QueryParameter String region) {
-            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, accessId, secretKey);
+        public ListBoxModel doFillZoneItems(@QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String credentialsId, @QueryParameter String region) {
+            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId);
             return fillZoneItems(credentialsProvider, region);
         }
 

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -20,6 +20,34 @@ package hudson.plugins.ec2;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl;
+import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.ProxyConfiguration;
+import hudson.model.Computer;
+import hudson.model.Descriptor;
+import hudson.model.Hudson;
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.security.ACL;
+import hudson.slaves.Cloud;
+import hudson.slaves.NodeProvisioner.PlannedNode;
+import hudson.util.FormValidation;
+import hudson.util.HttpResponses;
+import hudson.util.ListBoxModel;
+import hudson.util.Secret;
+import hudson.util.StreamTaskListener;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -40,6 +68,8 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.HashMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -115,9 +145,17 @@ public abstract class EC2Cloud extends Cloud {
 
     private final boolean useInstanceProfileForCredentials;
 
-    private final String accessId;
-
-    private final Secret secretKey;
+    /**
+     * Id of the {@link AmazonWebServicesCredentials} used to connect to Amazon ECS
+     */
+    @CheckForNull
+    private String credentialsId;
+    @CheckForNull
+    @Deprecated
+    private transient String accessId;
+    @CheckForNull
+    @Deprecated
+    private transient Secret secretKey;
 
     protected final EC2PrivateKey privateKey;
 
@@ -134,12 +172,11 @@ public abstract class EC2Cloud extends Cloud {
 
     private static AWSCredentialsProvider awsCredentialsProvider;
 
-    protected EC2Cloud(String id, boolean useInstanceProfileForCredentials, String accessId, String secretKey, String privateKey,
+    protected EC2Cloud(String id, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey,
             String instanceCapStr, List<? extends SlaveTemplate> templates) {
         super(id);
         this.useInstanceProfileForCredentials = useInstanceProfileForCredentials;
-        this.accessId = accessId.trim();
-        this.secretKey = Secret.fromString(secretKey.trim());
+        this.credentialsId = credentialsId;
         this.privateKey = new EC2PrivateKey(privateKey);
 
         if (templates == null) {
@@ -164,6 +201,52 @@ public abstract class EC2Cloud extends Cloud {
     protected Object readResolve() {
         for (SlaveTemplate t : templates)
             t.parent = this;
+        if (this.accessId != null && credentialsId == null) {
+            // REPLACE this.accessId and this.secretId by a credential
+
+            SystemCredentialsProvider systemCredentialsProvider = SystemCredentialsProvider.getInstance();
+            // ITERATE ON EXISTING CREDS AND DON'T CREATE IF EXIST
+            for (Credentials credentials: systemCredentialsProvider.getCredentials()) {
+                if (credentials instanceof AmazonWebServicesCredentials) {
+                    AmazonWebServicesCredentials awsCreds = (AmazonWebServicesCredentials) credentials;
+                    AWSCredentials awsCredentials = awsCreds.getCredentials();
+                    if (accessId.equals(awsCredentials.getAWSAccessKeyId()) &&
+                            Secret.toString(this.secretKey).equals(awsCredentials.getAWSSecretKey())) {
+
+                        this.credentialsId = awsCreds.getId();
+                        this.accessId = null;
+                        this.secretKey = null;
+                        return this;
+                    }
+                }
+            }
+            // CREATE
+            for (CredentialsStore credentialsStore: CredentialsProvider.lookupStores(Jenkins.getInstance())) {
+
+                if (credentialsStore instanceof  SystemCredentialsProvider.StoreImpl) {
+
+                    try {
+                        String credsId = UUID.randomUUID().toString();
+                        credentialsStore.addCredentials(Domain.global(), new AWSCredentialsImpl(
+                                CredentialsScope.SYSTEM,
+                                credsId,
+                                this.accessId,
+                                this.secretKey.getEncryptedValue(),
+                                "EC2 Cloud - " + getDisplayName()));
+                        this.credentialsId = credsId;
+                        this.accessId = null;
+                        this.secretKey = null;
+                        return this;
+                    } catch (IOException e) {
+                        this.credentialsId = null;
+                        LOGGER.log(Level.WARNING, "Exception converting legacy configuration to the new credentials API", e);
+                    }
+                }
+
+            }
+            // PROBLEM, GLOBAL STORE NOT FOUND
+            LOGGER.log(Level.WARNING, "EC2 Plugin could not migrate credentials to the Jenkins Global Credentials Store, EC2 Plugin for cloud {0} must be manually reconfigured", getDisplayName());
+        }
         return this;
     }
 
@@ -171,12 +254,8 @@ public abstract class EC2Cloud extends Cloud {
         return useInstanceProfileForCredentials;
     }
 
-    public String getAccessId() {
-        return accessId;
-    }
-
-    public Secret getSecretKey() {
-        return secretKey;
+    public String getCredentialsId() {
+        return credentialsId;
     }
 
     public EC2PrivateKey getPrivateKey() {
@@ -485,27 +564,34 @@ public abstract class EC2Cloud extends Cloud {
     }
 
     private AWSCredentialsProvider createCredentialsProvider() {
-        return createCredentialsProvider(useInstanceProfileForCredentials, accessId, secretKey);
-    }
-
-    public static AWSCredentialsProvider createCredentialsProvider(final boolean useInstanceProfileForCredentials,
-            final String accessId, final String secretKey) {
-        return createCredentialsProvider(useInstanceProfileForCredentials, accessId.trim(), Secret.fromString(secretKey.trim()));
+        return createCredentialsProvider(useInstanceProfileForCredentials, credentialsId);
     }
 
     public static String getSlaveTypeTagValue(String slaveType, String templateDescription) {
         return templateDescription != null ? slaveType + "_" + templateDescription : slaveType;
     }
 
-    public static AWSCredentialsProvider createCredentialsProvider(final boolean useInstanceProfileForCredentials,
-            final String accessId, final Secret secretKey) {
+    public static AWSCredentialsProvider createCredentialsProvider(final boolean useInstanceProfileForCredentials, final String credentialsId) {
 
         if (useInstanceProfileForCredentials) {
             return new InstanceProfileCredentialsProvider();
+        } else if (StringUtils.isBlank(credentialsId)) {
+            return new DefaultAWSCredentialsProviderChain();
+        } else {
+            AmazonWebServicesCredentials credentials = getCredentials(credentialsId);
+            return new StaticCredentialsProvider(credentials.getCredentials());
         }
+    }
 
-        BasicAWSCredentials credentials = new BasicAWSCredentials(accessId, secretKey.getPlainText());
-        return new StaticCredentialsProvider(credentials);
+    @CheckForNull
+    private static AmazonWebServicesCredentials getCredentials(@Nullable String credentialsId) {
+        if (StringUtils.isBlank(credentialsId)) {
+            return null;
+        }
+        return (AmazonWebServicesCredentials) CredentialsMatchers.firstOrNull(
+                CredentialsProvider.lookupCredentials(AmazonWebServicesCredentials.class, Jenkins.getInstance(),
+                        ACL.SYSTEM, Collections.EMPTY_LIST),
+                CredentialsMatchers.withId(credentialsId));
     }
 
     /**
@@ -599,17 +685,6 @@ public abstract class EC2Cloud extends Cloud {
             return InstanceType.values();
         }
 
-        public FormValidation doCheckAccessId(@QueryParameter String value) throws IOException, ServletException {
-            if (value.trim().length() != 20) {
-                return FormValidation.error(Messages.EC2Cloud_InvalidAccessId());
-            }
-            return FormValidation.validateBase64(value, false, false, Messages.EC2Cloud_InvalidAccessId());
-        }
-
-        public FormValidation doCheckSecretKey(@QueryParameter String value) throws IOException, ServletException {
-            return FormValidation.validateBase64(value, false, false, Messages.EC2Cloud_InvalidSecretKey());
-        }
-
         public FormValidation doCheckUseInstanceProfileForCredentials(@QueryParameter boolean value) {
             if (value) {
                 try {
@@ -640,11 +715,10 @@ public abstract class EC2Cloud extends Cloud {
             return FormValidation.ok();
         }
 
-        protected FormValidation doTestConnection(URL ec2endpoint, boolean useInstanceProfileForCredentials, String accessId,
-                String secretKey, String privateKey) throws IOException, ServletException {
+        protected FormValidation doTestConnection(URL ec2endpoint, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey)
+                throws IOException, ServletException {
             try {
-                AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, accessId,
-                        secretKey);
+                AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, credentialsId);
                 AmazonEC2 ec2 = connect(credentialsProvider, ec2endpoint);
                 ec2.describeInstances();
 
@@ -667,11 +741,10 @@ public abstract class EC2Cloud extends Cloud {
             }
         }
 
-        public FormValidation doGenerateKey(StaplerResponse rsp, URL ec2EndpointUrl, boolean useInstanceProfileForCredentials,
-                String accessId, String secretKey) throws IOException, ServletException {
+        public FormValidation doGenerateKey(StaplerResponse rsp, URL ec2EndpointUrl, boolean useInstanceProfileForCredentials, String credentialsId)
+                throws IOException, ServletException {
             try {
-                AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, accessId,
-                        secretKey);
+                AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials, credentialsId);
                 AmazonEC2 ec2 = connect(credentialsProvider, ec2EndpointUrl);
                 List<KeyPairInfo> existingKeys = ec2.describeKeyPairs().getKeyPairs();
 
@@ -698,6 +771,17 @@ public abstract class EC2Cloud extends Cloud {
                 LOGGER.log(Level.WARNING, "Failed to check EC2 credential", e);
                 return FormValidation.error(e.getMessage());
             }
+        }
+
+        public ListBoxModel doFillCredentialsIdItems() {
+            return new StandardListBoxModel()
+                    .withEmptySelection()
+                    .withMatching(
+                            CredentialsMatchers.always(),
+                            CredentialsProvider.lookupCredentials(AmazonWebServicesCredentials.class,
+                                    Jenkins.getInstance(),
+                                    ACL.SYSTEM,
+                                    Collections.EMPTY_LIST));
         }
     }
 

--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -23,7 +23,9 @@
  */
 package hudson.plugins.ec2;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Util;
+import hudson.model.Node;
 import hudson.slaves.SlaveComputer;
 import java.io.IOException;
 import java.util.Collections;
@@ -178,9 +180,12 @@ public class EC2Computer extends SlaveComputer {
     /**
      * What username to use to run root-like commands
      *
+     * @return remote admin or {@code null} if the associated {@link Node} is {@code null}
      */
+    @CheckForNull
     public String getRemoteAdmin() {
-        return getNode().getRemoteAdmin();
+        EC2AbstractSlave node = getNode();
+        return node == null ? null : node.getRemoteAdmin();
     }
 
     public int getSshPort() {

--- a/src/main/java/hudson/plugins/ec2/Eucalyptus.java
+++ b/src/main/java/hudson/plugins/ec2/Eucalyptus.java
@@ -46,9 +46,9 @@ public class Eucalyptus extends EC2Cloud {
     public final URL s3endpoint;
 
     @DataBoundConstructor
-    public Eucalyptus(URL ec2endpoint, URL s3endpoint, boolean useInstanceProfileForCredentials, String accessId, String secretKey, String privateKey, String instanceCapStr, List<SlaveTemplate> templates)
+    public Eucalyptus(URL ec2endpoint, URL s3endpoint, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String instanceCapStr, List<SlaveTemplate> templates)
             throws IOException {
-        super("eucalyptus", useInstanceProfileForCredentials, accessId, secretKey, privateKey, instanceCapStr, templates);
+        super("eucalyptus", useInstanceProfileForCredentials, credentialsId, privateKey, instanceCapStr, templates);
         this.ec2endpoint = ec2endpoint;
         this.s3endpoint = s3endpoint;
     }
@@ -71,15 +71,15 @@ public class Eucalyptus extends EC2Cloud {
         }
 
         @Override
-        public FormValidation doTestConnection(@QueryParameter URL ec2endpoint, @QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String accessId, @QueryParameter String secretKey, @QueryParameter String privateKey)
+        public FormValidation doTestConnection(@QueryParameter URL ec2endpoint, @QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String credentialsId, @QueryParameter String privateKey)
                 throws IOException, ServletException {
-            return super.doTestConnection(ec2endpoint, useInstanceProfileForCredentials, accessId, secretKey, privateKey);
+            return super.doTestConnection(ec2endpoint, useInstanceProfileForCredentials, credentialsId, privateKey);
         }
 
         @Override
-        public FormValidation doGenerateKey(StaplerResponse rsp, @QueryParameter URL url, @QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String accessId, @QueryParameter String secretKey)
+        public FormValidation doGenerateKey(StaplerResponse rsp, @QueryParameter URL url, @QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String credentialsId)
                 throws IOException, ServletException {
-            return super.doGenerateKey(rsp, url, useInstanceProfileForCredentials, accessId, secretKey);
+            return super.doGenerateKey(rsp, url, useInstanceProfileForCredentials, credentialsId);
         }
     }
 }

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -1014,10 +1014,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
          * Check that the AMI requested is available in the cloud and can be used.
          */
         public FormValidation doValidateAmi(@QueryParameter boolean useInstanceProfileForCredentials,
-                @QueryParameter String accessId, @QueryParameter String secretKey, @QueryParameter String ec2endpoint,
+                @QueryParameter String credentialsId, @QueryParameter String ec2endpoint,
                 @QueryParameter String region, final @QueryParameter String ami) throws IOException {
             AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials,
-                    accessId, secretKey);
+                    credentialsId);
             AmazonEC2 ec2;
             if (region != null) {
                 ec2 = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
@@ -1096,10 +1096,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
 
         public ListBoxModel doFillZoneItems(@QueryParameter boolean useInstanceProfileForCredentials,
-                @QueryParameter String accessId, @QueryParameter String secretKey, @QueryParameter String region)
+                @QueryParameter String credentialsId, @QueryParameter String region)
                 throws IOException, ServletException {
             AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials,
-                    accessId, secretKey);
+                    credentialsId);
             return EC2AbstractSlave.fillZoneItems(credentialsProvider, region);
         }
 
@@ -1143,7 +1143,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
          * Check the current Spot price of the selected instance type for the selected region
          */
         public FormValidation doCurrentSpotPrice(@QueryParameter boolean useInstanceProfileForCredentials,
-                @QueryParameter String accessId, @QueryParameter String secretKey, @QueryParameter String region,
+                @QueryParameter String credentialsId, @QueryParameter String region,
                 @QueryParameter String type, @QueryParameter String zone) throws IOException, ServletException {
 
             String cp = "";
@@ -1152,7 +1152,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             // Connect to the EC2 cloud with the access id, secret key, and
             // region queried from the created cloud
             AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials,
-                    accessId, secretKey);
+                    credentialsId);
             AmazonEC2 ec2 = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
 
             if (ec2 != null) {

--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -130,6 +130,7 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
                 logger.println("Connecting to " + host + "(" + ip + ") with WinRM as " + computer.getNode().remoteAdmin);
 
                 WinConnection connection = new WinConnection(ip, computer.getNode().remoteAdmin, computer.getNode().getAdminPassword().getPlainText());
+
                 connection.setUseHTTPS(computer.getNode().isUseHTTPS());
                 if (!connection.ping()) {
                     logger.println("Waiting for WinRM to come up. Sleeping 10s.");

--- a/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
@@ -1,18 +1,14 @@
 <!--
 The MIT License
-
 Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,15 +17,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:entry title="${%Name}" field="cloudName">
     <f:textbox />
   </f:entry>
-  <f:entry title="${%Access Key ID}" field="accessId">
-    <f:textbox />
-  </f:entry>
-  <f:entry title="${%Secret Access Key}" field="secretKey">
-    <f:password />
+  <f:entry field="credentialsId" title="${%Amazon EC2 Crendentials}" description="AWS IAM Access Key used to connect to EC2. If not specified, implicit authentication mechanisms are used (IAM roles...)">
+    <c:select />
   </f:entry>
   <f:entry title="${%Use EC2 instance profile to obtain credentials}" field="useInstanceProfileForCredentials">
     <f:checkbox />
@@ -47,6 +40,6 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
   </f:advanced>
-  <f:validateButton title="${%Generate Key}" progress="${%Generate...}" method="generateKey" with="region,useInstanceProfileForCredentials,secretKey,accessId" />
-  <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="region,useInstanceProfileForCredentials,secretKey,accessId,privateKey" />
+  <f:validateButton title="${%Generate Key}" progress="${%Generate...}" method="generateKey" with="region,useInstanceProfileForCredentials,credentialsId" />
+  <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="region,useInstanceProfileForCredentials,credentialsId,privateKey" />
 </j:jelly>

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-credentialsId.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-credentialsId.html
@@ -1,18 +1,14 @@
 <!--
 The MIT License
-
 Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,8 +18,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <div>
-    Jenkins uses this access key ID and secret access key to interface with Amazon EC2.
-    If you have already signed up on EC2, you can obtain this from
-    <a href="http://aws-portal.amazon.com/gp/aws/developer/account/index.html?action=access-key">here</a>.
-    Otherwise, you need to sign up to Amazon Web Services to get one.
+    <p>Jenkins uses this access key ID and secret access key to interface with Amazon EC2.
+        If you have already signed up on EC2, you can obtain this from
+        <a href="http://aws-portal.amazon.com/gp/aws/developer/account/index.html?action=access-key">here</a>.
+        Otherwise, you need to sign up to Amazon Web Services to get one.</p>
+    <p>
+        If no access key is set, implicit authentication mechanisms are used:
+    </p>
+    <ul>
+        <li>Environment Variables -
+            <code>AWS_ACCESS_KEY_ID</code> and <code>AWS_SECRET_ACCESS_KEY</code>
+            (RECOMMENDED since they are recognized by all the AWS SDKs and CLI except for .NET),
+            or <code>AWS_ACCESS_KEY</code> and <code>AWS_SECRET_KEY</code> (only recognized by Java SDK)
+        </li>
+        <li>Java System Properties - aws.accessKeyId and aws.secretKey</li>
+        <li>Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI</li>
+        <li>Instance profile credentials delivered through the Amazon EC2 metadata service (IAM role defined at the ec2 instance level)</li>
+    </ul>
 </div>

--- a/src/main/resources/hudson/plugins/ec2/Eucalyptus/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/Eucalyptus/config-entries.jelly
@@ -1,18 +1,14 @@
 <!--
 The MIT License
-
 Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,18 +17,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:entry title="${%Eucalyptus EC2 URL}" field="ec2endpoint">
     <f:textbox />
   </f:entry>
   <f:entry title="${%Eucalyptus S3 URL}" field="s3endpoint">
     <f:textbox />
   </f:entry>
-  <f:entry title="${%Access ID}" field="accessId">
-    <f:textbox />
-  </f:entry>
-  <f:entry title="${%Secret Key}" field="secretKey">
-    <f:password />
+  <f:entry field="credentialsId" title="${%Amazon EC2 Crendentials}" description="AWS IAM Access Key used to connect to EC2. If not specified, implicit authentication mechanisms are used (IAM roles...)">
+    <c:select />
   </f:entry>
   <f:entry title="${%Use EC2 instance profile to obtain credentials}" field="useInstanceProfileForCredentials">
     <f:checkbox />
@@ -45,6 +38,6 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
   </f:advanced>
-  <f:validateButton title="${%Generate Key}" progress="${%Generate...}" method="generateKey" with="ec2endpoint,useInstanceProfileForCredentials,secretKey,accessId" />
-  <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="ec2endpoint,useInstanceProfileForCredentials,secretKey,accessId,privateKey" />
+  <f:validateButton title="${%Generate Key}" progress="${%Generate...}" method="generateKey" with="ec2endpoint,useInstanceProfileForCredentials,credentialsId" />
+  <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="ec2endpoint,useInstanceProfileForCredentials,credentialsId,privateKey" />
 </j:jelly>

--- a/src/main/resources/hudson/plugins/ec2/Messages.properties
+++ b/src/main/resources/hudson/plugins/ec2/Messages.properties
@@ -1,5 +1,3 @@
-EC2Cloud.InvalidAccessId=Invalid AWS access key ID
-EC2Cloud.InvalidSecretKey=Invalid AWS secret access key
 EC2Cloud.FailedToObtainCredentailsFromEC2=Failed to obtain credentials from EC2 instance profile: %s
 EC2Cloud.Success=Success
 

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -90,7 +90,7 @@ THE SOFTWARE.
   </f:entry>
 
   <f:advanced>
-      
+
     <f:entry title="${%Override temporary dir location}" field="tmpDir">
       <f:textbox />
     </f:entry>

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
@@ -23,32 +23,39 @@
  */
 package hudson.plugins.ec2;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import hudson.slaves.Cloud;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Collections;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class AmazonEC2CloudTest extends HudsonTestCase {
+public class AmazonEC2CloudTest {
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Before
+    public void setUp() throws Exception {
         AmazonEC2Cloud.testMode = true;
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+    @After
+    public void tearDown() throws Exception {
         AmazonEC2Cloud.testMode = false;
     }
 
+    @After
     public void testConfigRoundtrip() throws Exception {
         AmazonEC2Cloud orig = new AmazonEC2Cloud("us-east-1", true, "abc", "def", "us-east-1", "ghi", "3", Collections.<SlaveTemplate> emptyList());
-        hudson.clouds.add(orig);
-        submit(createWebClient().goTo("configure").getFormByName("config"));
+        r.jenkins.clouds.add(orig);
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
 
-        assertEqualBeans(orig, hudson.clouds.iterator().next(), "cloudName,region,useInstanceProfileForCredentials,accessId,secretKey,privateKey,instanceCap");
+        Cloud actual = r.jenkins.clouds.iterator().next();
+        r.assertEqualBeans(orig, actual, "cloudName,region,useInstanceProfileForCredentials,accessId,privateKey,instanceCap");
     }
 }

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
@@ -51,7 +51,7 @@ public class AmazonEC2CloudTest {
 
     @After
     public void testConfigRoundtrip() throws Exception {
-        AmazonEC2Cloud orig = new AmazonEC2Cloud("us-east-1", true, "abc", "def", "us-east-1", "ghi", "3", Collections.<SlaveTemplate> emptyList());
+        AmazonEC2Cloud orig = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", "ghi", "3", Collections.<SlaveTemplate> emptyList());
         r.jenkins.clouds.add(orig);
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
 

--- a/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
@@ -1,14 +1,22 @@
 package hudson.plugins.ec2;
 
 import hudson.slaves.NodeProperty;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.ArrayList;
 
-public class EC2AbstractSlaveTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+
+public class EC2AbstractSlaveTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     int timeoutInSecs = Integer.MAX_VALUE;
 
+    @Test
     public void testGetLaunchTimeoutInMillisShouldNotOverflow() throws Exception {
         EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "root", "jvm", false, "idle", null, "cloud", false, false, Integer.MAX_VALUE, new UnixData("remote", "22")) {
             @Override

--- a/src/test/java/hudson/plugins/ec2/EC2InstanceTypesTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2InstanceTypesTest.java
@@ -23,11 +23,12 @@
  */
 package hudson.plugins.ec2;
 
-import org.jvnet.hudson.test.HudsonTestCase;
-
 import com.amazonaws.services.ec2.model.InstanceType;
+import org.junit.Test;
 
-public class EC2InstanceTypesTest extends HudsonTestCase {
+public class EC2InstanceTypesTest {
+
+    @Test
     public void testListTypes() throws Exception {
         System.out.println("EC2 Instance Types available:");
         for (InstanceType t : InstanceType.values()) {

--- a/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
@@ -1,10 +1,18 @@
 package hudson.plugins.ec2;
 
 import hudson.model.Node;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
-public class EC2OndemandSlaveTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
 
+public class EC2OndemandSlaveTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
     public void testSpecifyMode() throws Exception {
         EC2OndemandSlave slaveNormal = new EC2OndemandSlave("instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.NORMAL, "initScript", "tmpDir", "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", null, "cloudName", false, false, 0, new UnixData("a", "b"));
         assertEquals(Node.Mode.NORMAL, slaveNormal.getMode());

--- a/src/test/java/hudson/plugins/ec2/EC2PrivateKeyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2PrivateKeyTest.java
@@ -23,14 +23,18 @@
  */
 package hudson.plugins.ec2;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Test;
 
 import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class EC2PrivateKeyTest extends HudsonTestCase {
+public class EC2PrivateKeyTest {
+
+    @Test
     public void testFingerprint() throws IOException {
         EC2PrivateKey k = new EC2PrivateKey("-----BEGIN RSA PRIVATE KEY-----\n"
                 + "MIIEowIBAAKCAQEAlpK/pGxCRoHpbIObxYW53fl4qA+EQNHuSveNyxt+6m/HAdRLhEMGHe7/b7dR\n"
@@ -58,6 +62,7 @@ public class EC2PrivateKeyTest extends HudsonTestCase {
         assertEquals("3c:ee:c2:12:57:5f:d0:73:79:38:d6:aa:ef:91:0a:b8:2c:5f:47:65", k.getFingerprint());
     }
 
+    @Test
     public void testPublicFingerprint() throws IOException {
         EC2PrivateKey k = new EC2PrivateKey("-----BEGIN RSA PRIVATE KEY-----\n"
                 + "MIIEowIBAAKCAQEAlpK/pGxCRoHpbIObxYW53fl4qA+EQNHuSveNyxt+6m/HAdRLhEMGHe7/b7dR\n"

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -2,16 +2,25 @@ package hudson.plugins.ec2;
 
 import com.amazonaws.AmazonClientException;
 import hudson.slaves.NodeProperty;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class EC2RetentionStrategyTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EC2RetentionStrategyTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     final AtomicBoolean idleTimeoutCalled = new AtomicBoolean(false);
 
+    @Test
     public void testOnBillingHourRetention() throws Exception {
         EC2RetentionStrategy rs = new EC2RetentionStrategy("-2");
         List<int[]> upTime = new ArrayList<int[]>();

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -26,30 +26,38 @@ package hudson.plugins.ec2;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import com.amazonaws.services.ec2.model.InstanceType;
 import com.amazonaws.services.ec2.model.SpotInstanceType;
 
 import hudson.model.Node;
+import org.jvnet.hudson.test.JenkinsRule;
 
 /**
  * Basic test to validate SlaveTemplate.
  */
-public class SlaveTemplateTest extends HudsonTestCase {
+public class SlaveTemplateTest {
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Before
+    public void setUp() throws Exception {
         AmazonEC2Cloud.testMode = true;
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+    @After
+    public void tearDown() throws Exception {
         AmazonEC2Cloud.testMode = false;
     }
 
+    @Test
     public void testConfigRoundtrip() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
@@ -66,13 +74,14 @@ public class SlaveTemplateTest extends HudsonTestCase {
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
-        hudson.clouds.add(ac);
+        r.jenkins.clouds.add(ac);
 
-        submit(createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) hudson.clouds.iterator().next()).getTemplate(description);
-        assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,usePrivateDnsName,useEphemeralDevices,useDedicatedTenancy");
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,usePrivateDnsName,useEphemeralDevices,useDedicatedTenancy");
     }
 
+    @Test
     public void testConfigRoundtripWithPrivateDns() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
@@ -89,11 +98,11 @@ public class SlaveTemplateTest extends HudsonTestCase {
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
-        hudson.clouds.add(ac);
+        r.jenkins.clouds.add(ac);
 
-        submit(createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) hudson.clouds.iterator().next()).getTemplate(description);
-        assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
     }
 
     /**
@@ -103,6 +112,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
      * @throws Exception
      *             - Exception that can be thrown by the Jenkins test harness
      */
+    @Test
     public void testConfigWithSpotBidPrice() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
@@ -120,11 +130,11 @@ public class SlaveTemplateTest extends HudsonTestCase {
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
-        hudson.clouds.add(ac);
+        r.jenkins.clouds.add(ac);
 
-        submit(createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) hudson.clouds.iterator().next()).getTemplate(description);
-        assertEqualBeans(orig, received, "ami,zone,spotConfig,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(orig, received, "ami,zone,spotConfig,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
     }
 
     /**
@@ -132,6 +142,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testConfigRoundtripIamRole() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
@@ -148,18 +159,20 @@ public class SlaveTemplateTest extends HudsonTestCase {
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
-        hudson.clouds.add(ac);
+        r.jenkins.clouds.add(ac);
 
-        submit(createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) hudson.clouds.iterator().next()).getTemplate(description);
-        assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,usePrivateDnsName,iamInstanceProfile");
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,usePrivateDnsName,iamInstanceProfile");
     }
 
+    @Test
     public void testNullTimeoutShouldReturnMaxInt() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
+    @Test
     public void testUpdateAmi() {
         SlaveTemplate st = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "0", false, "");
         assertEquals("ami1", st.getAmi());
@@ -169,36 +182,43 @@ public class SlaveTemplateTest extends HudsonTestCase {
         assertEquals("ami3", st.getAmi());
     }
 
+    @Test
     public void test0TimeoutShouldReturnMaxInt() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "0", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
+    @Test
     public void testNegativeTimeoutShouldReturnMaxInt() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "-1", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
+    @Test
     public void testNonNumericTimeoutShouldReturnMaxInt() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "NotANumber", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
+    @Test
     public void testAssociatePublicIpSetting() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true, "");
         assertEquals(true, st.getAssociatePublicIp());
     }
 
+    @Test
     public void testConnectUsingPublicIpSetting() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true, "", false, true);
         assertTrue(st.isConnectUsingPublicIp());
     }
 
+    @Test
     public void testConnectUsingPublicIpSettingWithDefaultSetting() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true, "");
         assertFalse(st.isConnectUsingPublicIp());
     }
 
+    @Test
     public void testBackwardCompatibleUnixData() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "rrr", "sudo", "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, "NotANumber");
         assertFalse(st.isWindowsSlave());
@@ -206,6 +226,7 @@ public class SlaveTemplateTest extends HudsonTestCase {
         assertEquals("sudo", st.getRootCommandPrefix());
     }
 
+    @Test
     public void testWindowsConfigRoundTrip() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
@@ -222,15 +243,16 @@ public class SlaveTemplateTest extends HudsonTestCase {
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
-        hudson.clouds.add(ac);
+        r.jenkins.clouds.add(ac);
 
-        submit(createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) hudson.clouds.iterator().next()).getTemplate(description);
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         assertEquals(orig.getAdminPassword(), received.getAdminPassword());
         assertEquals(orig.amiType, received.amiType);
-        assertEqualBeans(orig, received, "amiType");
+        r.assertEqualBeans(orig, received, "amiType");
     }
 
+    @Test
     public void testUnixConfigRoundTrip() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
@@ -247,10 +269,10 @@ public class SlaveTemplateTest extends HudsonTestCase {
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
-        hudson.clouds.add(ac);
+        r.jenkins.clouds.add(ac);
 
-        submit(createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) hudson.clouds.iterator().next()).getTemplate(description);
-        assertEqualBeans(orig, received, "amiType");
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(orig, received, "amiType");
     }
 }

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -73,7 +73,7 @@ public class SlaveTemplateTest {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
@@ -97,7 +97,7 @@ public class SlaveTemplateTest {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
@@ -129,7 +129,7 @@ public class SlaveTemplateTest {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
@@ -158,7 +158,7 @@ public class SlaveTemplateTest {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
@@ -242,7 +242,7 @@ public class SlaveTemplateTest {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
@@ -268,7 +268,7 @@ public class SlaveTemplateTest {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
 
-        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));

--- a/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
+++ b/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
@@ -60,7 +60,7 @@ public class TemplateLabelsTest {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(template);
 
-        ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
+        ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
+++ b/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
@@ -27,12 +27,19 @@ import com.amazonaws.services.ec2.model.InstanceType;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class TemplateLabelsTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+
+public class TemplateLabelsTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     private AmazonEC2Cloud ac;
     private final String LABEL1 = "label1";
@@ -56,6 +63,7 @@ public class TemplateLabelsTest extends HudsonTestCase {
         ac = new AmazonEC2Cloud("us-east-1", false, "abc", "def", "us-east-1", "ghi", "3", templates);
     }
 
+    @Test
     public void testLabelAtom() throws Exception {
         setUpCloud(LABEL1 + " " + LABEL2);
 
@@ -65,6 +73,7 @@ public class TemplateLabelsTest extends HudsonTestCase {
         assertEquals(true, ac.canProvision(null));
     }
 
+    @Test
     public void testLabelExpression() throws Exception {
         setUpCloud(LABEL1 + " " + LABEL2);
 
@@ -76,12 +85,14 @@ public class TemplateLabelsTest extends HudsonTestCase {
         assertEquals(false, ac.canProvision(Label.parseExpression("aaa || bbb")));
     }
 
+    @Test
     public void testEmptyLabel() throws Exception {
         setUpCloud("");
 
         assertEquals(true, ac.canProvision(null));
     }
 
+    @Test
     public void testExclusiveMode() throws Exception {
         setUpCloud(LABEL1 + " " + LABEL2, Node.Mode.EXCLUSIVE);
 
@@ -91,6 +102,7 @@ public class TemplateLabelsTest extends HudsonTestCase {
         assertEquals(false, ac.canProvision(null));
     }
 
+    @Test
     public void testExclusiveModeEmptyLabel() throws Exception {
         setUpCloud("", Node.Mode.EXCLUSIVE);
 

--- a/src/test/java/hudson/plugins/ec2/util/DeviceMappingParserTest.java
+++ b/src/test/java/hudson/plugins/ec2/util/DeviceMappingParserTest.java
@@ -25,12 +25,13 @@ package hudson.plugins.ec2.util;
 
 import com.amazonaws.services.ec2.model.BlockDeviceMapping;
 import com.amazonaws.services.ec2.model.EbsBlockDevice;
-import org.jvnet.hudson.test.HudsonTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class DeviceMappingParserTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+
+public class DeviceMappingParserTest {
 
     public void testParserWithAmi() throws Exception {
         List<BlockDeviceMapping> expected = new ArrayList<BlockDeviceMapping>();


### PR DESCRIPTION
Use centralized AWS credentials to manage the IAM access key in the Jenkins Credentials Store and allow to reuse the credentials in other plugins, help auditing configuration changes... (See screenshot 1)

Additional enhancement: if no IAM Credentials have been defined, use the standard AWS credentials resolution mechanism (see [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) and screenshot 2):
 * Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (RECOMMENDED since they are recognized by all the AWS SDKs and CLI except for .NET), or `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` (only recognized by Java SDK)
 * Java System Properties - aws.accessKeyId and aws.secretKey
 * Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI
 * Instance profile credentials delivered through the Amazon EC2 metadata service (IAM role defined at the ec2 instance level)

Note: this PR is based on PR #173 

### Screenshot 1: Jenkins EC2 Plugin - AWS credentials support

![Jenkins EC2 Plugin with AWS credentials](http://snag.gy/u23gR.jpg)

### Screenshot 2: Jenkins EC2 Plugin - AWS credentials resolution

![Jenkins EC2 Plugin - AWS credentials resolution](http://snag.gy/BeSp6.jpg)