### PR TITLE
JENKINS-34671 - Remove spot request bid type setting

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -240,12 +240,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return parent;
     }
 
-    public String getBidType() {
-        if (spotConfig == null)
-            return null;
-        return spotConfig.spotInstanceBidType;
-    }
-
     public String getLabelString() {
         return labels;
     }
@@ -695,7 +689,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             spotRequest.setSpotPrice(getSpotMaxBidPrice());
             spotRequest.setInstanceCount(1);
-            spotRequest.setType(getBidType());
 
             LaunchSpecification launchSpecification = new LaunchSpecification();
             InstanceNetworkInterfaceSpecification net = new InstanceNetworkInterfaceSpecification();
@@ -1125,18 +1118,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             }
 
             return availabilityZones;
-        }
-
-        /**
-         * Populates the Bid Type Drop down on the slave template config.
-         *
-         * @return
-         */
-        public ListBoxModel doFillBidTypeItems() {
-            ListBoxModel items = new ListBoxModel();
-            items.add(SpotInstanceType.OneTime.toString());
-            items.add(SpotInstanceType.Persistent.toString());
-            return items;
         }
 
         /*

--- a/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
+++ b/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
@@ -4,12 +4,10 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 public final class SpotConfiguration {
     public final String spotMaxBidPrice;
-    public final String spotInstanceBidType;
 
     @DataBoundConstructor
-    public SpotConfiguration(String spotMaxBidPrice, String bidType) {
+    public SpotConfiguration(String spotMaxBidPrice) {
         this.spotMaxBidPrice = spotMaxBidPrice;
-        this.spotInstanceBidType = bidType;
     }
 
     @Override
@@ -19,8 +17,7 @@ public final class SpotConfiguration {
         }
         final SpotConfiguration config = (SpotConfiguration) obj;
 
-        return normalizeBid(this.spotMaxBidPrice).equals(normalizeBid(config.spotMaxBidPrice))
-                && this.spotInstanceBidType.equals(config.spotInstanceBidType);
+        return normalizeBid(this.spotMaxBidPrice).equals(normalizeBid(config.spotMaxBidPrice));
     }
 
     /**

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -55,10 +55,6 @@ THE SOFTWARE.
     <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice">
       <f:textbox />
     </f:entry>
-
-    <f:entry field="bidType" title="Choose Bid Type">
-      <f:select />
-    </f:entry>
   </f:optionalBlock>
 
   <f:entry title="${%Security group names}" field="securityGroups">

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-bidType.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-bidType.html
@@ -1,5 +1,0 @@
-<div>
-  Choose the bid type of your spot requests.
-  <br>Persistent: Ensure that requests are resubmitted after its instance is terminated by you or by Amazon EC2, until you cancel the bid request. This enables you to automate launching Spot instances any time the Spot price is below your maximum price.
-  <br>Volatile: Requests are not resubmitted after its instance is terminated. 
-</div>

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -35,7 +35,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import com.amazonaws.services.ec2.model.InstanceType;
-import com.amazonaws.services.ec2.model.SpotInstanceType;
 
 import hudson.model.Node;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -123,7 +122,7 @@ public class SlaveTemplateTest {
         tags.add(tag1);
         tags.add(tag2);
 
-        SpotConfiguration spotConfig = new SpotConfiguration(".05", SpotInstanceType.OneTime.toString());
+        SpotConfiguration spotConfig = new SpotConfiguration(".05");
 
         SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, true, null, "", false, false, "", false, "");
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();


### PR DESCRIPTION
With slaves now being fully controlled by Jenkins master, there is no longer a need to be able to set "persistent" spot bids--in fact it's dangerous because it will cause "zombie" spot instances to be auto-created by AWS which are not visible to Jenkins!