### PR TITLE
Clarifies documentation of negative idle termination times.

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/EC2Computer/help-idleTerminationMinutes.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Computer/help-idleTerminationMinutes.html
@@ -26,6 +26,7 @@ THE SOFTWARE.
     <p>
     Times are expressed in minutes.
     A value of 0 (or an empty string) indicates that idle slaves should never be stopped/terminated.
-    A negative value indicates that the instance should idle up to the billing hour, minus the idle minute time. For example, a value of 
-    -2 means that if an instance will be retained if checked less than 58 minutes into the billing hour, but stopped or terminated if checked between the 58th and 60th active minute.  This strategy keeps slaves alive and available for additional work during already paid for period.
+    A negative value indicates that the instance should idle up to the billing hour, minus the idle minute time. For example, a value of
+    -2 means that an instance will be retained if checked less than 58 minutes into the billing hour and found active, but stopped or
+    terminated if found idle. This strategy keeps slaves alive and available for additional work during already paid for period.
 </div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-idleTerminationMinutes.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-idleTerminationMinutes.html
@@ -22,13 +22,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <div>
-    <p>Determines how long slaves can remain idle before being stopped or terminated (see the Stop/Disconnect on Idle Timeout setting).</p>
+    <p>Determines how long slaves can remain idle before being stopped or terminated (see the Stop/Disconnect on Idle
+      Timeout setting). Also determines how frequently nodes are checked for stopping/terminating.</p>
     <p>Times are expressed in minutes, and a value of 0 (or an empty string) indicates that idle slaves should
     never be stopped/terminated. Positive values are simple time-outs after that many idle minutes. Negative values
-    cause the node to time out when idle and within the specified number of minutes from the end of an hourly
+    cause the node to time out when found idle within the specified number of minutes from the end of an hourly
     EC2 billing period.</p>
-    <p>E.g. if a node has an idle timeout of 5 and at 11:30 it has been idle since 11:20 (10 minutes), it will be terminated. If it has
-    an idle timeout of -5 it won't be terminated because the hourly billing period doesn't run out until 12:00.</p>
-    <p>If a node has an idle timeout of -5, and it becomes idle at 11:58, it will be terminated because it's within 5 minutes of the
-    end of the billing period - even if it was active less than 5 minutes ago.</p>
+    <p>As an example, let's say a node was started at 11:00.</p>
+    <p>If it has an idle timeout of 5 it will be checked every 5 minutes starting at 11:05. If it's checked at 11:30
+      and has been idle since 11:26 (for 4 minutes), it will be stopped or terminated.</p>
+    <p>If it has an idle timeout of -5 it will first be checked at 11:55, and then continuously until 12:00. If it
+      becomes idle during that time it will be stopped or terminated.</p>
 </div>


### PR DESCRIPTION
I was so confused by the documentation in `src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-idleTerminationMinutes.html` (which shows up on the Manage Jenkins page) on what negative idle times do that I consulted the source code to understand what it meant. This pull request is my attempt to clarify that documention.

I've also documented that the idle termination time is also used to determine how frequently a node is checked for idleness. As part of that I made a guess (based on my observation of behaviour) as to from when and how frequently the plugin checks when a negative idle time is specified -- that's the sentence "_If it has an idle timeout of -5 it will first be checked at 11:55, and then continuously until 12:00_". I'm particularly unsure about the "continuously".