### PR TITLE
squid:S1943 - Classes and methods that rely on the default system enc…

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -21,6 +21,7 @@ package hudson.plugins.ec2;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -507,7 +508,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 }
             }
 
-            String userDataString = Base64.encodeBase64String(userData.getBytes());
+            String userDataString = Base64.encodeBase64String(userData.getBytes(StandardCharsets.UTF_8));
             riRequest.setUserData(userDataString);
             riRequest.setKeyName(keyPair.getKeyName());
             diFilters.add(new Filter("key-name").withValues(keyPair.getKeyName()));
@@ -756,7 +757,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 }
             }
 
-            String userDataString = Base64.encodeBase64String(userData.getBytes());
+            String userDataString = Base64.encodeBase64String(userData.getBytes(StandardCharsets.UTF_8));
 
             launchSpecification.setUserData(userDataString);
             launchSpecification.setKeyName(keyPair.getKeyName());

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -39,12 +39,14 @@ import hudson.slaves.CommandLauncher;
 import hudson.slaves.ComputerLauncher;
 
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -255,12 +257,14 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
         File tempFile = File.createTempFile("ec2_", ".pem");
 
         try {
-            FileWriter writer = new FileWriter(tempFile);
+            FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
+            OutputStreamWriter writer = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8);
             try {
                 writer.write(privateKey);
                 writer.flush();
             } finally {
                 writer.close();
+                fileOutputStream.close();
             }
             FilePath filePath = new FilePath(tempFile);
             filePath.chmod(0400); // octal file mask - readonly by owner

--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -12,6 +12,7 @@ import hudson.slaves.ComputerLauncher;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 import jenkins.model.Jenkins;
@@ -54,7 +55,7 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
                 }
 
                 OutputStream initGuard = connection.putFile(tmpDir + ".jenkins-init");
-                initGuard.write("init ran".getBytes());
+                initGuard.write("init ran".getBytes(StandardCharsets.UTF_8));
                 logger.println("init script ran successfully");
             }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat