### PR TITLE
[JENKINS-35457] Migrate from using bouncy castle to bouncycastle-api plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,10 +105,9 @@ THE SOFTWARE.
 			</exclusions>
     </dependency>
     <dependency>
-      <!-- we only use this to handle key fingerprint. should be able to replace this with trilead -->
-      <groupId>bouncycastle</groupId>
-      <artifactId>bcprov-jdk15</artifactId>
-      <version>140</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>bouncycastle-api</artifactId>
+      <version>1.0</version>
     </dependency>
   	<dependency>
 	  <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>bouncycastle-api</artifactId>
-      <version>1.0</version>
+      <version>1.0.2</version>
     </dependency>
   	<dependency>
 	  <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/hudson/plugins/ec2/EC2PrivateKeyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2PrivateKeyTest.java
@@ -23,7 +23,9 @@
  */
 package hudson.plugins.ec2;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
 
@@ -34,6 +36,9 @@ import static org.junit.Assert.assertEquals;
  */
 public class EC2PrivateKeyTest {
 
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
     @Test
     public void testFingerprint() throws IOException {
         EC2PrivateKey k = new EC2PrivateKey("-----BEGIN RSA PRIVATE KEY-----\n"


### PR DESCRIPTION
[JENKINS-35457](https://issues.jenkins-ci.org/browse/JENKINS-35457)
Dependency to multiple Bouncy Castle versions from jenkins core and plugins is causing problems due to the binary incompatibility between versions, the different supported algorithms, etc.

Plugins should be migrated to use a common API and BC version in order to avoid these problems, see [bouncycastle-api plugin](https://github.com/jenkinsci/bouncycastle-api/blob/master/README.md)

@reviewbybees 