### PR TITLE
Update aws-java-sdk version to 1.10.50.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@ THE SOFTWARE.
   	<dependency>
 	  <groupId>org.jenkins-ci.plugins</groupId>
 	  <artifactId>aws-java-sdk</artifactId>
-	  <version>1.10.45</version>
+	  <version>1.10.50</version>
 	</dependency>
   	<dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
 Resolves JENKINS-33196 - Add g2.8xlarge to the list of instance types.