### PR TITLE
Upgrade httpclient to version 4.5.2 to fix HTTPCLIENT-1715 / HTTPCLIENT-1686

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,12 +122,7 @@ THE SOFTWARE.
     <dependency>
     	<groupId>org.apache.httpcomponents</groupId>
     	<artifactId>httpclient</artifactId>
-    	<version>4.4</version>
-    </dependency>
-    <dependency>
-    	<groupId>org.apache.httpcomponents</groupId>
-    	<artifactId>httpcore</artifactId>
-    	<version>4.4</version>
+    	<version>4.5.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
After upgrading past version 1.31 of the ec2 plugin, we've been experiencing frequent failures of Windows slaves due to the nodes becoming disconnected.

Eventually I tracked the issue back to httpclient being upgraded to https://issues.apache.org/jira/browse/HTTPCLIENT-1686, which was fixed in version 4.5.2 of httpclient via https://issues.apache.org/jira/browse/HTTPCLIENT-1715.

Additionally this removes an unnecessary direct dependency on httpcore (which should be pulled in transitively by httpclient).