### PR TITLE
Cleanup - squid:S2142 - InterruptedException should not be ignored

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
@@ -125,6 +125,7 @@ public abstract class EC2ComputerLauncher extends ComputerLauncher {
         } catch (IOException e) {
             e.printStackTrace(listener.error(e.getMessage()));
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             e.printStackTrace(listener.error(e.getMessage()));
         }
 

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -619,6 +619,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             throw new AssertionError(e); // we should have discovered all
                                         // configuration issues upfront
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }
@@ -835,6 +836,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             throw new AssertionError(); // we should have discovered all
                                         // configuration issues upfront
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
@@ -241,6 +241,7 @@ public class WinRMClient {
                         try {
                             Thread.sleep(TimeUnit.MINUTES.toMillis(3));
                         } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
                         }
                         authCache.set(new BasicAuthCache());
                         log.log(Level.WARNING, "winrm returned 401 - retrying now");

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
@@ -44,6 +44,7 @@ public class WindowsProcess {
         try {
             Thread.sleep(1000);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
         startStdinCopyThread();
     }
@@ -74,6 +75,7 @@ public class WindowsProcess {
             }
             return client.exitCode();
         } catch (InterruptedException exc) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException("Exception while executing command", exc);
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2142 - "InterruptedException" should not be ignored

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2142

Please let me know if you have any questions.

M-Ezzat