### PR TITLE
Ensure EBS optimized flag is passed to spot instances

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -722,6 +722,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             launchSpecification.setImageId(ami);
             launchSpecification.setInstanceType(type);
+            launchSpecification.setEbsOptimized(ebsOptimized);
 
             if (StringUtils.isNotBlank(getZone())) {
                 SpotPlacement placement = new SpotPlacement(getZone());


### PR DESCRIPTION
Currently, the EBS optimized flag is ignored for spot instances.