### PR TITLE
Ensure slave type tag is set on spot instance request

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -788,9 +788,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 }
             }
             if (!hasCustomTypeTag) {
-                if (instTags != null)
-                    instTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, EC2Cloud.getSlaveTypeTagValue(
-                            EC2Cloud.EC2_SLAVE_TYPE_SPOT, description)));
+                if (instTags == null) {
+                    instTags = new HashSet<Tag>();
+                }
+                instTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, EC2Cloud.getSlaveTypeTagValue(
+                        EC2Cloud.EC2_SLAVE_TYPE_SPOT, description)));
             }
 
             if (StringUtils.isNotBlank(getIamInstanceProfile())) {


### PR DESCRIPTION
If no custom tags were set, the slave type tag would not be set on the spot instance request.