### PR TITLE
Fix issue when counting non-fulfilled spot requests

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -635,10 +635,10 @@ public abstract class EC2Cloud extends Cloud {
             	if (connection == null) {
                     connection = connect(createCredentialsProvider(), getEc2EndpointUrl());
             	}
-           	    return connection;
+                    return connection;
         	} catch (IOException e) {
-           	    throw new AmazonClientException("Failed to retrieve the endpoint", e);
-       		}
+                    throw new AmazonClientException("Failed to retrieve the endpoint", e);
+            }
 	}
     }
 

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -635,10 +635,10 @@ public abstract class EC2Cloud extends Cloud {
             	if (connection == null) {
                     connection = connect(createCredentialsProvider(), getEc2EndpointUrl());
             	}
-                    return connection;
+           	    return connection;
         	} catch (IOException e) {
-                    throw new AmazonClientException("Failed to retrieve the endpoint", e);
-            }
+           	    throw new AmazonClientException("Failed to retrieve the endpoint", e);
+       		}
 	}
     }
 

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -400,13 +400,15 @@ public abstract class EC2Cloud extends Cloud {
             for (SpotInstanceRequest sir : sirs) {
                 sirSet.add(sir);
                 if (sir.getState().equals("open") || sir.getState().equals("active")) {
-                    if (instanceIds.contains(sir.getInstanceId()))
+                    if (sir.getInstanceId() != null && instanceIds.contains(sir.getInstanceId()))
                         continue;
 
                     LOGGER.log(Level.FINE, "Spot instance request found: " + sir.getSpotInstanceRequestId() + " AMI: "
                             + sir.getInstanceId() + " state: " + sir.getState() + " status: " + sir.getStatus());
                     n++;
-                    instanceIds.add(sir.getInstanceId());
+                    
+                    if (sir.getInstanceId() != null)
+                        instanceIds.add(sir.getInstanceId());
                 } else {
                     // Canceled or otherwise dead
                     for (Node node : Jenkins.getInstance().getNodes()) {
@@ -455,13 +457,15 @@ public abstract class EC2Cloud extends Cloud {
                     for (Tag tag : instanceTags) {
                         if (StringUtils.equals(tag.getKey(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE) && StringUtils.equals(tag.getValue(), getSlaveTypeTagValue(EC2_SLAVE_TYPE_SPOT, template.description)) && sir.getLaunchSpecification().getImageId().equals(template.getAmi())) {
                         
-                            if (instanceIds.contains(sir.getInstanceId()))
+                            if (sir.getInstanceId() != null && instanceIds.contains(sir.getInstanceId()))
                                 continue;
                 
                             LOGGER.log(Level.FINE, "Spot instance request found (from node): " + sir.getSpotInstanceRequestId() + " AMI: "
                                     + sir.getInstanceId() + " state: " + sir.getState() + " status: " + sir.getStatus());
                             n++;
-                            instanceIds.add(sir.getInstanceId());
+                            
+                            if (sir.getInstanceId() != null)
+                                instanceIds.add(sir.getInstanceId());
                         }
                     }
                 }

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -629,15 +629,17 @@ public abstract class EC2Cloud extends Cloud {
     /**
      * Connects to EC2 and returns {@link AmazonEC2}, which can then be used to communicate with EC2.
      */
-    public synchronized AmazonEC2 connect() throws AmazonClientException {
-        try {
-            if (connection == null) {
-                connection = connect(createCredentialsProvider(), getEc2EndpointUrl());
-            }
-            return connection;
-        } catch (IOException e) {
-            throw new AmazonClientException("Failed to retrieve the endpoint", e);
-        }
+    public AmazonEC2 connect() throws AmazonClientException {
+        synchronized (EC2Cloud.class) {
+            try {
+            	if (connection == null) {
+                    connection = connect(createCredentialsProvider(), getEc2EndpointUrl());
+            	}
+           	    return connection;
+        	} catch (IOException e) {
+           	    throw new AmazonClientException("Failed to retrieve the endpoint", e);
+       		}
+	}
     }
 
     /***

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -629,17 +629,15 @@ public abstract class EC2Cloud extends Cloud {
     /**
      * Connects to EC2 and returns {@link AmazonEC2}, which can then be used to communicate with EC2.
      */
-    public AmazonEC2 connect() throws AmazonClientException {
-        synchronized (EC2Cloud.class) {
-            try {
-            	if (connection == null) {
-                    connection = connect(createCredentialsProvider(), getEc2EndpointUrl());
-            	}
-           	    return connection;
-        	} catch (IOException e) {
-           	    throw new AmazonClientException("Failed to retrieve the endpoint", e);
-       		}
-	}
+    public synchronized AmazonEC2 connect() throws AmazonClientException {
+        try {
+            if (connection == null) {
+                connection = connect(createCredentialsProvider(), getEc2EndpointUrl());
+            }
+            return connection;
+        } catch (IOException e) {
+            throw new AmazonClientException("Failed to retrieve the endpoint", e);
+        }
     }
 
     /***


### PR DESCRIPTION
Spot instances that did not have associated instance IDs (e.g. just started or price too low) were not being counted properly. Added stricter checks to fix this behavior and still avoid double counting fulfilled requests.

Unrelated, we're still looking at the deadlock issue but it needs a bit more testing...
