### PR TITLE
workaround for JENKINS-37483; refactor slave counting to make it more efficient

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -171,6 +171,11 @@ public class EC2Computer extends SlaveComputer {
     private Instance _describeInstanceOnce() throws AmazonClientException {
         DescribeInstancesRequest request = new DescribeInstancesRequest();
         String instanceId = getNode().getInstanceId();
+        if (instanceId == null) {
+            String message = "Node has null instanceId: " + getNode();
+            LOGGER.log(Level.INFO, message);
+            throw new AmazonClientException(message);
+        }
         request.setInstanceIds(Collections.<String> singletonList(instanceId));
 
         List<Reservation> reservations = getCloud().connect().describeInstances(request).getReservations();


### PR DESCRIPTION
There's a few different ways to fix JENKINS-37483, I'm trying to do so without changing the overall locking behavior too much.

Included in the EC2Cloud changes are more fixes for correctly counting SIRs when they are in open/unfulfilled state.  Also a refactor for the slave count methods so that they only call ec2-describe-instances once.  We have hundreds of instances and calling this twice seems inefficient.

We are still testing this at scale.  

One open issue with the spot feature is that there's no support for canceling the SIR when the market moves ahead of your bid for hours - we end up with starvation in the queue and are forced to re-label pending jobs manually.
