### PR TITLE
Support native SSH client for interaction with slave.

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2Logger.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2Logger.java
@@ -1,0 +1,28 @@
+package hudson.plugins.ec2.ssh;
+
+import hudson.model.TaskListener;
+import hudson.plugins.ec2.EC2Cloud;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class EC2Logger {
+    private static final Logger LOGGER = Logger.getLogger(EC2UnixLauncher.class.getName());
+
+    private TaskListener listener;
+
+    public EC2Logger(TaskListener listener) {
+        this.listener = listener;
+    }
+
+    public void warn(String message) {
+        EC2Cloud.log(LOGGER, Level.WARNING, listener, message);
+    }
+
+    public void info(String message) {
+        EC2Cloud.log(LOGGER, Level.INFO, listener, message);
+    }
+
+    public void exception(String message, Throwable ex) {
+        EC2Cloud.log(LOGGER, Level.WARNING, listener, message, ex);
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -23,45 +23,20 @@
  */
 package hudson.plugins.ec2.ssh;
 
-import hudson.FilePath;
 import hudson.Util;
-import hudson.ProxyConfiguration;
 import hudson.model.Descriptor;
 import hudson.model.TaskListener;
-import hudson.plugins.ec2.EC2AbstractSlave;
-import hudson.plugins.ec2.EC2Cloud;
 import hudson.plugins.ec2.EC2ComputerLauncher;
 import hudson.plugins.ec2.EC2Computer;
 import hudson.plugins.ec2.SlaveTemplate;
-import hudson.remoting.Channel;
-import hudson.remoting.Channel.Listener;
-import hudson.slaves.CommandLauncher;
 import hudson.slaves.ComputerLauncher;
-
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.io.PrintStream;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import jenkins.model.Jenkins;
-
-import org.apache.commons.io.IOUtils;
-
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.KeyPair;
-import com.trilead.ssh2.Connection;
-import com.trilead.ssh2.HTTPProxyData;
-import com.trilead.ssh2.SCPClient;
-import com.trilead.ssh2.ServerHostKeyVerifier;
-import com.trilead.ssh2.Session;
 
 /**
  * {@link ComputerLauncher} that connects to a Unix slave on EC2 by using SSH.
@@ -69,8 +44,6 @@ import com.trilead.ssh2.Session;
  * @author Kohsuke Kawaguchi
  */
 public class EC2UnixLauncher extends EC2ComputerLauncher {
-
-    private static final Logger LOGGER = Logger.getLogger(EC2UnixLauncher.class.getName());
 
     private static final String BOOTSTRAP_AUTH_SLEEP_MS = "jenkins.ec2.bootstrapAuthSleepMs";
     private static final String BOOTSTRAP_AUTH_TRIES= "jenkins.ec2.bootstrapAuthTries";
@@ -87,28 +60,6 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
             bootstrapAuthTries = Integer.parseInt(prop);
     }
 
-    private final int FAILED = -1;
-
-    protected void log(Level level, EC2Computer computer, TaskListener listener, String message) {
-        EC2Cloud cloud = computer.getCloud();
-        if (cloud != null)
-            cloud.log(LOGGER, level, listener, message);
-    }
-
-    protected void logException(EC2Computer computer, TaskListener listener, String message, Throwable exception) {
-        EC2Cloud cloud = computer.getCloud();
-        if (cloud != null)
-            cloud.log(LOGGER, Level.WARNING, listener, message, exception);
-    }
-
-    protected void logInfo(EC2Computer computer, TaskListener listener, String message) {
-        log(Level.INFO, computer, listener, message);
-    }
-
-    protected void logWarning(EC2Computer computer, TaskListener listener, String message) {
-        log(Level.WARNING, computer, listener, message);
-    }
-
     protected String buildUpCommand(EC2Computer computer, String command) {
         if (!computer.getRemoteAdmin().equals("root")) {
             command = computer.getRootCommandPrefix() + " " + command;
@@ -119,89 +70,55 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
     @Override
     protected void launch(EC2Computer computer, TaskListener listener, Instance inst) throws IOException,
             AmazonClientException, InterruptedException {
-        final Connection bootstrapConn;
-        final Connection conn;
-        Connection cleanupConn = null; // java's code path analysis for final
-                                       // doesn't work that well.
-        boolean successful = false;
+        EC2Logger log = new EC2Logger(listener);
+
         PrintStream logger = listener.getLogger();
-        logInfo(computer, listener, "Launching instance: " + computer.getNode().getInstanceId());
+        log.info("Launching instance: " + computer.getNode().getInstanceId());
+
+        SshClient sshClient = null;
 
         try {
-            boolean isBootstrapped = bootstrap(computer, listener);
-            if (isBootstrapped) {
-                // connect fresh as ROOT
-                logInfo(computer, listener, "connect fresh as root");
-                cleanupConn = connectToSsh(computer, listener);
-                KeyPair key = computer.getCloud().getKeyPair();
-                if (!cleanupConn.authenticateWithPublicKey(computer.getRemoteAdmin(), key.getKeyMaterial().toCharArray(), "")) {
-                    logWarning(computer, listener, "Authentication failed");
-                    return; // failed to connect as root.
-                }
-            } else {
-                logWarning(computer, listener, "bootstrapresult failed");
-                return; // bootstrap closed for us.
-            }
-            conn = cleanupConn;
+            //this will internally call "connect() on the ssh and throw exception if we failed in the end
+            sshClient = createSshClient(computer, log);
 
-            SCPClient scp = conn.createSCPClient();
             String initScript = computer.getNode().initScript;
-            String tmpDir = (Util.fixEmptyAndTrim(computer.getNode().tmpDir) != null ? computer.getNode().tmpDir
-                    : "/tmp");
+            String tmpDir = (Util.fixEmptyAndTrim(computer.getNode().tmpDir) != null ?
+                    computer.getNode().tmpDir : "/tmp");
 
-            logInfo(computer, listener, "Creating tmp directory (" + tmpDir + ") if it does not exist");
-            conn.exec("mkdir -p " + tmpDir, logger);
+            log.info("Creating tmp directory (" + tmpDir + ") if it does not exist");
+            sshClient.run("mkdir -p " + tmpDir, logger);
 
             if (initScript != null && initScript.trim().length() > 0
-                    && conn.exec("test -e ~/.hudson-run-init", logger) != 0) {
-                logInfo(computer, listener, "Executing init script");
-                scp.put(initScript.getBytes("UTF-8"), "init.sh", tmpDir, "0700");
-                Session sess = conn.openSession();
-                sess.requestDumbPTY(); // so that the remote side bundles stdout
-                                       // and stderr
-                sess.execCommand(buildUpCommand(computer, tmpDir + "/init.sh"));
+                    && sshClient.run("test -e ~/.hudson-run-init", logger) != 0) {
+                log.info("Executing init script");
+                sshClient.put(initScript.getBytes("UTF-8"), "init.sh", tmpDir, "0700");
 
-                sess.getStdin().close(); // nothing to write here
-                sess.getStderr().close(); // we are not supposed to get anything
-                                          // from stderr
-                IOUtils.copy(sess.getStdout(), logger);
+                sshClient.run(buildUpCommand(computer, tmpDir + "/init.sh"), logger);
 
-                int exitStatus = waitCompletion(sess);
-                if (exitStatus != 0) {
-                    logWarning(computer, listener, "init script failed: exit code=" + exitStatus);
-                    return;
-                }
-                sess.close();
-
-                // Needs a tty to run sudo.
-                sess = conn.openSession();
-                sess.requestDumbPTY(); // so that the remote side bundles stdout
-                                       // and stderr
-                sess.execCommand(buildUpCommand(computer, "touch ~/.hudson-run-init"));
-                sess.close();
+                sshClient.run(buildUpCommand(computer, "touch ~/.hudson-run-init"), logger);
             }
 
             // TODO: parse the version number. maven-enforcer-plugin might help
-            logInfo(computer, listener, "Verifying that java exists");
-            if (conn.exec("java -fullversion", logger) != 0) {
-                logInfo(computer, listener, "Installing Java");
+            log.info("Verifying that java exists");
+            if (sshClient.run("java -fullversion", logger) != 0) {
+                log.info("Installing Java");
 
                 String jdk = "java1.6.0_12";
                 String path = "/hudson-ci/jdk/linux-i586/" + jdk + ".tgz";
 
                 URL url = computer.getCloud().buildPresignedURL(path);
-                if (conn.exec("wget -nv -O " + tmpDir + "/" + jdk + ".tgz '" + url + "'", logger) != 0) {
-                    logWarning(computer, listener, "Failed to download Java");
+                if (sshClient.run("wget -nv -O " + tmpDir + "/" + jdk + ".tgz '" + url + "'", logger) != 0) {
+                    log.warn("Failed to download Java");
                     return;
                 }
 
-                if (conn.exec(buildUpCommand(computer, "tar xz -C /usr -f " + tmpDir + "/" + jdk + ".tgz"), logger) != 0) {
-                    logWarning(computer, listener, "Failed to install Java");
+                if (sshClient.run(buildUpCommand(computer, "tar xz -C /usr -f " + tmpDir + "/" + jdk + ".tgz"), logger) != 0) {
+                    log.warn("Failed to install Java");
                     return;
                 }
 
-                if (conn.exec(buildUpCommand(computer, "ln -s /usr/" + jdk + "/bin/java /bin/java"), logger) != 0) {
-                    logWarning(computer, listener, "Failed to symlink Java");
+                if (sshClient.run(buildUpCommand(computer, "ln -s /usr/" + jdk + "/bin/java /bin/java"), logger) != 0) {
+                    log.warn("Failed to symlink Java");
                     return;
                 }
             }
@@ -210,112 +127,27 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
             // putting slave.jar as c:\tmp
             // bug in ec2-sshd?
 
-            logInfo(computer, listener, "Copying slave.jar");
-            scp.put(Jenkins.getInstance().getJnlpJars("slave.jar").readFully(), "slave.jar", tmpDir);
+            log.info("Copying slave.jar");
+            sshClient.put(Jenkins.getInstance().getJnlpJars("slave.jar").readFully(), "slave.jar", tmpDir, "0600");
 
             String jvmopts = computer.getNode().jvmopts;
             String launchString = "java " + (jvmopts != null ? jvmopts : "") + " -jar " + tmpDir + "/slave.jar";
 
-            SlaveTemplate slaveTemplate = computer.getSlaveTemplate();
-
-            if (slaveTemplate != null && slaveTemplate.isConnectBySSHProcess()) {
-                EC2AbstractSlave node = computer.getNode();
-                File identityKeyFile = createIdentityKeyFile(computer);
-
-                try {
-                    // Obviously the master must have an installed ssh client.
-                    String sshClientLaunchString = String.format("ssh -o StrictHostKeyChecking=no -i %s %s@%s -p %d %s", identityKeyFile.getAbsolutePath(), node.remoteAdmin, getEC2HostAddress(computer, inst), node.getSshPort(), launchString);
-
-                    logInfo(computer, listener, "Launching slave agent (via SSH client process): " + sshClientLaunchString);
-                    CommandLauncher commandLauncher = new CommandLauncher(sshClientLaunchString);
-                    commandLauncher.launch(computer, listener);
-                } finally {
-                    identityKeyFile.delete();
-                }
-            } else {
-                logInfo(computer, listener, "Launching slave agent (via Trilead SSH2 Connection): " + launchString);
-                final Session sess = conn.openSession();
-                sess.execCommand(launchString);
-                computer.setChannel(sess.getStdout(), sess.getStdin(), logger, new Listener() {
-                    @Override
-                    public void onClosed(Channel channel, IOException cause) {
-                        sess.close();
-                        conn.close();
-                    }
-                });
-            }
-
-            successful = true;
-        } finally {
-            if (cleanupConn != null && !successful)
-                cleanupConn.close();
-        }
-    }
-
-    private File createIdentityKeyFile(EC2Computer computer) throws IOException {
-        String privateKey = computer.getCloud().getPrivateKey().getPrivateKey();
-        File tempFile = File.createTempFile("ec2_", ".pem");
-
-        try {
-            FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
-            OutputStreamWriter writer = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8);
-            try {
-                writer.write(privateKey);
-                writer.flush();
-            } finally {
-                writer.close();
-                fileOutputStream.close();
-            }
-            FilePath filePath = new FilePath(tempFile);
-            filePath.chmod(0400); // octal file mask - readonly by owner
-            return tempFile;
+            sshClient.startCommandPipe(launchString, computer, listener);
         } catch (Exception e) {
-            tempFile.delete();
-            throw new IOException("Error creating temporary identity key file for connecting to EC2 slave.", e);
+            if (sshClient != null)
+                sshClient.close();
         }
     }
 
-    private boolean bootstrap(EC2Computer computer, TaskListener listener) throws IOException,
-            InterruptedException, AmazonClientException {
-        logInfo(computer, listener, "bootstrap()");
-        Connection bootstrapConn = null;
-        try {
-            int tries = bootstrapAuthTries;
-            boolean isAuthenticated = false;
-            logInfo(computer, listener, "Getting keypair...");
-            KeyPair key = computer.getCloud().getKeyPair();
-            logInfo(computer, listener, "Using key: " + key.getKeyName() + "\n" + key.getKeyFingerprint() + "\n"
-                    + key.getKeyMaterial().substring(0, 160));
-            while (tries-- > 0) {
-                logInfo(computer, listener, "Authenticating as " + computer.getRemoteAdmin());
-                try {
-                    bootstrapConn = connectToSsh(computer, listener);
-                    isAuthenticated = bootstrapConn.authenticateWithPublicKey(computer.getRemoteAdmin(), key.getKeyMaterial().toCharArray(), "");
-                } catch(IOException e) {
-                    logException(computer, listener, "Exception trying to authenticate", e);
-                    bootstrapConn.close();
-                }
-                if (isAuthenticated) {
-                    break;
-                }
-                logWarning(computer, listener, "Authentication failed. Trying again...");
-                Thread.sleep(bootstrapAuthSleepMs);
-            }
-            if (!isAuthenticated) {
-                logWarning(computer, listener, "Authentication failed");
-                return false;
-            }
-        } finally {
-            bootstrapConn.close();
-        }
-        return true;
-    }
-
-    private Connection connectToSsh(EC2Computer computer, TaskListener listener) throws AmazonClientException,
-            InterruptedException {
+    private SshClient createSshClient(EC2Computer computer, EC2Logger logger) throws AmazonClientException, InterruptedException {
         final long timeout = computer.getNode().getLaunchTimeoutInMillis();
         final long startTime = System.currentTimeMillis();
-        while (true) {
+        int tries = bootstrapAuthTries;
+
+        //note that we are redoing a lot on every iteration because many details (such as key info, etc)
+        // may not be available at the initial launch stages
+        while (tries-- > 0) {
             try {
                 long waitTime = System.currentTimeMillis() - startTime;
                 if (timeout > 0 && waitTime > timeout) {
@@ -327,47 +159,57 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 String host = getEC2HostAddress(computer, instance);
 
                 if ("0.0.0.0".equals(host)) {
-                    logWarning(computer, listener, "Invalid host 0.0.0.0, your host is most likely waiting for an ip address.");
+                    logger.warn("Invalid host 0.0.0.0, your host is most likely waiting for an ip address.");
                     throw new IOException("goto sleep");
                 }
 
                 int port = computer.getSshPort();
                 Integer slaveConnectTimeout = Integer.getInteger("jenkins.ec2.slaveConnectTimeout", 10000);
-                logInfo(computer, listener, "Connecting to " + host + " on port " + port + ", with timeout " + slaveConnectTimeout
-                        + ".");
-                Connection conn = new Connection(host, port);
-                ProxyConfiguration proxyConfig = Jenkins.getInstance().proxy;
-                Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(host);
-                if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
-                    InetSocketAddress address = (InetSocketAddress) proxy.address();
-                    HTTPProxyData proxyData = null;
-                    if (null != proxyConfig.getUserName()) {
-                        proxyData = new HTTPProxyData(address.getHostName(), address.getPort(), proxyConfig.getUserName(), proxyConfig.getPassword());
-                    } else {
-                        proxyData = new HTTPProxyData(address.getHostName(), address.getPort());
-                    }
-                    conn.setProxyData(proxyData);
-                    logInfo(computer, listener, "Using HTTP Proxy Configuration");
+                logger.info("Connecting to " + host + " on port " + port + ", with timeout "
+                        + slaveConnectTimeout + ". Left attempts="+tries+" time="+(timeout - waitTime));
+
+                logger.info("Getting keypair...");
+                KeyPair key = computer.getCloud().getKeyPair();
+                logger.info("Using key: " + key.getKeyName() + "\n" + key.getKeyFingerprint() + "\n"
+                        + key.getKeyMaterial().substring(0, 160));
+
+                SshClient ssh;
+                SlaveTemplate slaveTemplate = computer.getSlaveTemplate();
+
+                if (slaveTemplate != null && slaveTemplate.isConnectBySSHProcess()) {
+                    logger.info("Using system SSH client");
+                    ssh = new SystemSSHClient(
+                            logger,
+                            host,
+                            port,
+                            slaveConnectTimeout,
+                            computer.getRemoteAdmin(),
+                            computer.getCloud().getKeyPair().getKeyMaterial().toCharArray());
+                } else {
+                    logger.info("Using Trilead SSH client");
+                    ssh = new TrileadSshClient(
+                            logger,
+                            host,
+                            port,
+                            slaveConnectTimeout,
+                            computer.getRemoteAdmin(),
+                            computer.getCloud().getKeyPair().getKeyMaterial().toCharArray());
                 }
-                // currently OpenSolaris offers no way of verifying the host
-                // certificate, so just accept it blindly,
-                // hoping that no man-in-the-middle attack is going on.
-                conn.connect(new ServerHostKeyVerifier() {
-                    public boolean verifyServerHostKey(String hostname, int port, String serverHostKeyAlgorithm, byte[] serverHostKey)
-                            throws Exception {
-                        return true;
-                    }
-                }, slaveConnectTimeout, slaveConnectTimeout);
-                logInfo(computer, listener, "Connected via SSH.");
-                return conn; // successfully connected
+
+                ssh.connect();
+
+                return ssh; // successfully connected
             } catch (IOException e) {
                 // keep retrying until SSH comes up
-                logInfo(computer, listener, "Failed to connect via ssh: " + e.getMessage());
-                logInfo(computer, listener, "Waiting for SSH to come up. Sleeping 5.");
-                Thread.sleep(5000);
+                logger.info("Failed to connect via ssh: " + e.getMessage());
+                logger.info("Waiting for SSH to come up. Sleeping " + bootstrapAuthSleepMs + ".");
+                Thread.sleep(bootstrapAuthSleepMs);
             }
         }
+
+        return null;
     }
+
 
     private String getEC2HostAddress(EC2Computer computer, Instance inst) {
         if (computer.getNode().usePrivateDnsName) {
@@ -393,17 +235,6 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
         }
     }
 
-    private int waitCompletion(Session session) throws InterruptedException {
-        // I noticed that the exit status delivery often gets delayed. Wait up
-        // to 1 sec.
-        for (int i = 0; i < 10; i++) {
-            Integer r = session.getExitStatus();
-            if (r != null)
-                return r;
-            Thread.sleep(100);
-        }
-        return -1;
-    }
 
     @Override
     public Descriptor<ComputerLauncher> getDescriptor() {

--- a/src/main/java/hudson/plugins/ec2/ssh/SshClient.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/SshClient.java
@@ -1,0 +1,24 @@
+package hudson.plugins.ec2.ssh;
+
+import hudson.model.TaskListener;
+import hudson.plugins.ec2.EC2Computer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+interface SshClient {
+    void connect() throws IOException, InterruptedException;
+
+    //upload file to server over scp
+    void put(byte[] data, String remoteFileName, String remoteTargetDirectory, String mode)
+            throws IOException, InterruptedException;
+
+    //runs command on remote system (over ssh) and dumps stderr and stdout to given output stream
+    int run(String command, OutputStream output)
+            throws IOException, InterruptedException;
+
+    void startCommandPipe(String command, EC2Computer computer, TaskListener listener)
+            throws IOException, InterruptedException;
+
+    void close();
+}

--- a/src/main/java/hudson/plugins/ec2/ssh/SystemSSHClient.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/SystemSSHClient.java
@@ -1,0 +1,134 @@
+package hudson.plugins.ec2.ssh;
+
+import hudson.FilePath;
+import hudson.Util;
+import hudson.model.TaskListener;
+import hudson.plugins.ec2.EC2Computer;
+import hudson.slaves.CommandLauncher;
+import hudson.util.StreamCopyThread;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+
+class SystemSSHClient implements SshClient {
+    private String host;
+    private int port;
+    private int connectTimeout; //btw, we can pass it as timeout in ssh command too
+    private String user;
+    private File privateKeyFile;
+    private EC2Logger logger;
+
+    SystemSSHClient(EC2Logger logger, String host, int port, int connectTimeout,
+                           String user, char[] pemPrivateKey) throws IOException, InterruptedException {
+        this.host = host;
+        this.port = port;
+        this.connectTimeout = connectTimeout;
+        this.user = user;
+        this.logger = logger;
+        privateKeyFile = createIdentityKeyFile(pemPrivateKey);
+    }
+
+    @Override
+    public void connect() throws IOException, InterruptedException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        int r = run("hostname", bos);
+        logger.info("[native ssh] connect check result= " + r + " output=" + new String(bos.toByteArray()));
+        if (r != 0)
+            throw new IOException("[native ssh] Failed to connect due to [" +  new String(bos.toByteArray()) + "].");
+    }
+
+    @Override
+    public void put(byte[] data, String remoteFileName, String remoteTargetDirectory, String mode) throws IOException, InterruptedException {
+        File dataFile = File.createTempFile("ec2", "_data");
+
+        dataFile.delete();
+        dataFile.mkdirs();
+
+        File fullSrc = new File(dataFile, remoteFileName);
+
+        save(data, fullSrc);
+
+        String sshClientLaunchString = String.format("scp -o StrictHostKeyChecking=no -i %s -P %d %s %s@%s:%s",
+                privateKeyFile.getAbsolutePath(), port,
+                fullSrc.getAbsolutePath(),
+                user, host, remoteTargetDirectory);
+
+        logger.info("[native ssh] copy command: " + sshClientLaunchString);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+
+        int r = exec(sshClientLaunchString, bos);
+
+        logger.info("[native ssh] put exit code " + r + ", result: " + new String(bos.toByteArray()));
+
+        if (r != 0)
+            throw new IOException("Scp did not succeed. Reason [" + new String(bos.toByteArray()) + "]");
+    }
+
+    public void startCommandPipe(String command, EC2Computer computer, TaskListener listener)
+            throws IOException, InterruptedException {
+        // Obviously the master must have an installed ssh client.
+        String sshClientLaunchString = String.format("ssh -o StrictHostKeyChecking=no -i %s %s@%s -p %d %s",
+                privateKeyFile.getAbsolutePath(), user, host, port, command);
+
+        logger.info("[native ssh] Running " + sshClientLaunchString);
+        CommandLauncher commandLauncher = new CommandLauncher(sshClientLaunchString);
+        commandLauncher.launch(computer, listener);
+    }
+
+    private int exec(String command, OutputStream output) throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder(Util.tokenize(command));
+
+        Process proc = pb.start();
+
+        // capture error information from stderr. this will terminate itself
+        // when the process is killed.
+        new StreamCopyThread("[native ssh] stderr copier for remote cmd",
+                proc.getErrorStream(), output).start();
+
+        new StreamCopyThread("[native ssh] stdout copier for remote cmd",
+                proc.getInputStream(), output).start();
+
+        return proc.waitFor();
+    }
+
+    @Override
+    public int run(String command, OutputStream output) throws IOException, InterruptedException {
+        String sshClientLaunchString = String.format("ssh -o StrictHostKeyChecking=no -i %s %s@%s -p %d %s",
+                privateKeyFile.getAbsolutePath(), user, host, port, command);
+
+        logger.info("[native ssh] Trying " + sshClientLaunchString);
+
+        int r = exec(sshClientLaunchString, output);
+
+        logger.info("[native ssh] exit code " + r);
+
+        return r;
+    }
+
+    @Override
+    public void close() {
+        if (privateKeyFile != null) privateKeyFile.delete();
+    }
+
+    private void save(byte[] data, File tempFile) throws IOException, InterruptedException {
+        try(FileOutputStream fos = new FileOutputStream(tempFile)) {
+            fos.write(data);
+            fos.flush();
+        }
+
+        FilePath filePath = new FilePath(tempFile);
+        filePath.chmod(0400); // octal file mask - readonly by owner
+    }
+
+    private File createIdentityKeyFile(char[] privateKey) throws IOException, InterruptedException {
+        File tempFile = File.createTempFile("ec2_", ".pem");
+
+        try {
+            save(new String(privateKey).getBytes(StandardCharsets.UTF_8), tempFile);
+        } catch (Exception e) {
+            tempFile.delete();
+            throw new IOException("[native ssh] Error creating temporary identity key file.", e);
+        }
+        return tempFile;
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/ssh/TrileadSshClient.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/TrileadSshClient.java
@@ -1,0 +1,146 @@
+package hudson.plugins.ec2.ssh;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import com.trilead.ssh2.Connection;
+import com.trilead.ssh2.HTTPProxyData;
+import com.trilead.ssh2.SCPClient;
+import com.trilead.ssh2.ServerHostKeyVerifier;
+import com.trilead.ssh2.Session;
+import hudson.ProxyConfiguration;
+import hudson.model.TaskListener;
+import hudson.plugins.ec2.EC2Computer;
+import hudson.remoting.Channel;
+import jenkins.model.Jenkins;
+import org.apache.commons.io.IOUtils;
+
+class TrileadSshClient implements SshClient {
+    private String host;
+    private int port;
+    private int connectTimeout;
+    private String user;
+    private char[] privateKey;
+    private EC2Logger logger;
+
+    private Connection conn;
+
+    TrileadSshClient(EC2Logger logger, String host, int port, int connectTimeout,
+                            String user, char[] pemPrivateKey) {
+        this.host = host;
+        this.port = port;
+        this.connectTimeout = connectTimeout;
+        this.user = user;
+        this.privateKey = pemPrivateKey;
+        this.logger = logger;
+    }
+
+    @Override
+    public void connect() throws IOException, InterruptedException {
+        conn = new Connection(host, port);
+
+        ProxyConfiguration proxyConfig = Jenkins.getInstance().proxy;
+        Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(host);
+
+        if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
+            InetSocketAddress address = (InetSocketAddress) proxy.address();
+            HTTPProxyData proxyData;
+            if (proxyConfig != null && null != proxyConfig.getUserName()) {
+                proxyData = new HTTPProxyData(address.getHostName(), address.getPort(), proxyConfig.getUserName(), proxyConfig.getPassword());
+            } else {
+                proxyData = new HTTPProxyData(address.getHostName(), address.getPort());
+            }
+            conn.setProxyData(proxyData);
+            logger.info("[ssh] Using HTTP Proxy Configuration");
+        }
+
+        // currently OpenSolaris offers no way of verifying the host
+        // certificate, so just accept it blindly,
+        // hoping that no man-in-the-middle attack is going on.
+        conn.connect(new ServerHostKeyVerifier() {
+            public boolean verifyServerHostKey(String hostname, int port, String serverHostKeyAlgorithm, byte[] serverHostKey)
+                    throws Exception {
+                return true;
+            }
+        }, connectTimeout, connectTimeout);
+
+        if (!conn.authenticateWithPublicKey(user, privateKey, "")) {
+            logger.warn("[ssh] Authentication failed");
+            return; // failed to connect as root. - FIXME: shall throw exception!
+        }
+
+        logger.info("[ssh] Connected via SSH.");
+    }
+
+    @Override
+    public void put(byte[] data, String remoteFileName, String remoteTargetDirectory, String mode) throws IOException, InterruptedException {
+        SCPClient scp = new SCPClient(conn);
+
+        scp.put(data, remoteFileName, remoteTargetDirectory, mode);
+    }
+
+    @Override
+    public void startCommandPipe(String command, EC2Computer computer, TaskListener listener)
+            throws IOException, InterruptedException {
+        if (conn == null)
+            throw new IOException("[ssh] Not connected");
+
+        logger.info("[ssh] runAsync cmd="+command);
+
+        final Session sess = conn.openSession();
+        sess.execCommand(command);
+
+        computer.setChannel(sess.getStdout(), sess.getStdin(), listener, new Channel.Listener() {
+            @Override
+            public void onClosed(Channel channel, IOException cause) {
+                sess.close();
+                conn.close();
+            }
+        });
+    }
+
+    @Override
+    public int run(String command, OutputStream output) throws IOException, InterruptedException {
+        if (conn == null)
+            throw new IOException("Not connected");
+
+        Session sess = conn.openSession();
+        sess.requestDumbPTY(); // so that the remote side bundles stdout
+        // and stderr
+        sess.execCommand(command);
+
+        sess.getStdin().close(); // nothing to write here
+        sess.getStderr().close(); // we are not supposed to get anything
+        // from stderr
+        IOUtils.copy(sess.getStdout(), output);
+
+        int exitStatus = waitCompletion(sess);
+        if (exitStatus != 0) {
+            logger.warn("[ssh] init script failed: exit code=" + exitStatus);
+            return exitStatus;
+        }
+        sess.close();
+
+        return 0;
+    }
+
+    private int waitCompletion(Session session) throws InterruptedException {
+        // I noticed that the exit status delivery often gets delayed. Wait up to 1 sec.
+        for (int i = 0; i < 10; i++) {
+            Integer r = session.getExitStatus();
+            if (r != null)
+                return r;
+            Thread.sleep(100);
+        }
+        return -1;
+    }
+
+    @Override
+    public void close() {
+        if (conn != null) {
+            conn.close();
+            conn = null;
+        }
+    }
+}


### PR DESCRIPTION
This will allow chose to use of native ssh/scp to configure slave node. Helps to overcome limitations of java-based ssh client, e.g. launch slaves in different VPC and access them through jumphost (can be configured using system ssh config file)