### PR TITLE
Do not require the ssh key to exist on AWS

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -762,7 +762,7 @@ public abstract class EC2Cloud extends Cloud {
                     EC2PrivateKey pk = new EC2PrivateKey(privateKey);
                     if (pk.find(ec2) == null)
                         return FormValidation
-                                .error("The EC2 key pair private key isn't registered to this EC2 region (fingerprint is "
+                                .warning("The EC2 key pair private key isn't registered to this EC2 region (fingerprint is "
                                         + pk.getFingerprint() + ")");
                 }
 

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -763,7 +763,7 @@ public abstract class EC2Cloud extends Cloud {
                     if (pk.find(ec2) == null)
                         return FormValidation
                                 .warning("The EC2 key pair private key isn't registered to this EC2 region (fingerprint is "
-                                        + pk.getFingerprint() + ")");
+                                        + pk.getFingerprint() + "), this will fail unless your SSH public key is acquired via some other means");
                 }
 
                 return FormValidation.ok(Messages.EC2Cloud_Success());

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -515,8 +515,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             String userDataString = Base64.encodeBase64String(userData.getBytes(StandardCharsets.UTF_8));
             riRequest.setUserData(userDataString);
-            riRequest.setKeyName(keyPair.getKeyName());
-            diFilters.add(new Filter("key-name").withValues(keyPair.getKeyName()));
+
+            if(keyPair != null) {
+                riRequest.setKeyName(keyPair.getKeyName());
+                diFilters.add(new Filter("key-name").withValues(keyPair.getKeyName()));
+            }
+
             riRequest.setInstanceType(type.toString());
             diFilters.add(new Filter("instance-type").withValues(type.toString()));
 
@@ -859,10 +863,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     /**
      * Get a KeyPair from the configured information for the slave template
      */
-    private KeyPair getKeyPair(AmazonEC2 ec2) throws IOException, AmazonClientException {
+    private KeyPair getKeyPair(AmazonEC2 ec2) throws IOException {
         KeyPair keyPair = parent.getPrivateKey().find(ec2);
         if (keyPair == null) {
-            throw new AmazonClientException("No matching keypair found on EC2. Is the EC2 private key a valid one?");
+            LOGGER.log(Level.WARNING, "No matching keypair found on EC2. Is the EC2 private key a valid one?");
         }
         return keyPair;
     }

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -866,7 +866,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     private KeyPair getKeyPair(AmazonEC2 ec2) throws IOException {
         KeyPair keyPair = parent.getPrivateKey().find(ec2);
         if (keyPair == null) {
-            LOGGER.log(Level.WARNING, "No matching keypair found on EC2. Is the EC2 private key a valid one?");
+            LOGGER.log(Level.INFO, "No matching keypair found on EC2. Is public key acquired via some other means?");
         }
         return keyPair;
     }

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -133,8 +133,8 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 // connect fresh as ROOT
                 logInfo(computer, listener, "connect fresh as root");
                 cleanupConn = connectToSsh(computer, listener);
-                KeyPair key = computer.getCloud().getKeyPair();
-                if (!cleanupConn.authenticateWithPublicKey(computer.getRemoteAdmin(), key.getKeyMaterial().toCharArray(), "")) {
+                String key = computer.getCloud().getPrivateKey().getPrivateKey();
+                if (!cleanupConn.authenticateWithPublicKey(computer.getRemoteAdmin(), key.toCharArray(), "")) {
                     logWarning(computer, listener, "Authentication failed");
                     return; // failed to connect as root.
                 }
@@ -283,14 +283,13 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
             int tries = bootstrapAuthTries;
             boolean isAuthenticated = false;
             logInfo(computer, listener, "Getting keypair...");
-            KeyPair key = computer.getCloud().getKeyPair();
-            logInfo(computer, listener, "Using key: " + key.getKeyName() + "\n" + key.getKeyFingerprint() + "\n"
-                    + key.getKeyMaterial().substring(0, 160));
+            String keyPair = computer.getCloud().getPrivateKey().getPrivateKey();
+
             while (tries-- > 0) {
                 logInfo(computer, listener, "Authenticating as " + computer.getRemoteAdmin());
                 try {
                     bootstrapConn = connectToSsh(computer, listener);
-                    isAuthenticated = bootstrapConn.authenticateWithPublicKey(computer.getRemoteAdmin(), key.getKeyMaterial().toCharArray(), "");
+                    isAuthenticated = bootstrapConn.authenticateWithPublicKey(computer.getRemoteAdmin(), keyPair.toCharArray(), "");
                 } catch(IOException e) {
                     logException(computer, listener, "Exception trying to authenticate", e);
                     bootstrapConn.close();


### PR DESCRIPTION
In some cases you may not want a key to exist within AWS.

Examples:

  - The public key is prebaked on your image
  - Your slave is actually a docker container running on an instance and started by user-data

This PR forces the plugin to pull the ssh private key from the private key field rather than enforcing the requirement to have a key on EC2.
 
Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>