### PR TITLE
JENKINS-41824 Meaningful exception message if the EC2 KeyPair private key is missing/empty

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2PrivateKey.java
+++ b/src/main/java/hudson/plugins/ec2/EC2PrivateKey.java
@@ -56,13 +56,17 @@ public class EC2PrivateKey {
 
     /**
      * Obtains the fingerprint of the key in the "ab:cd:ef:...:12" format.
-     */
-    /**
-     * Obtains the fingerprint of the key in the "ab:cd:ef:...:12" format.
+     *
+     * @throw IOException if the underlying private key is invalid: empty or password protected
+     *    (password protected private keys are not yet supported)
      */
     public String getFingerprint() throws IOException {
+        String pemData = privateKey.getPlainText();
+        if (pemData == null || pemData.isEmpty()) {
+            throw new IOException("This private key cannot be empty");
+        }
         try {
-            return PEMEncodable.decode(privateKey.getPlainText()).getPrivateKeyFingerprint();
+            return PEMEncodable.decode(pemData).getPrivateKeyFingerprint();
         } catch (UnrecoverableKeyException e) {
             throw new IOException("This private key is password protected, which isn't supported yet");
         }

--- a/src/test/java/hudson/plugins/ec2/EC2PrivateKeyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2PrivateKeyTest.java
@@ -25,6 +25,7 @@ package hudson.plugins.ec2;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
@@ -93,5 +94,12 @@ public class EC2PrivateKeyTest {
                 + "9ontJin0nlHPk+AOmV8xt3yYD+wPAJy5MjUco7tS4Ix6bmvxcpZi2ZcHT1GwkiIzgKWE\n"
                 + "-----END RSA PRIVATE KEY-----");
         assertEquals("e3:cc:f6:5d:0b:bb:8b:ca:32:12:fd:70:98:57:c0:21", k.getPublicFingerprint());
+    }
+
+    @Issue("JENKINS-41824")
+    @Test(expected = IOException.class)
+    public void testEmptyPrivateKey() throws Exception {
+        EC2PrivateKey k = new EC2PrivateKey("");
+        k.getFingerprint();
     }
 }


### PR DESCRIPTION
[JENKINS-41824](https://issues.jenkins-ci.org/browse/JENKINS-41824) Meaningful exception message if the EC2 KeyPair private key is missing/empty:  `IOException("This private key cannot be empty")` instead of `NullPointerException()