### PR TITLE
[JENKINS-43677] Update AWS SDK to 1.11.119

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ THE SOFTWARE.
     </parent>
 
     <artifactId>ec2</artifactId>
-    <version>1.37-SNAPSHOT</version>
+    <version>1.38-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Amazon EC2 plugin</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Plugin</url>
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.37</version>
+            <version>1.11.119</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
To add I3 instances added in 1.11.96
Waiting for https://github.com/jenkinsci/aws-java-sdk-plugin/pull/11 to work