### PR TITLE
Tag on-demand instances at creation using latest SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.37</version>
+            <version>1.11.119</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -577,17 +577,18 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 if (StringUtils.isNotBlank(getIamInstanceProfile())) {
                     riRequest.setIamInstanceProfile(new IamInstanceProfileSpecification().withArn(getIamInstanceProfile()));
                 }
+
+                if (instTags != null) {
+                    TagSpecification tagSpecification = new TagSpecification();
+                    tagSpecification.setResourceType(ResourceType.Instance);
+                    tagSpecification.setTags(instTags);
+                    Set<TagSpecification> tagSpecifications =  Collections.singleton(tagSpecification);
+                    riRequest.setTagSpecifications(tagSpecifications);
+                }
+
                 // Have to create a new instance
                 Instance inst = ec2.runInstances(riRequest).getReservation().getInstances().get(0);
 
-                /* Now that we have our instance, we can set tags on it */
-                if (instTags != null) {
-                    updateRemoteTags(ec2, instTags, "InvalidInstanceID.NotFound", inst.getInstanceId());
-
-                    // That was a remote request - we should also update our
-                    // local instance data.
-                    inst.setTags(instTags);
-                }
                 logProvisionInfo(logger, "No existing instance found - created new instance: " + inst);
                 return newOndemandSlave(inst);
             }
@@ -618,9 +619,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         } catch (FormException e) {
             throw new AssertionError(e); // we should have discovered all
                                         // configuration issues upfront
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
When creating on-demand instances, create tags in the same runInstances operation.
Allows to give Jenkins a restrictive IAM Role (ie. only allowed to manage instances with a given tag value) and still be able to run instances.