### PR TITLE
[JENKINS-44560] Provision AWS instance from within a pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,40 @@ THE SOFTWARE.
             <artifactId>httpclient</artifactId>
             <version>4.5.2</version>
         </dependency>
+        <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-cps</artifactId>
+                <version>2.25</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <classifier>tests</classifier>
+            <version>2.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <version>2.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -549,19 +549,21 @@ public abstract class EC2Cloud extends Cloud {
                 if (slave == null)
                     break;
                 LOGGER.log(Level.INFO, String.format("We have now %s computers", Jenkins.getInstance().getComputers().length));
-                Jenkins.getInstance().addNode(slave);
-                LOGGER.log(Level.INFO, String.format("Added node named: %s, We have now %s computers", slave.getNodeName(), Jenkins.getInstance().getComputers().length));
-                r.add(new PlannedNode(t.getDisplayName(), Computer.threadPoolForRemoting.submit(new Callable<Node>() {
+                if (!(t.isNode())) {
+                    Jenkins.getInstance().addNode(slave);
+                    LOGGER.log(Level.INFO, String.format("Added node named: %s, We have now %s computers", slave.getNodeName(), Jenkins.getInstance().getComputers().length));
+                    r.add(new PlannedNode(t.getDisplayName(), Computer.threadPoolForRemoting.submit(new Callable<Node>() {
 
-                    public Node call() throws Exception {
-                        long startTime = System.currentTimeMillis(); // fetch starting time
-                        while ((System.currentTimeMillis() - startTime) < slave.launchTimeout * 1000) {
+                        public Node call() throws Exception {
+                            long startTime = System.currentTimeMillis(); // fetch starting time
+                            while ((System.currentTimeMillis() - startTime) < slave.launchTimeout * 1000) {
+                                return tryToCallSlave(slave, t);
+                            }
+                            LOGGER.log(Level.WARNING, "Expected - Instance - failed to connect within launch timeout");
                             return tryToCallSlave(slave, t);
                         }
-                        LOGGER.log(Level.WARNING, "Expected - Instance - failed to connect within launch timeout");
-                        return tryToCallSlave(slave, t);
-                    }
-                }), t.getNumExecutors()));
+                    }), t.getNumExecutors()));
+                }
 
                 excessWorkload -= t.getNumExecutors();
             }

--- a/src/main/java/hudson/plugins/ec2/EC2Step.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Step.java
@@ -1,0 +1,176 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.ec2;
+
+import com.amazonaws.services.ec2.model.Instance;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.TaskListener;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.Cloud;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.steps.*;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.util.*;
+
+/**
+ * Returns the instance provisioned.
+ *
+ * Used like:
+ *
+ * <pre>
+ * node {
+ *     def x = ec2 cloud: 'myCloud', template: 'aws-CentOS-7'
+ * }
+ * </pre>
+ *
+ * @author Alicia Doblas
+ */
+public class EC2Step extends Step {
+
+    private String cloud;
+    private String template;
+
+    @DataBoundConstructor
+    public EC2Step(String cloud, String template) {
+        this.cloud = cloud;
+        this.template = template;
+    }
+    public String getCloud() {
+        return cloud;
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new EC2Step.Execution( this, context);
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "ec2";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Cloud template provisioning";
+        }
+
+
+        public ListBoxModel doFillCloudItems() {
+            ListBoxModel r = new ListBoxModel();
+            r.add("", "");
+            Jenkins.CloudList clouds = jenkins.model.Jenkins.getActiveInstance().clouds;
+            for (Cloud cList : clouds) {
+                if (cList instanceof AmazonEC2Cloud) {
+                    r.add(cList.getDisplayName(), cList.getDisplayName());
+                }
+            }
+            return r;
+        }
+
+        public ListBoxModel doFillTemplateItems(@QueryParameter String cloud) {
+            cloud = Util.fixEmpty(cloud);
+            ListBoxModel r = new ListBoxModel();
+            for (Cloud cList : jenkins.model.Jenkins.getActiveInstance().clouds) {
+                if (cList.getDisplayName().equals(cloud)) {
+                    List<SlaveTemplate> templates = ((AmazonEC2Cloud) cList).getTemplates();
+                    for (SlaveTemplate template : templates) {
+                        for (String labelList : template.labels.split(" ")) {
+                            r.add(labelList + "  (AMI: " + template.getAmi() + ", REGION: " + ((AmazonEC2Cloud) cList).getRegion() + ", TYPE: " + template.type.name() + ")", labelList);
+                        }
+                    }
+                }
+            }
+            return r;
+        }
+
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.singleton(TaskListener.class);
+        }
+
+    }
+
+    public static class Execution extends SynchronousNonBlockingStepExecution<Instance> {
+        private final String cloud;
+        private final String template;
+
+
+        Execution(EC2Step step, StepContext context) {
+            super(context);
+            this.cloud = step.cloud;
+            this.template = step.template;
+        }
+
+        @Override
+        protected Instance run() throws Exception {
+            Cloud cl = getByDisplayName(jenkins.model.Jenkins.getActiveInstance().clouds, this.cloud);
+            if (cl instanceof AmazonEC2Cloud) {
+                SlaveTemplate t;
+                t = ((AmazonEC2Cloud) cl).getTemplate(this.template);
+                if (t != null) {
+                    t.setNode(false);
+                    LabelAtom lbl = new LabelAtom(this.template);
+                    SlaveTemplate.ProvisionOptions universe = SlaveTemplate.ProvisionOptions.ALLOW_CREATE;
+                    EnumSet<SlaveTemplate.ProvisionOptions> opt = EnumSet.noneOf(SlaveTemplate.ProvisionOptions.class);
+                    opt.add(universe);
+
+                    EC2AbstractSlave instance = t.provision(TaskListener.NULL, lbl, opt);
+                    Instance myInstance = EC2AbstractSlave.getInstance(instance.getInstanceId(), instance.getCloud());
+                    return myInstance;
+                } else {
+                    throw new IllegalArgumentException("Error in AWS Cloud. Please review AWS template defined in Jenkins configuration.");
+                }
+            } else {
+                throw new IllegalArgumentException("Error in AWS Cloud. Please review EC2 settings in Jenkins configuration.");
+            }
+        }
+
+        public Cloud getByDisplayName(Jenkins.CloudList clouds, String name) {
+            Iterator i$ = clouds.iterator();
+            Cloud c;
+            c = (Cloud) i$.next();
+
+            while (!c.getDisplayName().equals(name)) {
+                if (!i$.hasNext()) {
+                    return null;
+                }
+                c = (Cloud) i$.next();
+            }
+            return c;
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -118,13 +118,15 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public final boolean useDedicatedTenancy;
 
-    public AMITypeData amiType;
+    public transient AMITypeData amiType;
 
     public int launchTimeout;
 
     public boolean connectBySSHProcess;
 
     public final boolean connectUsingPublicIp;
+
+    private boolean node = true;
 
     private transient/* almost final */Set<LabelAtom> labelSet;
 
@@ -372,7 +374,16 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return iamInstanceProfile;
     }
 
-    enum ProvisionOptions { ALLOW_CREATE, FORCE_CREATE }
+    public void setNode(Boolean node) {
+        this.node = node;
+    }
+
+    public Boolean isNode() {
+        return this.node;
+    }
+
+
+    public enum ProvisionOptions { ALLOW_CREATE, FORCE_CREATE }
 
     /**
      * Provisions a new EC2 slave or starts a previously stopped on-demand instance.

--- a/src/main/resources/hudson/plugins/ec2/EC2Step/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Step/config.jelly
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2014 Jesse Glick.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="cloud" title="Amazon EC2 cloud name">
+        <f:select/>
+    </f:entry>
+    <f:entry field="template" title="Template name">
+        <f:select/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/ec2/EC2Step/help.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Step/help.html
@@ -1,0 +1,3 @@
+<div>
+    Creates an <code>AWS Instance</code> object, from an already globally defined cloud name and label without registering it as a Jenkins agent.
+</div>

--- a/src/test/java/hudson/plugins/ec2/EC2StepTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2StepTest.java
@@ -1,0 +1,115 @@
+package hudson.plugins.ec2;
+
+
+import hudson.model.Label;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.plugins.ec2.util.PluginTestRule;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Alicia Doblas
+ */
+@PowerMockIgnore({"javax.crypto.*", "org.hamcrest.*", "javax.net.ssl.*"})
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({EC2AbstractSlave.class, SlaveTemplate.class})
+public class EC2StepTest {
+    @Rule
+    public PluginTestRule r = new PluginTestRule();
+
+    @Mock
+    private AmazonEC2Cloud cl;
+
+    @Mock
+    private SlaveTemplate st;
+
+    @Mock
+    private EC2AbstractSlave instance;
+
+    @Before
+    public void setup () throws Exception {
+        List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
+        templates.add(st);
+
+        when(cl.getCloudName()).thenReturn("myCloud");
+        when(cl.getDisplayName()).thenReturn("myCloud");
+        when(cl.getTemplates()).thenReturn(templates);
+        when(cl.getTemplate(anyString())).thenReturn(st);
+        r.addCloud(cl);
+    }
+
+
+    @Test
+    public void bootInstance() throws Exception {
+
+        when(st.provision(any(TaskListener.class),any(Label.class),any(EnumSet.class))).thenReturn(instance);
+
+        WorkflowJob boot = r.jenkins.createProject(WorkflowJob.class, "EC2Test");
+        boot.setDefinition(new CpsFlowDefinition(
+                " node('master') {\n" +
+                        "    def X = ec2 cloud: 'myCloud', template: 'aws-CentOS-7'\n" +
+                        "}" , true));
+        WorkflowRun b = r.assertBuildStatusSuccess(boot.scheduleBuild2(0));
+        r.assertLogContains("SUCCESS", b);
+    }
+
+    @Test
+    public void boot_noCloud() throws Exception {
+
+        when(st.provision(any(TaskListener.class),any(Label.class),any(EnumSet.class))).thenReturn(instance);
+
+        WorkflowJob boot = r.jenkins.createProject(WorkflowJob.class, "EC2Test");
+        boot.setDefinition(new CpsFlowDefinition(
+                " node('master') {\n" +
+                        "    def X = ec2 cloud: 'dummyCloud', template: 'aws-CentOS-7'\n" +
+                        "    X.boot()\n" +
+                        "}" , true));
+        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, boot.scheduleBuild2(0).get());
+        r.assertLogContains("Error in AWS Cloud. Please review EC2 settings in Jenkins configuration.", b);
+        r.assertLogContains("FAILURE", b);
+    }
+
+
+    @Test
+    public void boot_noTemplate() throws Exception {
+
+        when(cl.getTemplate(anyString())).thenReturn(null);
+        when(st.provision(any(TaskListener.class),any(Label.class),any(EnumSet.class))).thenReturn(instance);
+
+        WorkflowJob boot = r.jenkins.createProject(WorkflowJob.class, "EC2Test");
+        boot.setDefinition(new CpsFlowDefinition(
+                " node('master') {\n" +
+                        "    def X = ec2 cloud: 'myCloud', template: 'dummyTemplate'\n" +
+                        "    X.boot()\n" +
+                        "}" , true));
+        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, boot.scheduleBuild2(0).get());
+        r.assertLogContains("Error in AWS Cloud. Please review AWS template defined in Jenkins configuration.", b);
+        r.assertLogContains("FAILURE", b);
+    }
+
+    @After
+    public void teardown () {
+        r.jenkins.clouds.clear();
+    }
+
+
+}

--- a/src/test/java/hudson/plugins/ec2/util/PluginTestRule.java
+++ b/src/test/java/hudson/plugins/ec2/util/PluginTestRule.java
@@ -1,0 +1,15 @@
+package hudson.plugins.ec2.util;
+
+import hudson.plugins.ec2.AmazonEC2Cloud;
+import hudson.plugins.ec2.SlaveTemplate;
+import hudson.slaves.Cloud;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.List;
+
+public class PluginTestRule extends JenkinsRule {
+
+    public void addCloud (AmazonEC2Cloud cl) {
+        jenkins.clouds.add(cl);
+    }
+}


### PR DESCRIPTION
Jenkins vsphere plugin allows to invoke some methods to the backend API, as noted on https://github.com/jenkinsci/vsphere-cloud-plugin/blob/master/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java

To enable aws provisioning (and avoid mantaining a Jenkins agent via the node step), a modification over https://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Plugin is needed. This could be implemented via a new pipeline step such as 



`ec2 cloud: 'AWS', template: 'aws-CentOS-7'
`