### PR TITLE
[FIXED JENKINS-40223] Avoid NPE when ssh connection fails and terminate agents under any Exception

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
@@ -125,14 +125,18 @@ public abstract class EC2ComputerLauncher extends ComputerLauncher {
             if (slaveComputer.getNode() instanceof  EC2AbstractSlave) {
                 LOGGER.log(Level.FINE, String.format("Terminating the ec2 agent %s due a problem launching or connecting to it", slaveComputer.getName()), e);
                 EC2AbstractSlave ec2AbstractSlave = (EC2AbstractSlave) slaveComputer.getNode();
-                ec2AbstractSlave.terminate();
+                if (ec2AbstractSlave != null) {
+                    ec2AbstractSlave.terminate();
+                }
             }
         } catch (IOException e) {
             e.printStackTrace(listener.error(e.getMessage()));
             if (slaveComputer.getNode() instanceof  EC2AbstractSlave) {
                 LOGGER.log(Level.FINE, String.format("Terminating the ec2 agent %s due a problem launching or connecting to it", slaveComputer.getName()), e);
                 EC2AbstractSlave ec2AbstractSlave = (EC2AbstractSlave) slaveComputer.getNode();
-                ec2AbstractSlave.terminate();
+                if (ec2AbstractSlave != null) {
+                    ec2AbstractSlave.terminate();
+                }
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -140,7 +144,9 @@ public abstract class EC2ComputerLauncher extends ComputerLauncher {
             if (slaveComputer.getNode() instanceof  EC2AbstractSlave) {
                 LOGGER.log(Level.FINE, String.format("Terminating the ec2 agent %s due a problem launching or connecting to it", slaveComputer.getName()), e);
                 EC2AbstractSlave ec2AbstractSlave = (EC2AbstractSlave) slaveComputer.getNode();
-                ec2AbstractSlave.terminate();
+                if (ec2AbstractSlave != null) {
+                    ec2AbstractSlave.terminate();
+                }
             }
         }
 

--- a/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
@@ -122,11 +122,26 @@ public abstract class EC2ComputerLauncher extends ComputerLauncher {
             launch(computer, listener, computer.describeInstance());
         } catch (AmazonClientException e) {
             e.printStackTrace(listener.error(e.getMessage()));
+            if (slaveComputer.getNode() instanceof  EC2AbstractSlave) {
+                LOGGER.log(Level.FINE, String.format("Terminating the ec2 agent %s due a problem launching or connecting to it", slaveComputer.getName()), e);
+                EC2AbstractSlave ec2AbstractSlave = (EC2AbstractSlave) slaveComputer.getNode();
+                ec2AbstractSlave.terminate();
+            }
         } catch (IOException e) {
             e.printStackTrace(listener.error(e.getMessage()));
+            if (slaveComputer.getNode() instanceof  EC2AbstractSlave) {
+                LOGGER.log(Level.FINE, String.format("Terminating the ec2 agent %s due a problem launching or connecting to it", slaveComputer.getName()), e);
+                EC2AbstractSlave ec2AbstractSlave = (EC2AbstractSlave) slaveComputer.getNode();
+                ec2AbstractSlave.terminate();
+            }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             e.printStackTrace(listener.error(e.getMessage()));
+            if (slaveComputer.getNode() instanceof  EC2AbstractSlave) {
+                LOGGER.log(Level.FINE, String.format("Terminating the ec2 agent %s due a problem launching or connecting to it", slaveComputer.getName()), e);
+                EC2AbstractSlave ec2AbstractSlave = (EC2AbstractSlave) slaveComputer.getNode();
+                ec2AbstractSlave.terminate();
+            }
         }
 
     }

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -306,7 +306,9 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 return false;
             }
         } finally {
-            bootstrapConn.close();
+            if (bootstrapConn != null) {
+                bootstrapConn.close();
+            }
         }
         return true;
     }


### PR DESCRIPTION
NPE coming from [JENKINS-40223 ](https://issues.jenkins-ci.org/browse/JENKINS-40223) fixed

```
INFO: Connecting to ec2-xxx.eu-west-1.compute.amazonaws.com on port 22, with timeout 10000.
Dec 05, 2016 3:16:04 PM null
INFO: Failed to connect via ssh: The kexTimeout (10000 ms) expired.
Dec 05, 2016 3:16:04 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
ERROR: Unexpected error in launching an agent. This is probably a bug in Jenkins
java.lang.NullPointerException
	at hudson.plugins.ec2.ssh.EC2UnixLauncher.bootstrap(EC2UnixLauncher.java:309)
	at hudson.plugins.ec2.ssh.EC2UnixLauncher.launch(EC2UnixLauncher.java:131)
	at hudson.plugins.ec2.EC2ComputerLauncher.launch(EC2ComputerLauncher.java:122)
	at hudson.slaves.SlaveComputer$1.call(SlaveComputer.java:261)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

Also, I added an agent termination in case there was a problem launching the agent. This part requires a review from the maintainer/s since I am not sure if this will have a bad side effect.