### PR TITLE
update minutes remaining in billing period log entry

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -131,7 +131,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
                 if (freeSecondsLeft <= TimeUnit.MINUTES.toSeconds(Math.abs(idleTerminationMinutes))) {
                     LOGGER.info("Idle timeout of " + computer.getName() + " after "
                             + TimeUnit2.MILLISECONDS.toMinutes(idleMilliseconds) + " idle minutes, with "
-                            + TimeUnit2.MILLISECONDS.toMinutes(freeSecondsLeft)
+                            + TimeUnit2.SECONDS.toMinutes(freeSecondsLeft)
                             + " minutes remaining in billing period");
                     computer.getNode().idleTimeout();
                 }


### PR DESCRIPTION
The "minutes remaining in billing period" log entry was converting milliseconds to minutes instead of seconds to minutes.  The input was being passed in as seconds. 