### PR TITLE
[JENKINS-25832] Launch multiple slaves in parallel for jobs with same node label

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Step.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Step.java
@@ -147,7 +147,7 @@ public class EC2Step extends Step {
                     EnumSet<SlaveTemplate.ProvisionOptions> opt = EnumSet.noneOf(SlaveTemplate.ProvisionOptions.class);
                     opt.add(universe);
 
-                    EC2AbstractSlave instance = t.provision(TaskListener.NULL, lbl, opt);
+                    EC2AbstractSlave instance = t.provision(TaskListener.NULL, lbl, opt, null);
                     Instance myInstance = EC2AbstractSlave.getInstance(instance.getInstanceId(), instance.getCloud());
                     return myInstance;
                 } else {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -445,6 +445,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 	for (String launched : alreadyLaunched) {
                 		if (existingInstance.getInstanceId().equals(launched)) {
                 			logProvision(logger, " false - Node already launched in this same iteration");
+                			return false;
                 		}
                 	}
                 	

--- a/src/test/java/hudson/plugins/ec2/EC2StepTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2StepTest.java
@@ -61,7 +61,7 @@ public class EC2StepTest {
     @Test
     public void bootInstance() throws Exception {
 
-        when(st.provision(any(TaskListener.class),any(Label.class),any(EnumSet.class))).thenReturn(instance);
+        when(st.provision(any(TaskListener.class),any(Label.class),any(EnumSet.class),any(List.class))).thenReturn(instance);
 
         WorkflowJob boot = r.jenkins.createProject(WorkflowJob.class, "EC2Test");
         boot.setDefinition(new CpsFlowDefinition(
@@ -75,7 +75,7 @@ public class EC2StepTest {
     @Test
     public void boot_noCloud() throws Exception {
 
-        when(st.provision(any(TaskListener.class),any(Label.class),any(EnumSet.class))).thenReturn(instance);
+        when(st.provision(any(TaskListener.class),any(Label.class),any(EnumSet.class),any(List.class))).thenReturn(instance);
 
         WorkflowJob boot = r.jenkins.createProject(WorkflowJob.class, "EC2Test");
         boot.setDefinition(new CpsFlowDefinition(
@@ -93,7 +93,7 @@ public class EC2StepTest {
     public void boot_noTemplate() throws Exception {
 
         when(cl.getTemplate(anyString())).thenReturn(null);
-        when(st.provision(any(TaskListener.class),any(Label.class),any(EnumSet.class))).thenReturn(instance);
+        when(st.provision(any(TaskListener.class),any(Label.class),any(EnumSet.class),any(List.class))).thenReturn(instance);
 
         WorkflowJob boot = r.jenkins.createProject(WorkflowJob.class, "EC2Test");
         boot.setDefinition(new CpsFlowDefinition(


### PR DESCRIPTION
When trying to provision a number of nodes for an excess workload greater than 1, when the plugin was checking if a new node was needed for the second and successive iterations, it was considering that no new instances were needed because there were nodes already starting. 

Added a list with the instances already considered in the excess workload loop, so they are no longer considered as usable to satisfy the excess workload.