### PR TITLE
Update from .119 to .226

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.119</version>
+            <version>1.11.226</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.249</version>
+            <version>1.11.248</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.226</version>
+            <version>1.11.249</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -199,6 +199,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 7;
         case C4Large:
             return 7;
+        case C5Large:
+            return 7;
         case M1Xlarge:
             return 8;
         case M22xlarge:
@@ -210,6 +212,8 @@ public abstract class EC2AbstractSlave extends Slave {
         case C3Xlarge:
             return 14;
         case C4Xlarge:
+            return 14;
+        case C5Xlarge:
             return 14;
         case C1Xlarge:
             return 20;
@@ -225,6 +229,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 28;
         case C42xlarge:
             return 28;
+        case C52xlarge:
+            return 28;
         case Cc14xlarge:
             return 33;
         case Cg14xlarge:
@@ -237,6 +243,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 55;
         case C44xlarge:
             return 55;
+        case C54xlarge:
+            return 55;
         case M44xlarge:
             return 55;
         case Cc28xlarge:
@@ -247,8 +255,12 @@ public abstract class EC2AbstractSlave extends Slave {
             return 108;
         case C48xlarge:
             return 108;
+        case C59xlarge:
+            return 108;
         case M410xlarge:
             return 120;
+        case C518xlarge:
+            return 216;
             // We don't have a suggestion, but we don't want to fail completely
             // surely?
         default:

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -191,6 +191,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 4;
         case M4Large:
             return 4;
+        case M5Large:
+            return 4;
         case C1Medium:
             return 5;
         case M2Xlarge:
@@ -209,6 +211,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 13;
         case M4Xlarge:
             return 13;
+        case M5Xlarge:
+            return 13;
         case C3Xlarge:
             return 14;
         case C4Xlarge:
@@ -222,6 +226,8 @@ public abstract class EC2AbstractSlave extends Slave {
         case M32xlarge:
             return 26;
         case M42xlarge:
+            return 26;
+        case M52xlarge:
             return 26;
         case G22xlarge:
             return 26;
@@ -247,6 +253,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 55;
         case M44xlarge:
             return 55;
+        case M54xlarge:
+            return 55;
         case Cc28xlarge:
             return 88;
         case Cr18xlarge:
@@ -259,8 +267,12 @@ public abstract class EC2AbstractSlave extends Slave {
             return 108;
         case M410xlarge:
             return 120;
+        case M512xlarge:
+            return 120;
         case C518xlarge:
             return 216;
+        case M524xlarge:
+            return 240;
             // We don't have a suggestion, but we don't want to fail completely
             // surely?
         default:


### PR DESCRIPTION
.... to take advantage of the new C5 instance types.
Now covers M5 types and sets default executors based on those types.
The build system is having an intermittent problem starting Surefire :-(  Not sure how to get this to try again.  It builds & passes on my system and I see other builds here are suffering from the same Surefire problem.