### PR TITLE
Bump aws-java-sdk to pick up c5, m5 instance types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.226</version>
+            <version>1.11.264</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.119</version>
+            <version>1.11.226</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -199,6 +199,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 7;
         case C4Large:
             return 7;
+        case C5Large:
+            return 7;
         case M1Xlarge:
             return 8;
         case M22xlarge:
@@ -210,6 +212,8 @@ public abstract class EC2AbstractSlave extends Slave {
         case C3Xlarge:
             return 14;
         case C4Xlarge:
+            return 14;
+        case C5Xlarge:
             return 14;
         case C1Xlarge:
             return 20;
@@ -225,6 +229,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 28;
         case C42xlarge:
             return 28;
+        case C52xlarge:
+            return 28;
         case Cc14xlarge:
             return 33;
         case Cg14xlarge:
@@ -237,6 +243,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 55;
         case C44xlarge:
             return 55;
+        case C54xlarge:
+            return 55;
         case M44xlarge:
             return 55;
         case Cc28xlarge:
@@ -247,8 +255,13 @@ public abstract class EC2AbstractSlave extends Slave {
             return 108;
         case C48xlarge:
             return 108;
+        case C59xlarge:
+            return 108;
         case M410xlarge:
             return 120;
+            // TODO: M416xlarge
+        case C518xlarge:
+            return 216;
             // We don't have a suggestion, but we don't want to fail completely
             // surely?
         default:


### PR DESCRIPTION
Hello,

I've applied the following patch (similar to that in #242) to the ec2-plugin in our Jenkins installation so we can use c5 instances. I have a couple of questions though:

1. I saw that #242 failed CI, do you have some idea of whether that's a problem introduced by the version bump / something wedged on the CI environment right now / a spurious failure?
2. What are the values in `toNumExecutors` supposed to be? For the c5 instances I introduced, I've copied numbers from similar instance types (where possible) but I'm not sure I did the right thing.

Thanks in advance for your help!

Phil
