### PR TITLE
Add optional bootDelay parameter for SSH slaves

### DIFF
--- a/src/main/java/hudson/plugins/ec2/AMITypeData.java
+++ b/src/main/java/hudson/plugins/ec2/AMITypeData.java
@@ -6,4 +6,6 @@ public abstract class AMITypeData extends AbstractDescribableImpl<AMITypeData> {
     public abstract boolean isWindows();
 
     public abstract boolean isUnix();
+
+    public abstract int getBootDelayInMillis();
 }

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -23,12 +23,10 @@
  */
 package hudson.plugins.ec2;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
-import hudson.model.Hudson;
 import hudson.model.Node;
 import hudson.model.Slave;
 import hudson.slaves.NodeProperty;
@@ -162,7 +160,7 @@ public abstract class EC2AbstractSlave extends Slave {
         }
 
         if (amiType == null) {
-            amiType = new UnixData(rootCommandPrefix, slaveCommandPrefix, Integer.toString(sshPort));
+            amiType = new UnixData(rootCommandPrefix, slaveCommandPrefix, Integer.toString(sshPort), null);
         }
 
         return this;
@@ -550,7 +548,7 @@ public abstract class EC2AbstractSlave extends Slave {
     }
 
     public int getBootDelay() {
-        return amiType.isWindows() ? ((WindowsData) amiType).getBootDelayInMillis() : 0;
+        return amiType.getBootDelayInMillis();
     }
 
     public static ListBoxModel fillZoneItems(AWSCredentialsProvider credentialsProvider, String region) {

--- a/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
@@ -2,7 +2,6 @@ package hudson.plugins.ec2;
 
 import hudson.Extension;
 import hudson.model.Descriptor.FormException;
-import hudson.model.Hudson;
 import hudson.model.Node;
 import hudson.plugins.ec2.ssh.EC2UnixLauncher;
 import hudson.plugins.ec2.win.EC2WindowsLauncher;
@@ -57,7 +56,7 @@ public final class EC2OndemandSlave extends EC2AbstractSlave {
      * Constructor for debugging.
      */
     public EC2OndemandSlave(String instanceId) throws FormException, IOException {
-        this(instanceId, instanceId, "debug", "/tmp/hudson", 1, "debug", Mode.NORMAL, "", "/tmp", Collections.<NodeProperty<?>> emptyList(), null, null, false, null, "Fake public", "Fake private", null, null, false, false, 0, new UnixData(null, null, null));
+        this(instanceId, instanceId, "debug", "/tmp/hudson", 1, "debug", Mode.NORMAL, "", "/tmp", Collections.<NodeProperty<?>> emptyList(), null, null, false, null, "Fake public", "Fake private", null, null, false, false, 0, new UnixData(null, null, null, null));
     }
 
     /**

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -243,7 +243,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             boolean usePrivateDnsName, String instanceCapStr, String iamInstanceProfile, boolean useEphemeralDevices,
             String launchTimeoutStr) {
         this(ami, zone, spotConfig, securityGroups, remoteFS, type, ebsOptimized, labelString, mode, description, initScript,
-                tmpDir, userData, numExecutors, remoteAdmin, new UnixData(rootCommandPrefix, slaveCommandPrefix, sshPort),
+                tmpDir, userData, numExecutors, remoteAdmin, new UnixData(rootCommandPrefix, slaveCommandPrefix, sshPort, null),
                 jvmopts, stopOnTerminate, subnetId, tags, idleTerminationMinutes, usePrivateDnsName, instanceCapStr, iamInstanceProfile,
                 useEphemeralDevices, false, launchTimeoutStr, false, null);
     }
@@ -1037,7 +1037,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
 
         if (amiType == null) {
-            amiType = new UnixData(rootCommandPrefix, slaveCommandPrefix, sshPort);
+            amiType = new UnixData(rootCommandPrefix, slaveCommandPrefix, sshPort, null);
         }
         return this;
     }

--- a/src/main/java/hudson/plugins/ec2/UnixData.java
+++ b/src/main/java/hudson/plugins/ec2/UnixData.java
@@ -11,16 +11,20 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
+import java.util.concurrent.TimeUnit;
+
 public class UnixData extends AMITypeData {
     private final String rootCommandPrefix;
     private final String slaveCommandPrefix;
     private final String sshPort;
+    private final String bootDelay;
 
     @DataBoundConstructor
-    public UnixData(String rootCommandPrefix, String slaveCommandPrefix, String sshPort) {
+    public UnixData(String rootCommandPrefix, String slaveCommandPrefix, String sshPort, String bootDelay) {
         this.rootCommandPrefix = rootCommandPrefix;
         this.slaveCommandPrefix = slaveCommandPrefix;
         this.sshPort = sshPort;
+        this.bootDelay = bootDelay;
 
         this.readResolve();
     }
@@ -78,6 +82,20 @@ public class UnixData extends AMITypeData {
         return sshPort == null || sshPort.isEmpty() ? "22" : sshPort;
     }
 
+    public String getBootDelay() {
+        return bootDelay;
+    }
+
+    public int getBootDelayInMillis() {
+        if (bootDelay == null)
+            return 0;
+        try {
+            return (int) TimeUnit.SECONDS.toMillis(Integer.parseInt(bootDelay));
+        } catch (NumberFormatException nfe) {
+            return 0;
+        }
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -85,6 +103,7 @@ public class UnixData extends AMITypeData {
         result = prime * result + ((rootCommandPrefix == null) ? 0 : rootCommandPrefix.hashCode());
         result = prime * result + ((slaveCommandPrefix == null) ? 0 : slaveCommandPrefix.hashCode());
         result = prime * result + ((sshPort == null) ? 0 : sshPort.hashCode());
+        result = prime * result + ((bootDelay == null) ? 0 : bootDelay.hashCode());
         return result;
     }
 
@@ -111,6 +130,11 @@ public class UnixData extends AMITypeData {
             if (!StringUtils.isEmpty(other.sshPort))
                 return false;
         } else if (!sshPort.equals(other.sshPort))
+            return false;
+        if (bootDelay == null) {
+            if (other.bootDelay != null)
+                return false;
+        } else if (!bootDelay.equals(other.bootDelay))
             return false;
         return true;
     }

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -130,6 +130,12 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
         try {
             boolean isBootstrapped = bootstrap(computer, listener);
             if (isBootstrapped) {
+                int bootDelay = computer.getNode().getBootDelay();
+                if (bootDelay > 0) {
+                    logInfo(computer, listener, "SSH service responded. Waiting for service to stabilize");
+                    Thread.sleep(bootDelay);
+                }
+
                 // connect fresh as ROOT
                 logInfo(computer, listener, "connect fresh as root");
                 cleanupConn = connectToSsh(computer, listener);

--- a/src/main/resources/hudson/plugins/ec2/UnixData/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/UnixData/config.jelly
@@ -33,4 +33,7 @@ THE SOFTWARE.
       <f:entry title="${%Remote ssh port}" field="sshPort">
         <f:textbox />
       </f:entry>
+      <f:entry title="${%Boot Delay}" field="bootDelay">
+        <f:textbox />
+      </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/ec2/UnixData/help-bootDelay.html
+++ b/src/main/resources/hudson/plugins/ec2/UnixData/help-bootDelay.html
@@ -1,0 +1,6 @@
+<div>
+Indicate here the time in seconds to wait for the machine to be ready once the plugin detects SSH is available.
+Unfortunately, on Windows during the boot, the SSH service might be started, and then several minutes after will be
+restarted. If this restart happens during the slave provisioning, Windows will prevent subsequent SSH connections and
+the slave will not be correctly provisioned.
+</div>

--- a/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
@@ -18,7 +18,7 @@ public class EC2AbstractSlaveTest {
 
     @Test
     public void testGetLaunchTimeoutInMillisShouldNotOverflow() throws Exception {
-        EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "root", "jvm", false, "idle", null, "cloud", false, false, Integer.MAX_VALUE, new UnixData("remote", null, "22")) {
+        EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "root", "jvm", false, "idle", null, "cloud", false, false, Integer.MAX_VALUE, new UnixData("remote", null, "22", null)) {
             @Override
             public void terminate() {
                 // To change body of implemented methods use File | Settings |

--- a/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
@@ -14,10 +14,10 @@ public class EC2OndemandSlaveTest {
 
     @Test
     public void testSpecifyMode() throws Exception {
-        EC2OndemandSlave slaveNormal = new EC2OndemandSlave("instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.NORMAL, "initScript", "tmpDir", "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", null, "cloudName", false, false, 0, new UnixData("a", null, "b"));
+        EC2OndemandSlave slaveNormal = new EC2OndemandSlave("instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.NORMAL, "initScript", "tmpDir", "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", null, "cloudName", false, false, 0, new UnixData("a", null, "b", null));
         assertEquals(Node.Mode.NORMAL, slaveNormal.getMode());
 
-        EC2OndemandSlave slaveExclusive = new EC2OndemandSlave("instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.EXCLUSIVE, "initScript", "tmpDir", "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", null, "cloudName", false, false, 0, new UnixData("a", null, "b"));
+        EC2OndemandSlave slaveExclusive = new EC2OndemandSlave("instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.EXCLUSIVE, "initScript", "tmpDir", "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", null, "cloudName", false, false, 0, new UnixData("a", null, "b", null));
         assertEquals(Node.Mode.EXCLUSIVE, slaveExclusive.getMode());
     }
 

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -262,7 +262,7 @@ public class SlaveTemplateTest {
         tags.add(tag1);
         tags.add(tag2);
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "rrr", new UnixData("sudo", null, "22"), "-Xmx1g", false, "subnet 456", tags, null, false, null, "", true, false, "", false, "");
+        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "rrr", new UnixData("sudo", null, "22", "123"), "-Xmx1g", false, "subnet 456", tags, null, false, null, "", true, false, "", false, "");
 
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);


### PR DESCRIPTION
Our EC2 Windows slaves were suffering from frequent disconnects, causing any in-progress builds to fail.  Knowing that our Linux slaves were far more stable, we decided to experiment with SSH connections for Windows.

Using a customized daemon (https://github.com/varju/ec2-sshd), we have found that our Windows slaves are now consistently staying connected.  Unfortunately sshd on Windows suffers from the same problem as WinRM, requiring a bit of a delay after startup due to services that restart shortly after boot.

This PR adds a boot delay option to Unix slaves.  Normally the delay will be 0, but this can be manually increased if using a less conventional setup like Windows over SSH.