### PR TITLE
Add option to run t2 unlimited instances

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.119</version>
+            <version>1.11.264</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -39,6 +39,10 @@ THE SOFTWARE.
     <f:enum>${it.name()}</f:enum>
   </f:entry>
 
+  <f:entry title="${%T2 Unlimited}" field="t2Unlimited">
+    <f:checkbox />
+  </f:entry>
+
   <f:entry title="${%EBS Optimized}" field="ebsOptimized">
     <f:checkbox />
   </f:entry>


### PR DESCRIPTION
Hello. We faced a problem when t2 instances have too few credits and they can't gain them in the stopped state. Recently AWS added a new feature t2 unlimited that can solve our problem with credits. It would be great to use such feature in the plugin. I'm open to your suggestions what can be improved in this PR.