### PR TITLE
Update help-securityGroups.html security group delimiter

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/EC2Slave/help-securityGroups.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Slave/help-securityGroups.html
@@ -23,6 +23,6 @@ THE SOFTWARE.
 -->
 <div>
     Specify the security group names (do not specify the security group IDs) that will be applied to this instance.
-    If there are multiple security groups, separate them by a space. If the instance uses a VPC (you have specified
+    If there are multiple security groups, separate them with commas. If the instance uses a VPC (you have specified
     a subnet ID for the VPC), then all security groups need to be part of the VPC.
 </div>


### PR DESCRIPTION
In the security groups [parse method](https://github.com/jenkinsci/ec2-plugin/blob/master/src/main/java/hudson/plugins/ec2/SlaveTemplate.java#L291) it is using commas to delimit security group names. 