### PR TITLE
Fix intermittent "Pipe closed" exception when communicating with WinRM protocol agent

### DIFF
--- a/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WinRMClient.java
@@ -1,10 +1,11 @@
 package hudson.plugins.ec2.win.winrm;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import hudson.plugins.ec2.win.winrm.request.RequestFactory;
 import hudson.plugins.ec2.win.winrm.soap.Namespaces;
-
+import hudson.remoting.FastPipedOutputStream;
 import java.io.IOException;
-import java.io.PipedOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -16,7 +17,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -46,9 +46,6 @@ import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.XPath;
 import org.jaxen.SimpleNamespaceContext;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 
 public class WinRMClient {
     private static final Logger log = Logger.getLogger(WinRMClient.class.getName());
@@ -123,9 +120,9 @@ public class WinRMClient {
         sendRequest(request);
     }
 
-    public boolean slurpOutput(PipedOutputStream stdout, PipedOutputStream stderr) throws IOException {
+    public boolean slurpOutput(FastPipedOutputStream stdout, FastPipedOutputStream stderr) throws IOException {
         log.log(Level.FINE, "--> SlurpOutput");
-        ImmutableMap<String, PipedOutputStream> streams = ImmutableMap.of("stdout", stdout, "stderr", stderr);
+        ImmutableMap<String, FastPipedOutputStream> streams = ImmutableMap.of("stdout", stdout, "stderr", stderr);
 
         Document request = factory.newGetOutputRequest(shellId, commandId).build();
         Document response = sendRequest(request);
@@ -137,7 +134,7 @@ public class WinRMClient {
 
         Base64 base64 = new Base64();
         for (Element e : (List<Element>) xpath.selectNodes(response)) {
-            PipedOutputStream stream = streams.get(e.attribute("Name").getText().toLowerCase());
+            FastPipedOutputStream stream = streams.get(e.attribute("Name").getText().toLowerCase());
             final byte[] decode = base64.decode(e.getText());
             log.log(Level.FINE, "piping " + decode.length + " bytes from "
                     + e.attribute("Name").getText().toLowerCase());

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
@@ -1,27 +1,27 @@
 package hudson.plugins.ec2.win.winrm;
 
+import com.google.common.io.Closeables;
+import hudson.remoting.FastPipedInputStream;
+import hudson.remoting.FastPipedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.google.common.io.Closeables;
-
 public class WindowsProcess {
+
     private static final Logger log = Logger.getLogger(WindowsProcess.class.getName());
 
     private final static int INPUT_BUFFER = 16 * 1024;
     private final WinRMClient client;
 
-    private final PipedInputStream toCallersStdin;
-    private final PipedOutputStream callersStdin;
-    private final PipedInputStream callersStdout;
-    private final PipedOutputStream toCallersStdout;
-    private final PipedInputStream callersStderr;
-    private final PipedOutputStream toCallersStderr;
+    private final FastPipedInputStream toCallersStdin;
+    private final FastPipedOutputStream callersStdin;
+    private final FastPipedInputStream callersStdout;
+    private final FastPipedOutputStream toCallersStdout;
+    private final FastPipedInputStream callersStderr;
+    private final FastPipedOutputStream toCallersStderr;
 
     private boolean terminated;
     private final String command;
@@ -34,12 +34,13 @@ public class WindowsProcess {
         this.client = client;
         this.command = command;
 
-        toCallersStdin = new PipedInputStream(INPUT_BUFFER);
-        callersStdin = new PipedOutputStream(toCallersStdin);
-        callersStdout = new PipedInputStream(INPUT_BUFFER);
-        toCallersStdout = new PipedOutputStream(callersStdout);
-        callersStderr = new PipedInputStream(INPUT_BUFFER);
-        toCallersStderr = new PipedOutputStream(callersStderr);
+        toCallersStdin = new FastPipedInputStream();
+        callersStdin = new FastPipedOutputStream(toCallersStdin);
+        callersStdout = new FastPipedInputStream();
+        toCallersStdout = new FastPipedOutputStream(callersStdout);
+        callersStderr = new FastPipedInputStream();
+        toCallersStderr = new FastPipedOutputStream(callersStderr);
+
         startStdoutCopyThread();
         try {
             Thread.sleep(1000);
@@ -121,19 +122,8 @@ public class WindowsProcess {
                 try {
                     byte[] buf = new byte[INPUT_BUFFER];
                     for (;;) {
-                        int n = 0;
-                        try {
-                            n = toCallersStdin.read(buf);
-                        } catch (IOException ioe) {
-                            // it's safe to ignore IO Exception coming from
-                            // Jenkins
-                            // This can happen with PipedInputStream if the
-                            // writing Thread
-                            // is killed but the input stream is handed to
-                            // another thread
-                            // in this case, we can still read from the pipe.
-                            continue;
-                        }
+                        int n = toCallersStdin.read(buf);
+
                         if (n == -1)
                             break;
                         if (n == 0)

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
@@ -10,7 +10,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class WindowsProcess {
-
     private static final Logger log = Logger.getLogger(WindowsProcess.class.getName());
 
     private final static int INPUT_BUFFER = 16 * 1024;


### PR DESCRIPTION
This resolves an issue where Windows (WinRM) agent running on EC2 would intermittently fail with no apparent cause or clear way to reproduce.

This was tracked down to use of `Piped*Stream` classes that are sensitive to identity of thread used - and conflict with internal threads pooling both on client and server side.

The issue has been consistently reproducible and verified using our 30+ builds on number of dynamic ec2 instances in a row internal test harness.

**Note:** Instead of merging this, consider merging https://github.com/jenkinsci/ec2-plugin/pull/264 outright (more extensive cleanups and include this change as well).

---

Example stack trace from a failure scenario (valid use of `FilePath` resulting in attempt to make a remove call over `FilePath::act` running into a reportedly killed connection due to different thread in use by time this stage/operation is attempted than the one during original setup):

```
06:11:54 Caused by: java.io.IOException: Pipe closed
06:11:54 	at java.io.PipedInputStream.checkStateForReceive(PipedInputStream.java:260)
06:11:54 	at java.io.PipedInputStream.receive(PipedInputStream.java:226)
06:11:54 	at java.io.PipedOutputStream.write(PipedOutputStream.java:149)
06:11:54 	at java.io.OutputStream.write(OutputStream.java:75)
06:11:54 	at hudson.remoting.ChunkedOutputStream.sendFrame(ChunkedOutputStream.java:89)
06:11:54 	at hudson.remoting.ChunkedOutputStream.drain(ChunkedOutputStream.java:85)
06:11:54 	at hudson.remoting.ChunkedOutputStream.write(ChunkedOutputStream.java:54)
06:11:54 	at java.io.OutputStream.write(OutputStream.java:75)
06:11:54 	at hudson.remoting.ChunkedCommandTransport.writeBlock(ChunkedCommandTransport.java:45)
06:11:54 	at hudson.remoting.AbstractSynchronousByteArrayCommandTransport.write(AbstractSynchronousByteArrayCommandTransport.java:45)
06:11:54 	at hudson.remoting.Channel.send(Channel.java:675)
06:11:54 	at hudson.remoting.Request.call(Request.java:150)
06:11:54 	at hudson.remoting.Channel.call(Channel.java:907)
06:11:54 	at hudson.FilePath.act(FilePath.java:986)
06:11:54 	... 19 more
06:11:55 FATAL: remote file operation failed: C:\tools\hudson.tasks.Maven_MavenInstallation\3.3.9\.installedFrom at hudson.remoting.Channel@c037d29:Windows 2016 dotNet build image 2018.01.1 (sir-kypg7ixj): java.io.IOException: Pipe closed
06:11:55 java.io.IOException: Pipe closed
06:11:55 	at java.io.PipedInputStream.checkStateForReceive(PipedInputStream.java:260)
06:11:55 	at java.io.PipedInputStream.receive(PipedInputStream.java:226)
06:11:55 	at java.io.PipedOutputStream.write(PipedOutputStream.java:149)
06:11:55 	at java.io.OutputStream.write(OutputStream.java:75)
06:11:55 	at hudson.remoting.ChunkedOutputStream.sendFrame(ChunkedOutputStream.java:89)
06:11:55 	at hudson.remoting.ChunkedOutputStream.drain(ChunkedOutputStream.java:85)
06:11:55 	at hudson.remoting.ChunkedOutputStream.write(ChunkedOutputStream.java:54)
06:11:55 	at java.io.OutputStream.write(OutputStream.java:75)
06:11:55 	at hudson.remoting.ChunkedCommandTransport.writeBlock(ChunkedCommandTransport.java:45)
06:11:55 	at hudson.remoting.AbstractSynchronousByteArrayCommandTransport.write(AbstractSynchronousByteArrayCommandTransport.java:45)
06:11:55 	at hudson.remoting.Channel.send(Channel.java:675)
06:11:55 	at hudson.remoting.Request.call(Request.java:150)
06:11:55 	at hudson.remoting.Channel.call(Channel.java:907)
06:11:55 	at hudson.FilePath.act(FilePath.java:986)
06:11:55 Caused: java.io.IOException: remote file operation failed: C:\tools\hudson.tasks.Maven_MavenInstallation\3.3.9\.installedFrom at hudson.remoting.Channel@c037d29:Windows 2016 dotNet build image 2018.01.1 (sir-kypg7ixj)
06:11:55 	at hudson.FilePath.act(FilePath.java:993)
06:11:55 	at hudson.FilePath.act(FilePath.java:975)
06:11:55 	at hudson.FilePath.exists(FilePath.java:1440)
06:11:55 	at hudson.tools.DownloadFromUrlInstaller.isUpToDate(DownloadFromUrlInstaller.java:46)
06:11:55 	at hudson.tools.DownloadFromUrlInstaller.performInstallation(DownloadFromUrlInstaller.java:74)
06:11:55 	at hudson.tools.InstallerTranslator.getToolHome(InstallerTranslator.java:72)
06:11:55 	at hudson.tools.ToolLocationNodeProperty.getToolHome(ToolLocationNodeProperty.java:109)
06:11:55 	at hudson.tools.ToolInstallation.translateFor(ToolInstallation.java:206)
06:11:55 	at hudson.tasks.Maven$MavenInstallation.forNode(Maven.java:662)
06:11:55 	at hudson.tasks.Maven.perform(Maven.java:317)
06:11:55 	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
06:11:55 	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:744)
06:11:55 	at hudson.model.Build$BuildExecution.build(Build.java:206)
06:11:55 	at hudson.model.Build$BuildExecution.doRun(Build.java:163)
06:11:55 	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:504)
06:11:55 	at hudson.model.Run.execute(Run.java:1724)
06:11:55 	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
06:11:55 	at hudson.model.ResourceController.execute(ResourceController.java:97)
06:11:55 	at hudson.model.Executor.run(Executor.java:421)
```