### PR TITLE
hudson.plugins.ec2.win package spring clean-up

### DIFF
--- a/src/main/java/hudson/plugins/ec2/win/winrm/RuntimeIOException.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/RuntimeIOException.java
@@ -1,20 +1,8 @@
 package hudson.plugins.ec2.win.winrm;
 
-@SuppressWarnings("serial")
-public class RuntimeIOException extends RuntimeException {
-    public RuntimeIOException() {
-        super();
-    }
+class RuntimeIOException extends RuntimeException {
 
-    public RuntimeIOException(String message) {
-        super(message);
-    }
-
-    public RuntimeIOException(Throwable cause) {
-        super(cause);
-    }
-
-    public RuntimeIOException(String message, Throwable cause) {
+    RuntimeIOException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WinRM.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WinRM.java
@@ -3,14 +3,13 @@ package hudson.plugins.ec2.win.winrm;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.logging.Logger;
 
 public class WinRM {
-    private static final Logger log = Logger.getLogger(WinRM.class.getName());
 
     private final String host;
     private final String username;
     private final String password;
+
     private int timeout = 60;
 
     private boolean useHTTPS;
@@ -21,8 +20,8 @@ public class WinRM {
         this.password = password;
     }
 
-    public void ping() throws IOException {
-        final WinRMClient client = new WinRMClient(buildURL(), username, password);
+    public void ping() {
+        WinRMClient client = new WinRMClient(buildURL(), username, password);
         client.setTimeout(secToDuration(timeout));
         client.setUseHTTPS(isUseHTTPS());
         try {
@@ -31,12 +30,13 @@ public class WinRM {
             try {
                 client.deleteShell();
             } catch (Exception e) {
+                // No-op
             }
         }
     }
 
     public WindowsProcess execute(String commandLine) {
-        final WinRMClient client = new WinRMClient(buildURL(), username, password);
+        WinRMClient client = new WinRMClient(buildURL(), username, password);
         client.setTimeout(secToDuration(timeout));
         client.setUseHTTPS(isUseHTTPS());
         try {
@@ -49,7 +49,7 @@ public class WinRM {
         }
     }
 
-    public URL buildURL() {
+    private URL buildURL() {
         String scheme = useHTTPS ? "https" : "http";
         int port = useHTTPS ? 5986 : 5985;
 
@@ -60,43 +60,22 @@ public class WinRM {
         }
     }
 
-    /**
-     * @return the useHTTPS
-     */
-    public boolean isUseHTTPS() {
+    private boolean isUseHTTPS() {
         return useHTTPS;
     }
 
-    /**
-     * @param useHTTPS
-     *            the useHTTPS to set
-     */
     public void setUseHTTPS(boolean useHTTPS) {
         this.useHTTPS = useHTTPS;
     }
 
-    /**
-     * @return the timeout
-     */
-    public int getTimeout() {
-        return timeout;
-    }
-
-    /**
-     * @param timeout
-     *            the timeout to set
-     */
-    public void setTimeout(int timeout) {
-        this.timeout = timeout;
+    public void setTimeout(int seconds) {
+        this.timeout = seconds;
     }
 
     /**
      * # Convert the number of seconds to an ISO8601 duration format # @see
      * http://tools.ietf.org/html/rfc2445#section-4.3.6 # @param [Fixnum] seconds The amount of seconds for this
      * duration
-     * 
-     * @param timeout
-     * @return
      */
     private static String secToDuration(int seconds) {
         StringBuilder iso = new StringBuilder("P");

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WinRMConnectException.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WinRMConnectException.java
@@ -1,9 +1,8 @@
 package hudson.plugins.ec2.win.winrm;
 
-public class WinRMConnectException extends RuntimeIOException {
+class WinRMConnectException extends RuntimeIOException {
 
-    public WinRMConnectException(String message, Throwable cause) {
+    WinRMConnectException(String message, Throwable cause) {
         super(message, cause);
     }
-
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/AbstractWinRMRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/AbstractWinRMRequest.java
@@ -1,28 +1,25 @@
 package hudson.plugins.ec2.win.winrm.request;
 
+import hudson.plugins.ec2.win.winrm.soap.HeaderBuilder;
+import hudson.plugins.ec2.win.winrm.soap.MessageBuilder;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.UUID;
-
-import hudson.plugins.ec2.win.winrm.soap.HeaderBuilder;
-import hudson.plugins.ec2.win.winrm.soap.MessageBuilder;
-
 import org.dom4j.Document;
 import org.dom4j.Element;
 
 public abstract class AbstractWinRMRequest implements WinRMRequest {
 
-    protected MessageBuilder message = new MessageBuilder();
-    protected HeaderBuilder header = message.newHeader();
+    private final MessageBuilder message = new MessageBuilder();
+    private final HeaderBuilder header = message.newHeader();
+    private final URL url;
 
-    protected String timeout = "PT60S";
-    protected int envelopSize = 153600;
-    protected String locale = "en-US";
+    private String timeout = "PT60S";
+    private int envelopSize = 153600;
+    private String locale = "en-US";
 
-    protected URL url;
-
-    public AbstractWinRMRequest(URL url) {
+    AbstractWinRMRequest(URL url) {
         this.url = url;
     }
 
@@ -33,41 +30,33 @@ public abstract class AbstractWinRMRequest implements WinRMRequest {
         return message.build();
     }
 
-    protected HeaderBuilder defaultHeader() throws URISyntaxException {
-        return header.to(url.toURI()).replyTo(new URI("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous")).maxEnvelopeSize(envelopSize).id(generateUUID()).locale(locale).timeout(timeout);
+    HeaderBuilder defaultHeader() throws URISyntaxException {
+        return header.to(url.toURI())
+                .replyTo(new URI("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous"))
+                .maxEnvelopeSize(envelopSize)
+                .id(generateUUID())
+                .locale(locale)
+                .timeout(timeout);
     }
 
-    protected void setBody(Element body) {
+    void setBody(Element body) {
         message.addHeader(header.build());
         message.addBody(body);
     }
 
-    protected String generateUUID() {
+    private String generateUUID() {
         return "uuid:" + UUID.randomUUID().toString().toUpperCase();
-    }
-
-    public String getTimeout() {
-        return timeout;
     }
 
     public void setTimeout(String timeout) {
         this.timeout = timeout;
     }
 
-    public int getEnvelopSize() {
-        return envelopSize;
-    }
-
     public void setEnvelopSize(int envelopSize) {
         this.envelopSize = envelopSize;
-    }
-
-    public String getLocale() {
-        return locale;
     }
 
     public void setLocale(String locale) {
         this.locale = locale;
     }
-
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/DeleteShellRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/DeleteShellRequest.java
@@ -16,12 +16,13 @@ public class DeleteShellRequest extends AbstractWinRMRequest {
     @Override
     protected void construct() {
         try {
-            defaultHeader().action(new URI("http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete")).shellId(shellId).resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd"));
+            defaultHeader().action(new URI("http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete"))
+                    .shellId(shellId)
+                    .resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd"));
 
             setBody(null);
         } catch (URISyntaxException e) {
             throw new RuntimeException("Error while building request content", e);
         }
     }
-
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/ExecuteCommandRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/ExecuteCommandRequest.java
@@ -1,17 +1,14 @@
 package hudson.plugins.ec2.win.winrm.request;
 
+import com.google.common.collect.ImmutableList;
 import hudson.plugins.ec2.win.winrm.soap.Namespaces;
 import hudson.plugins.ec2.win.winrm.soap.Option;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.QName;
-
-import com.google.common.collect.ImmutableList;
 
 public class ExecuteCommandRequest extends AbstractWinRMRequest {
 
@@ -27,14 +24,18 @@ public class ExecuteCommandRequest extends AbstractWinRMRequest {
     @Override
     protected void construct() {
         try {
-            defaultHeader().action(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command")).resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd")).shellId(shellId).options(ImmutableList.of(new Option("WINRS_CONSOLEMODE_STDIN", "FALSE")));
+            defaultHeader().action(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command"))
+                    .resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd"))
+                    .shellId(shellId)
+                    .options(ImmutableList.of(new Option("WINRS_CONSOLEMODE_STDIN", "FALSE")));
 
             Element body = DocumentHelper.createElement(QName.get("CommandLine", Namespaces.NS_WIN_SHELL));
+
             body.addElement(QName.get("Command", Namespaces.NS_WIN_SHELL)).addText("\"" + command + "\"");
+
             setBody(body);
         } catch (URISyntaxException e) {
             throw new RuntimeException("Error while building request content", e);
         }
     }
-
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/GetOutputRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/GetOutputRequest.java
@@ -1,18 +1,17 @@
 package hudson.plugins.ec2.win.winrm.request;
 
 import hudson.plugins.ec2.win.winrm.soap.Namespaces;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.QName;
 
 public class GetOutputRequest extends AbstractWinRMRequest {
 
-    private final String shellId, commandId;
+    private final String shellId;
+    private final String commandId;
 
     public GetOutputRequest(URL url, String shellId, String commandId) {
         super(url);
@@ -23,14 +22,19 @@ public class GetOutputRequest extends AbstractWinRMRequest {
     @Override
     protected void construct() {
         try {
-            defaultHeader().action(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive")).resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd")).shellId(shellId);
+            defaultHeader().action(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive"))
+                    .resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd"))
+                    .shellId(shellId);
 
             Element body = DocumentHelper.createElement(QName.get("Receive", Namespaces.NS_WIN_SHELL));
-            body.addElement(QName.get("DesiredStream", Namespaces.NS_WIN_SHELL)).addAttribute("CommandId", commandId).addText("stdout stderr");
+
+            body.addElement(QName.get("DesiredStream", Namespaces.NS_WIN_SHELL))
+                    .addAttribute("CommandId", commandId)
+                    .addText("stdout stderr");
+
             setBody(body);
         } catch (URISyntaxException e) {
             throw new RuntimeException("Error while building request content", e);
         }
     }
-
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/OpenShellRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/OpenShellRequest.java
@@ -1,17 +1,14 @@
 package hudson.plugins.ec2.win.winrm.request;
 
+import com.google.common.collect.ImmutableList;
 import hudson.plugins.ec2.win.winrm.soap.Namespaces;
 import hudson.plugins.ec2.win.winrm.soap.Option;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.QName;
-
-import com.google.common.collect.ImmutableList;
 
 public class OpenShellRequest extends AbstractWinRMRequest implements WinRMRequest {
 
@@ -21,16 +18,18 @@ public class OpenShellRequest extends AbstractWinRMRequest implements WinRMReque
 
     protected void construct() {
         try {
-            defaultHeader().action(new URI("http://schemas.xmlsoap.org/ws/2004/09/transfer/Create")).resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd")).options(ImmutableList.of(new Option("WINRS_NOPROFILE", "FALSE"), new Option("WINRS_CODEPAGE", "437")));
+            defaultHeader().action(new URI("http://schemas.xmlsoap.org/ws/2004/09/transfer/Create"))
+                    .resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd"))
+                    .options(ImmutableList.of(new Option("WINRS_NOPROFILE", "FALSE"), new Option("WINRS_CODEPAGE", "437")));
 
             Element body = DocumentHelper.createElement(QName.get("Shell", Namespaces.NS_WIN_SHELL));
+
             body.addElement(QName.get("InputStreams", Namespaces.NS_WIN_SHELL)).addText("stdin");
             body.addElement(QName.get("OutputStreams", Namespaces.NS_WIN_SHELL)).addText("stdout stderr");
+
             setBody(body);
         } catch (URISyntaxException e) {
             throw new RuntimeException("Error while building request content", e);
         }
-
     }
-
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/RequestFactory.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/RequestFactory.java
@@ -3,10 +3,13 @@ package hudson.plugins.ec2.win.winrm.request;
 import java.net.URL;
 
 public class RequestFactory {
+
+    private static final int DEFAULT_ENVELOP_SIZE = 153600;
+    private static final String DEFAULT_LOCALE = "en-US";
+
     private final URL url;
+
     private String timeout = "PT60S";
-    private int envelopSize = 153600;
-    private String locale = "en-US";
 
     public RequestFactory(URL url) {
         this.url = url;
@@ -50,8 +53,8 @@ public class RequestFactory {
 
     private void setDefaults(AbstractWinRMRequest r) {
         r.setTimeout(timeout);
-        r.setLocale(locale);
-        r.setEnvelopSize(envelopSize);
+        r.setLocale(DEFAULT_LOCALE);
+        r.setEnvelopSize(DEFAULT_ENVELOP_SIZE);
     }
 
     public String getTimeout() {
@@ -61,21 +64,4 @@ public class RequestFactory {
     public void setTimeout(String timeout) {
         this.timeout = timeout;
     }
-
-    public int getEnvelopSize() {
-        return envelopSize;
-    }
-
-    public void setEnvelopSize(int envelopSize) {
-        this.envelopSize = envelopSize;
-    }
-
-    public String getLocale() {
-        return locale;
-    }
-
-    public void setLocale(String locale) {
-        this.locale = locale;
-    }
-
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/SendInputRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/SendInputRequest.java
@@ -1,11 +1,9 @@
 package hudson.plugins.ec2.win.winrm.request;
 
 import hudson.plugins.ec2.win.winrm.soap.Namespaces;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-
 import org.apache.commons.codec.binary.Base64;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
@@ -13,8 +11,10 @@ import org.dom4j.QName;
 
 public class SendInputRequest extends AbstractWinRMRequest {
 
-    byte[] input;
-    private final String commandId, shellId;
+    private final byte[] input;
+    private final String commandId;
+    private final String shellId;
+    private final Base64 base64 = new Base64();
 
     public SendInputRequest(URL url, byte[] input, String shellId, String commandId) {
         super(url);
@@ -26,15 +26,18 @@ public class SendInputRequest extends AbstractWinRMRequest {
     @Override
     protected void construct() {
         try {
-            defaultHeader().action(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send")).resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd")).shellId(shellId);
+            defaultHeader().action(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send"))
+                    .resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd"))
+                    .shellId(shellId);
 
             Element body = DocumentHelper.createElement(QName.get("Send", Namespaces.NS_WIN_SHELL));
-            Base64 base64 = new Base64(0);
-            body.addElement(QName.get("Stream", Namespaces.NS_WIN_SHELL)).addAttribute("Name", "stdin").addAttribute("CommandId", commandId).addText(base64.encodeToString(input));
+
+            body.addElement(QName.get("Stream", Namespaces.NS_WIN_SHELL)).addAttribute("Name", "stdin")
+                    .addAttribute("CommandId", commandId).addText(base64.encodeToString(input));
+
             setBody(body);
         } catch (URISyntaxException e) {
             throw new RuntimeException("Error while building request content", e);
         }
     }
-
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/SignalRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/SignalRequest.java
@@ -1,11 +1,9 @@
 package hudson.plugins.ec2.win.winrm.request;
 
 import hudson.plugins.ec2.win.winrm.soap.Namespaces;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.QName;
@@ -23,15 +21,19 @@ public class SignalRequest extends AbstractWinRMRequest {
     @Override
     protected void construct() {
         try {
-            defaultHeader().action(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command")).resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd")).shellId(shellId);
+            defaultHeader().action(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command"))
+                    .resourceURI(new URI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd"))
+                    .shellId(shellId);
 
-            Element body = DocumentHelper.createElement(QName.get("Signal", Namespaces.NS_WIN_SHELL)).addAttribute("CommandId", commandId);
+            Element body = DocumentHelper.createElement(QName.get("Signal", Namespaces.NS_WIN_SHELL))
+                    .addAttribute("CommandId", commandId);
 
-            body.addElement(QName.get("Code", Namespaces.NS_WIN_SHELL)).addText("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/terminate");
+            body.addElement(QName.get("Code", Namespaces.NS_WIN_SHELL))
+                    .addText("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/terminate");
+
             setBody(body);
         } catch (URISyntaxException e) {
             throw new RuntimeException("Error while building request content", e);
         }
     }
-
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/request/WinRMRequest.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/request/WinRMRequest.java
@@ -2,6 +2,7 @@ package hudson.plugins.ec2.win.winrm.request;
 
 import org.dom4j.Document;
 
-public interface WinRMRequest {
-    public Document build();
+interface WinRMRequest {
+
+    Document build();
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/soap/Header.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/soap/Header.java
@@ -1,23 +1,24 @@
 package hudson.plugins.ec2.win.winrm.soap;
 
+import com.google.common.collect.ImmutableList;
 import org.dom4j.Element;
 import org.dom4j.QName;
 
-import com.google.common.collect.ImmutableList;
-
 public class Header {
-    private final String to;
-    private final  String replyTo;
-    private final  String maxEnvelopeSize;
-    private final  String timeout;
-    private final  String locale;
-    private final  String id;
-    private final  String action;
-    private final  String shellId;
-    private final  String resourceURI;
-    private final  ImmutableList<Option> optionSet;
 
-    Header(String to, String replyTo, String maxEnvelopeSize, String timeout, String locale, String id, String action, String shellId, String resourceURI, ImmutableList<Option> optionSet) {
+    private final String to;
+    private final String replyTo;
+    private final String maxEnvelopeSize;
+    private final String timeout;
+    private final String locale;
+    private final String id;
+    private final String action;
+    private final String shellId;
+    private final String resourceURI;
+    private final ImmutableList<Option> optionSet;
+
+    Header(String to, String replyTo, String maxEnvelopeSize, String timeout, String locale, String id, String action,
+            String shellId, String resourceURI, ImmutableList<Option> optionSet) {
         this.to = to;
         this.replyTo = replyTo;
         this.maxEnvelopeSize = maxEnvelopeSize;
@@ -83,5 +84,4 @@ public class Header {
     private static Element mustNotUnderstand(Element e) {
         return e.addAttribute("mustUnderstand", "false");
     }
-
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/soap/HeaderBuilder.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/soap/HeaderBuilder.java
@@ -1,11 +1,11 @@
 package hudson.plugins.ec2.win.winrm.soap;
 
+import com.google.common.collect.ImmutableList;
 import java.net.URI;
 import java.util.List;
 
-import com.google.common.collect.ImmutableList;
-
 public class HeaderBuilder {
+
     private String to;
     private String replyTo;
     private String maxEnvelopeSize;

--- a/src/main/java/hudson/plugins/ec2/win/winrm/soap/MessageBuilder.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/soap/MessageBuilder.java
@@ -7,6 +7,7 @@ import org.dom4j.Namespace;
 import org.dom4j.QName;
 
 public class MessageBuilder {
+
     private final Document doc = DocumentHelper.createDocument();
     private final Element envelope = doc.addElement(QName.get("Envelope", Namespaces.NS_SOAP_ENV));
 

--- a/src/main/java/hudson/plugins/ec2/win/winrm/soap/Namespaces.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/soap/Namespaces.java
@@ -1,27 +1,21 @@
 package hudson.plugins.ec2.win.winrm.soap;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
-
 import org.dom4j.Namespace;
 
-import com.google.common.collect.ImmutableList;
-
 public class Namespaces {
+
     public static final Namespace NS_SOAP_ENV = Namespace.get("env", "http://www.w3.org/2003/05/soap-envelope");
     public static final Namespace NS_ADDRESSING = Namespace.get("a", "http://schemas.xmlsoap.org/ws/2004/08/addressing");
-    public static final Namespace NS_CIMBINDING = Namespace.get("b", "http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd");
-    public static final Namespace NS_ENUM = Namespace.get("n", "http://schemas.xmlsoap.org/ws/2004/09/enumeration");
-    public static final Namespace NS_TRANSFER = Namespace.get("x", "http://schemas.xmlsoap.org/ws/2004/09/transfer");
     public static final Namespace NS_WSMAN_DMTF = Namespace.get("w", "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd");
     public static final Namespace NS_WSMAN_MSFT = Namespace.get("p", "http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd");
-    public static final Namespace NS_SCHEMA_INST = Namespace.get("xsi", "http://www.w3.org/2001/XMLSchema-instance");
     public static final Namespace NS_WIN_SHELL = Namespace.get("rsp", "http://schemas.microsoft.com/wbem/wsman/1/windows/shell");
-    public static final Namespace NS_WSMAN_FAULT = Namespace.get("f", "http://schemas.microsoft.com/wbem/wsman/1/wsmanfault");
 
     private Namespaces() {
     }
 
-    public static final List<Namespace> mostUsed() {
+    public static List<Namespace> mostUsed() {
         return ImmutableList.of(NS_SOAP_ENV, NS_ADDRESSING, NS_WIN_SHELL, NS_WSMAN_DMTF, NS_WSMAN_MSFT);
     }
 }

--- a/src/main/java/hudson/plugins/ec2/win/winrm/soap/Option.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/soap/Option.java
@@ -1,6 +1,7 @@
 package hudson.plugins.ec2.win.winrm.soap;
 
 public class Option {
+
     private final String name;
     private final String value;
 


### PR DESCRIPTION
This is a more extensive follow-up to https://github.com/jenkinsci/ec2-plugin/pull/263 which, in addition to fixing the Piped streams use, also includes lots of small code cleanups of whole `hudson.plugins.ec2.win` package.

* Original issue (included in here) described in https://github.com/jenkinsci/ec2-plugin/pull/263
* Code cleanups, dead code cleanup, general formatting cleanups, etc...
* Care and judgement was exercised to make sure that no functional changes are introduced

This represents custom build of the plugin we rely on now internally.