### PR TITLE
Mark dependencies used only in tests as test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,11 +130,13 @@ THE SOFTWARE.
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-cps</artifactId>
                 <version>2.25</version>
+                <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
             <version>2.8</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
These dependencies are only used in tests, so they should be in test scope.

@reviewbybees 