### PR TITLE
[JENKINS-47681] Don't count slaves we just provisioned multiple times

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -510,11 +510,14 @@ public abstract class EC2Cloud extends Cloud {
         return Math.min(availableAmiSlaves, availableTotalSlaves);
     }
 
+    private synchronized EC2AbstractSlave getNewOrExistingAvailableSlave(SlaveTemplate template, Label requiredLabel, boolean forceCreateNew) {
+        return getNewOrExistingAvailableSlave(template, requiredLabel, forceCreateNew, null);
+    }
     /**
      * Obtains a slave whose AMI matches the AMI of the given template, and that also has requiredLabel (if requiredLabel is non-null)
      * forceCreateNew specifies that the creation of a new slave is required. Otherwise, an existing matching slave may be re-used
      */
-    private synchronized EC2AbstractSlave getNewOrExistingAvailableSlave(SlaveTemplate template, Label requiredLabel, boolean forceCreateNew) {
+    private synchronized EC2AbstractSlave getNewOrExistingAvailableSlave(SlaveTemplate template, Label requiredLabel, boolean forceCreateNew, ArrayList<EC2AbstractSlave> excludedSlaves) {
         /*
          * Note this is synchronized between counting the instances and then allocating the node. Once the node is
          * allocated, we don't look at that instance as available for provisioning.
@@ -531,7 +534,7 @@ public abstract class EC2Cloud extends Cloud {
                 provisionOptions = EnumSet.of(SlaveTemplate.ProvisionOptions.FORCE_CREATE);
             else if (possibleSlavesCount > 0)
                 provisionOptions = EnumSet.of(SlaveTemplate.ProvisionOptions.ALLOW_CREATE);
-            return template.provision(StreamTaskListener.fromStdout(), requiredLabel, provisionOptions);
+            return template.provision(StreamTaskListener.fromStdout(), requiredLabel, provisionOptions, excludedSlaves);
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Exception during provisioning", e);
             return null;
@@ -542,16 +545,18 @@ public abstract class EC2Cloud extends Cloud {
     public Collection<PlannedNode> provision(Label label, int excessWorkload) {
         try {
             List<PlannedNode> r = new ArrayList<PlannedNode>();
+            ArrayList<EC2AbstractSlave> provisionedSlaves = new ArrayList();
             final SlaveTemplate t = getTemplate(label);
             LOGGER.log(Level.INFO, "Attempting to provision slave from template " + t + " needed by excess workload of " + excessWorkload + " units of label '" + label + "'");
             if (label == null) {
                 LOGGER.log(Level.WARNING, String.format("Label is null - can't calculate how many executors slave will have. Using %s number of executors", t.getNumExecutors()));
             }
             while (excessWorkload > 0) {
-                final EC2AbstractSlave slave = getNewOrExistingAvailableSlave(t, label, false);
+                final EC2AbstractSlave slave = getNewOrExistingAvailableSlave(t, label, false, provisionedSlaves);
                 // Returned null if a new node could not be created
                 if (slave == null)
                     break;
+                provisionedSlaves.add(slave);
                 LOGGER.log(Level.INFO, String.format("We have now %s computers", Jenkins.getInstance().getComputers().length));
                 if (t.isNode()) {
                     Jenkins.getInstance().addNode(slave);

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -404,18 +404,22 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public enum ProvisionOptions { ALLOW_CREATE, FORCE_CREATE }
 
+    public EC2AbstractSlave provision(TaskListener listener, Label requiredLabel, EnumSet<ProvisionOptions> provisionOptions) throws AmazonClientException, IOException {
+        return provision(listener, requiredLabel, provisionOptions, null);
+    }
+
     /**
      * Provisions a new EC2 slave or starts a previously stopped on-demand instance.
      *
      * @return always non-null. This needs to be then added to {@link Hudson#addNode(Node)}.
      */
-    public EC2AbstractSlave provision(TaskListener listener, Label requiredLabel, EnumSet<ProvisionOptions> provisionOptions) throws AmazonClientException, IOException {
+    public EC2AbstractSlave provision(TaskListener listener, Label requiredLabel, EnumSet<ProvisionOptions> provisionOptions, ArrayList<EC2AbstractSlave> excludedSlaves) throws AmazonClientException, IOException {
         if (this.spotConfig != null) {
             if (provisionOptions.contains(ProvisionOptions.ALLOW_CREATE) || provisionOptions.contains(ProvisionOptions.FORCE_CREATE))
                 return provisionSpot(listener);
             return null;
         }
-        return provisionOndemand(listener, requiredLabel, provisionOptions);
+        return provisionOndemand(listener, requiredLabel, provisionOptions, excludedSlaves);
     }
 
     /**
@@ -478,10 +482,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         LOGGER.info(message);
     }
 
+    private EC2AbstractSlave provisionOndemand(TaskListener listener, Label requiredLabel, EnumSet<ProvisionOptions> provisionOptions) throws AmazonClientException, IOException {
+        return provisionOndemand(listener, requiredLabel, provisionOptions, null);
+    }
+
     /**
      * Provisions an On-demand EC2 slave by launching a new instance or starting a previously-stopped instance.
      */
-    private EC2AbstractSlave provisionOndemand(TaskListener listener, Label requiredLabel, EnumSet<ProvisionOptions> provisionOptions) throws AmazonClientException, IOException {
+    private EC2AbstractSlave provisionOndemand(TaskListener listener, Label requiredLabel, EnumSet<ProvisionOptions> provisionOptions, ArrayList<EC2AbstractSlave> excludedSlaves) throws AmazonClientException, IOException {
         PrintStream logger = listener.getLogger();
         AmazonEC2 ec2 = getParent().connect();
 
@@ -602,9 +610,24 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 for (Reservation reservation : diResult.getReservations()) {
                     for (Instance instance : reservation.getInstances()) {
                         if (checkInstance(logger, instance, requiredLabel, ec2Node)) {
-                            existingInstance = instance;
-                            logProvision(logger, "Found existing instance: " + existingInstance + ((ec2Node[0] != null) ? (" node: " + ec2Node[0].getInstanceId()) : ""));
-                            break reservationLoop;
+                            boolean excluded = false;
+
+                            if (excludedSlaves != null) {
+                                for (EC2AbstractSlave slave : excludedSlaves) {
+                                    if (ec2Node[0].instanceId.equals(slave.instanceId)) {
+                                        logProvision(logger, "Excluding previously provisioned instance " + ec2Node[0].instanceId);
+                                        excluded = true;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (!excluded) {
+                                existingInstance = instance;
+                                logProvision(logger, "Found existing instance: " + existingInstance + ((ec2Node[0] != null) ? (" node: " + ec2Node[0].getInstanceId()) : ""));
+                                break reservationLoop;
+                            }
+
                         }
                     }
                 }


### PR DESCRIPTION
When provisioning several on demand slaves, provisionOndemand() can return the same slave multiple times while it is launching.
Keep a list of already provisioned slaves, and exclude them from the available pool when asking for more slaves.