### PR TITLE
JENKINS-50105 EC2 Step provisioning incorrectly specifies a label

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -553,21 +553,19 @@ public abstract class EC2Cloud extends Cloud {
                 if (slave == null)
                     break;
                 LOGGER.log(Level.INFO, String.format("We have now %s computers", Jenkins.getInstance().getComputers().length));
-                if (t.isNode()) {
-                    Jenkins.getInstance().addNode(slave);
-                    LOGGER.log(Level.INFO, String.format("Added node named: %s, We have now %s computers", slave.getNodeName(), Jenkins.getInstance().getComputers().length));
-                    r.add(new PlannedNode(t.getDisplayName(), Computer.threadPoolForRemoting.submit(new Callable<Node>() {
+                Jenkins.getInstance().addNode(slave);
+                LOGGER.log(Level.INFO, String.format("Added node named: %s, We have now %s computers", slave.getNodeName(), Jenkins.getInstance().getComputers().length));
+                r.add(new PlannedNode(t.getDisplayName(), Computer.threadPoolForRemoting.submit(new Callable<Node>() {
 
-                        public Node call() throws Exception {
-                            long startTime = System.currentTimeMillis(); // fetch starting time
-                            while ((System.currentTimeMillis() - startTime) < slave.launchTimeout * 1000) {
-                                return tryToCallSlave(slave, t);
-                            }
-                            LOGGER.log(Level.WARNING, "Expected - Instance - failed to connect within launch timeout");
+                    public Node call() throws Exception {
+                        long startTime = System.currentTimeMillis(); // fetch starting time
+                        while ((System.currentTimeMillis() - startTime) < slave.launchTimeout * 1000) {
                             return tryToCallSlave(slave, t);
                         }
-                    }), t.getNumExecutors()));
-                }
+                        LOGGER.log(Level.WARNING, "Expected - Instance - failed to connect within launch timeout");
+                        return tryToCallSlave(slave, t);
+                    }
+                }), t.getNumExecutors()));
 
                 excessWorkload -= t.getNumExecutors();
             }

--- a/src/main/java/hudson/plugins/ec2/EC2Step.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Step.java
@@ -141,14 +141,13 @@ public class EC2Step extends Step {
                 SlaveTemplate t;
                 t = ((AmazonEC2Cloud) cl).getTemplate(this.template);
                 if (t != null) {
-                    t.setNode(false);
-                    LabelAtom lbl = new LabelAtom(this.template);
                     SlaveTemplate.ProvisionOptions universe = SlaveTemplate.ProvisionOptions.ALLOW_CREATE;
                     EnumSet<SlaveTemplate.ProvisionOptions> opt = EnumSet.noneOf(SlaveTemplate.ProvisionOptions.class);
                     opt.add(universe);
 
-                    EC2AbstractSlave instance = t.provision(TaskListener.NULL, lbl, opt);
-                    Instance myInstance = EC2AbstractSlave.getInstance(instance.getInstanceId(), instance.getCloud());
+                    EC2AbstractSlave node = t.provision(TaskListener.NULL, null, opt);
+                    Jenkins.getInstance().addNode(node);
+                    Instance myInstance = EC2AbstractSlave.getInstance(node.getInstanceId(), node.getCloud());
                     return myInstance;
                 } else {
                     throw new IllegalArgumentException("Error in AWS Cloud. Please review AWS template defined in Jenkins configuration.");

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -128,8 +128,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public final boolean connectUsingPublicIp;
 
-    private boolean node = true;
-
     private transient/* almost final */Set<LabelAtom> labelSet;
 
     private transient/* almost final */Set<String> securityGroupSet;
@@ -392,15 +390,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public String getIamInstanceProfile() {
         return iamInstanceProfile;
     }
-
-    public void setNode(Boolean node) {
-        this.node = node;
-    }
-
-    public Boolean isNode() {
-        return this.node;
-    }
-
 
     public enum ProvisionOptions { ALLOW_CREATE, FORCE_CREATE }
 

--- a/src/test/java/hudson/plugins/ec2/EC2StepTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2StepTest.java
@@ -55,6 +55,8 @@ public class EC2StepTest {
         when(cl.getTemplates()).thenReturn(templates);
         when(cl.getTemplate(anyString())).thenReturn(st);
         r.addCloud(cl);
+
+        when(instance.getNodeName()).thenReturn("nodeName");
     }
 
 


### PR DESCRIPTION
JENKINS-47130 EC2 plugin 1.37 fails to provision previously defined slaves