### PR TITLE
JENKINS-38311: Don't start up EC2 slaves that are turned off when Jenkins starts up

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -144,7 +144,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
     }
 
     /**
-     * Called when a new {@link Computer} object is introduced (such as when Hudson started, or when
+     * Called when a new {@link EC2Computer} object is introduced (such as when Hudson started, or when
      * a new agent is added.)
      *
      * When Jenkins has just started, we don't want to spin up all the instances, so we only start if


### PR DESCRIPTION
Currently when jenkins is restarted, all EC2 slaves are started regardless of whether the EC2 instances are currently running.

In the case where there are a large number of slaves, this can have a non-trivial cost.

This change makes it so that when jenkins starts up, EC2 slaves are only started if the EC2 instance is running (or starting to run).

This fixes https://issues.jenkins-ci.org/browse/JENKINS-37552