### PR TITLE
Improving debug messaging for WinConnector. 

### DIFF
--- a/src/main/java/hudson/plugins/ec2/win/WinConnection.java
+++ b/src/main/java/hudson/plugins/ec2/win/WinConnection.java
@@ -120,7 +120,7 @@ public class WinConnection {
     }
 
     public boolean ping() {
-        log.log(Level.FINE, "pinging " + host);
+        log.log(Level.FINE, "checking SMB connection to " + host);
         try {
             Socket socket=new Socket();
             socket.connect(new InetSocketAddress(host, 445), TIMEOUT);


### PR DESCRIPTION
Ran into this issue when attempting to troubleshoot connection issues between master and windows slave. Instead of an ICMP packet, the "ping" method opens a TCP socket, and attempts to do an SMB file transfer.