### PR TITLE
Add support for Spot Instances without bidding

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -50,7 +50,11 @@ THE SOFTWARE.
     <f:textbox/>
   </f:entry>
 
-  <f:optionalBlock name="spotConfig" title="Use Spot Instance" checked="${instance.spotConfig != null}">
+  <f:entry title="${%Use Spot Instances without bid}" field="useSpotInstancesNoBid">
+    <f:checkbox />
+  </f:entry>
+
+  <f:optionalBlock name="spotConfig" title="Use Spot Instance with bid" checked="${instance.spotConfig != null}">
     <f:validateButton title="${%Check Current Spot Price}" progress="${%Checking...}" method="currentSpotPrice" with="useInstanceProfileForCredentials,credentialsId,region,type,zone" />
 
     <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice">

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-useSpotInstancesNoBid.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-useSpotInstancesNoBid.html
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<div>
+    Start the EC2 agent as a spot instance without specifying a bid price. AWS will automatically create a Spot Instance
+    Request with a bid at the current On-Demand price.
+</div>

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -207,7 +207,7 @@ public class SlaveTemplateTest {
 
     @Test
     public void testConnectUsingPublicIpSetting() {
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, false, null, true, "", false, true);
+        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, false, null, true, "", false, true, false);
         assertTrue(st.isConnectUsingPublicIp());
     }
 


### PR DESCRIPTION
At re:Invent 2017, AWS announced it would support starting EC2 spot instances without setting a bid price. The bid price is automatically set at the current On-Demand price. You still pay the current market price, which is most often less than the On-Demand price.

Supporting this in the plugin decreases the amount of configuration needed by the user. There is only a checkbox to check.

![2018-04-06_09h50_07](https://user-images.githubusercontent.com/5759247/38424704-ebbc7b02-397f-11e8-9820-f7eb15f325d0.png)