### PR TITLE
Tag slave instances to their jenkins master

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -81,6 +81,7 @@ import javax.servlet.ServletException;
 
 import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
+import jenkins.model.JenkinsLocationConfiguration;
 
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.HttpResponse;
@@ -355,19 +356,24 @@ public abstract class EC2Cloud extends Cloud {
      * @param template If left null, then all instances are counted.
      */
     private int countCurrentEC2Slaves(SlaveTemplate template) throws AmazonClientException {
-        LOGGER.log(Level.FINE, "Counting current slaves: " + (template != null ? (" AMI: " + template.getAmi()) : " All AMIS"));
+        String jenkinsServerUrl = JenkinsLocationConfiguration.get().getUrl();
+
+        LOGGER.log(Level.FINE, "Counting current slaves: "
+            + (template != null ? (" AMI: " + template.getAmi() + " TemplateDesc: " + template.description) : " All AMIS")
+            + " Jenkins Server: " + jenkinsServerUrl);
         int n = 0;
         Set<String> instanceIds = new HashSet<String>();
         String description = template != null ? template.description : null;
 
         for (Reservation r : connect().describeInstances().getReservations()) {
             for (Instance i : r.getInstances()) {
-                if (isEc2ProvisionedAmiSlave(i.getTags(), description) && (template == null
-                        || template.getAmi().equals(i.getImageId()))) {
+                if (isEc2ProvisionedAmiSlave(i.getTags(), description)
+                    && isEc2ProvisionedJenkinsSlave(i.getTags(), jenkinsServerUrl)
+                    && (template == null || template.getAmi().equals(i.getImageId()))) {
                     InstanceStateName stateName = InstanceStateName.fromValue(i.getState().getName());
                     if (stateName != InstanceStateName.Terminated && stateName != InstanceStateName.ShuttingDown) {
                         LOGGER.log(Level.FINE, "Existing instance found: " + i.getInstanceId() + " AMI: " + i.getImageId()
-                                + " Template: " + description);
+                        + (template != null ? (" Template: " + description) : "") + " Jenkins Server: " + jenkinsServerUrl);
                         n++;
                         instanceIds.add(i.getInstanceId());
                     }
@@ -382,6 +388,9 @@ public abstract class EC2Cloud extends Cloud {
             values.add(template.getAmi());
             filters.add(new Filter("launch.image-id", values));
         }
+
+        // The instances must match the jenkins server url
+        filters.add(new Filter("tag:" + EC2Tag.TAG_NAME_JENKINS_SERVER_URL + "=" + jenkinsServerUrl));
 
         values = new ArrayList<String>();
         values.add(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE);
@@ -475,6 +484,15 @@ public abstract class EC2Cloud extends Cloud {
         return n;
     }
 
+    private boolean isEc2ProvisionedJenkinsSlave(List<Tag> tags, String serverUrl) {
+        for (Tag tag : tags) {
+            if (StringUtils.equals(tag.getKey(), EC2Tag.TAG_NAME_JENKINS_SERVER_URL)) {
+                return StringUtils.equals(tag.getValue(), serverUrl);
+            }
+        }
+        return false;
+    }
+
     private boolean isEc2ProvisionedAmiSlave(List<Tag> tags, String description) {
         for (Tag tag : tags) {
             if (StringUtils.equals(tag.getKey(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE)) {
@@ -520,7 +538,7 @@ public abstract class EC2Cloud extends Cloud {
          * allocated, we don't look at that instance as available for provisioning.
          */
         int possibleSlavesCount = getPossibleNewSlavesCount(template);
-        if (possibleSlavesCount < 0) {
+        if (possibleSlavesCount <= 0) {
             LOGGER.log(Level.INFO, "Cannot provision - no capacity for instances: " + possibleSlavesCount);
             return null;
         }

--- a/src/main/java/hudson/plugins/ec2/EC2Tag.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Tag.java
@@ -41,6 +41,7 @@ public class EC2Tag extends AbstractDescribableImpl<EC2Tag> {
      * Tag name for the specific jenkings slave type tag, used to identify the EC2 instances provisioned by this plugin.
      */
     public static final String TAG_NAME_JENKINS_SLAVE_TYPE = "jenkins_slave_type";
+    public static final String TAG_NAME_JENKINS_SERVER_URL = "jenkins_server_url";
 
     @DataBoundConstructor
     public EC2Tag(String name, String value) {


### PR DESCRIPTION
This replaces PR #271 that had the wrong starting branch.

In the case where you have multiple Jenkins masters using the same configuration (same AMI for multiple clouds), the instance cap is shared between all instances and clouds. The workaround is to add an additional tag with the Jenkins url to have this instance cap unique per Jenkins master.