### PR TITLE
Start agent in cygwin friendly way

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -190,9 +190,8 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
             scp.put(Jenkins.getInstance().getJnlpJars("slave.jar").readFully(), "slave.jar", tmpDir);
 
             String jvmopts = computer.getNode().jvmopts;
-            String prefix = computer.getSlaveCommandPrefix();
-            String launchString = prefix + " java " + (jvmopts != null ? jvmopts : "") + " -jar " + tmpDir + "/slave.jar";
-           // launchString = launchString.trim();
+            String command = "cd " + tmpDir + " && java " + (jvmopts != null ? jvmopts : "") + " -jar slave.jar";
+            String launchString = computer.getSlaveCommandPrefix() + "\"" + command + "\"";
 
             SlaveTemplate slaveTemplate = computer.getSlaveTemplate();
 


### PR DESCRIPTION
Unfortunately, cygwin and Java are not best friends. So, JVM under cygwin is not
able to resolve '/tmp/slave.jar` properly. To avoid this issue let's
change directory first and execute local file.

After that user can use Windows node in absolutely same way as Unix node.