### PR TITLE
Bump aws-java-sdk to pick up c5d and m5d instance types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.329</version>
+            <version>1.11.341</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.264</version>
+            <version>1.11.332</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.332</version>
+            <version>1.11.329</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -201,6 +201,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 7;
         case C5Large:
             return 7;
+        case C5dLarge:
+            return 7;
         case M1Xlarge:
             return 8;
         case M22xlarge:
@@ -214,6 +216,8 @@ public abstract class EC2AbstractSlave extends Slave {
         case C4Xlarge:
             return 14;
         case C5Xlarge:
+            return 14;
+        case C5dXlarge:
             return 14;
         case C1Xlarge:
             return 20;
@@ -231,6 +235,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 28;
         case C52xlarge:
             return 28;
+        case C5d2xlarge:
+            return 28;
         case Cc14xlarge:
             return 33;
         case Cg14xlarge:
@@ -245,6 +251,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 55;
         case C54xlarge:
             return 55;
+        case C5d4xlarge:
+            return 55;
         case M44xlarge:
             return 55;
         case Cc28xlarge:
@@ -257,10 +265,14 @@ public abstract class EC2AbstractSlave extends Slave {
             return 108;
         case C59xlarge:
             return 108;
+        case C5d9xlarge:
+            return 108;
         case M410xlarge:
             return 120;
             // TODO: M416xlarge
         case C518xlarge:
+            return 216;
+        case C5d18xlarge:
             return 216;
             // We don't have a suggestion, but we don't want to fail completely
             // surely?


### PR DESCRIPTION
On may 17th - amazon released new C5d (with local storage) instance type, bump aws-java-sdk + add new types