### PR TITLE
Govcloud Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@ THE SOFTWARE.
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugins</artifactId>
+                <version>2.19.1</version>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
Create a region specific ec2 URL if the region is available. If the plugin is running inside of Govcloud, modified the way tags are applied to support Govcloud restrictions.