### PR TITLE
[JENKINS-47681] Don't count slaves we just provisioned multiple times

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,2 +1,3 @@
 - the uptime should be displayed there
 - cloud configuration page should be moved elsewhere, like how we configure slaves
+- blank commit to rerun pipeline

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -511,7 +511,7 @@ public abstract class EC2Cloud extends Cloud {
     }
 
     private synchronized EC2AbstractSlave getNewOrExistingAvailableSlave(SlaveTemplate template, Label requiredLabel, forceCreateNew, null){
-        return getNewOrExistingAvailableSlave(template, requiredLabel, forceCreateNew, null);
+        return getNewOrExistingAvailableSlave(template, requiredLabel, forceCreateNew);
     }
     /**
      * Obtains a slave whose AMI matches the AMI of the given template, and that also has requiredLabel (if requiredLabel is non-null)

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -510,7 +510,7 @@ public abstract class EC2Cloud extends Cloud {
         return Math.min(availableAmiSlaves, availableTotalSlaves);
     }
 
-    private synchronized EC2AbstractSlave getNewOrExistingAvailableSlave(SlaveTemplate template, Label requiredLabel, forceCreateNew){
+    private synchronized EC2AbstractSlave getNewOrExistingAvailableSlave(SlaveTemplate template, Label requiredLabel, boolean forceCreateNew){
         return getNewOrExistingAvailableSlave(template, requiredLabel, forceCreateNew, null);
     }
     /**

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -510,8 +510,8 @@ public abstract class EC2Cloud extends Cloud {
         return Math.min(availableAmiSlaves, availableTotalSlaves);
     }
 
-    private synchronized EC2AbstractSlave getNewOrExistingAvailableSlave(SlaveTemplate template, Label requiredLabel, forceCreateNew, null){
-        return getNewOrExistingAvailableSlave(template, requiredLabel, forceCreateNew);
+    private synchronized EC2AbstractSlave getNewOrExistingAvailableSlave(SlaveTemplate template, Label requiredLabel, forceCreateNew){
+        return getNewOrExistingAvailableSlave(template, requiredLabel, forceCreateNew, null);
     }
     /**
      * Obtains a slave whose AMI matches the AMI of the given template, and that also has requiredLabel (if requiredLabel is non-null)


### PR DESCRIPTION
Rerunning #267 to see if we can isolate the commit in the continuous integration run for debugging purposes. If this isn't best practice/there's a better way to do this, please let me know!