### PR TITLE
JENKINS-33443 Wait for touch ~/.hudson-run-init to complete

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -173,11 +173,24 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 }
                 sess.close();
 
+                logInfo(computer, listener, "Creating ~/.hudson-run-init");
+
                 // Needs a tty to run sudo.
                 sess = conn.openSession();
                 sess.requestDumbPTY(); // so that the remote side bundles stdout
                                        // and stderr
                 sess.execCommand(buildUpCommand(computer, "touch ~/.hudson-run-init"));
+
+                sess.getStdin().close(); // nothing to write here
+                sess.getStderr().close(); // we are not supposed to get anything
+                                          // from stderr
+                IOUtils.copy(sess.getStdout(), logger);
+
+                exitStatus = waitCompletion(sess);
+                if (exitStatus != 0) {
+                    logWarning(computer, listener, "init script failed: exit code=" + exitStatus);
+                    return;
+                }
                 sess.close();
             }
 


### PR DESCRIPTION
This prevents the session from sometimes being closed before the .hudson-run-init file has been written. It would also log any errors that occurred while trying.