### PR TITLE
JENKINS-52012: Fix counting of slave caps with spot instances

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -403,12 +403,14 @@ public abstract class EC2Cloud extends Cloud {
                     if (sir.getInstanceId() != null && instanceIds.contains(sir.getInstanceId()))
                         continue;
 
-                    LOGGER.log(Level.FINE, "Spot instance request found: " + sir.getSpotInstanceRequestId() + " AMI: "
-                            + sir.getInstanceId() + " state: " + sir.getState() + " status: " + sir.getStatus());
-                    n++;
-                    
-                    if (sir.getInstanceId() != null)
-                        instanceIds.add(sir.getInstanceId());
+                    if (isEc2ProvisionedAmiSlave(sir.getTags(), description)) {
+                        LOGGER.log(Level.FINE, "Spot instance request found: " + sir.getSpotInstanceRequestId() + " AMI: "
+                                + sir.getInstanceId() + " state: " + sir.getState() + " status: " + sir.getStatus());
+
+                        n++;
+                        if (sir.getInstanceId() != null)
+                            instanceIds.add(sir.getInstanceId());
+                    }
                 } else {
                     // Canceled or otherwise dead
                     for (Node node : Jenkins.getInstance().getNodes()) {


### PR DESCRIPTION
 When checking caps, only count spot instance requests with tag matching our description.