### PR TITLE
Convert global findbugs skip to specific per class

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,0 +1,74 @@
+<FindBugsFilter>
+    <Match>
+        <Class name="hudson.plugins.ec2.EC2Cloud"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.win.EC2WindowsLauncher"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.AmazonEC2Cloud"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.AmazonEC2Cloud$DescriptorImpl"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.ssh.EC2UnixLauncher"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.SlaveTemplate"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.SlaveTemplate$DescriptorImpl"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.EC2AbstractSlave"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.EC2AbstractSlave$DescriptorImpl"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.UnixData$DescriptorImpl"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.PluginImpl"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.EC2Computer"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.EC2ComputerLauncher"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.EC2OndemandSlave"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.EC2PrivateKey"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.EC2Step$Execution"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.EC2RetentionStrategy"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.EC2SlaveMonitor"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.EC2Tag"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.EC2SpotSlave"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.SpotConfiguration"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.ebs.ZPoolMonitor"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.win.WinConnection"/>
+    </Match>
+    <Match>
+        <Class name="hudson.plugins.ec2.win.winrm.request.SendInputRequest"/>
+    </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@ THE SOFTWARE.
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This change is to stop adding more FindBugs "violations" in other classes.

The idea is to also make fixing those more feasible progressively:
one can now remove a single "Match" entry from the exclusion file,
contribute a single fix for the related FindBugs errors, and move on.

I.e. one does not have to fix it all at once when removing "skip".

@francisu as the current maintainer.
cc @reviewbybees for more eyes.

Thanks!