### PR TITLE
introduce a ProvisionerStrategy to provision a node without delay

### DIFF
--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -42,6 +42,7 @@ import jenkins.model.Jenkins;
 
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -65,6 +66,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
 
     // Used when running unit tests
     public static boolean testMode;
+    private boolean noDelayProvisioning;
 
     @DataBoundConstructor
     public AmazonEC2Cloud(String cloudName, boolean useInstanceProfileForCredentials, String credentialsId, String region, String privateKey, String instanceCapStr, List<? extends SlaveTemplate> templates) {
@@ -115,6 +117,15 @@ public class AmazonEC2Cloud extends EC2Cloud {
         } catch (MalformedURLException e) {
             throw new Error(e); // Impossible
         }
+    }
+
+    public boolean isNoDelayProvisioning() {
+        return noDelayProvisioning;
+    }
+
+    @DataBoundSetter
+    public void setNoDelayProvisioning(boolean noDelayProvisioning) {
+        this.noDelayProvisioning = noDelayProvisioning;
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/ec2/NoDelayProvisionerStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/NoDelayProvisionerStrategy.java
@@ -1,0 +1,62 @@
+package hudson.plugins.ec2;
+
+import hudson.Extension;
+import hudson.model.Label;
+import hudson.model.LoadStatistics;
+import hudson.slaves.Cloud;
+import hudson.slaves.NodeProvisioner;
+import jenkins.model.Jenkins;
+
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Implementation of {@link NodeProvisioner.Strategy} which will provision a new node immediately as
+ * a task enter the queue.
+ * Now that EC2 is billed by the minute, we don't really need to wait before provisioning a new node.
+ *
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Extension(ordinal = 100)
+public class NoDelayProvisionerStrategy extends NodeProvisioner.Strategy {
+
+    private static final Logger LOGGER = Logger.getLogger(NoDelayProvisionerStrategy.class.getName());
+
+    @Override
+    public NodeProvisioner.StrategyDecision apply(NodeProvisioner.StrategyState strategyState) {
+        final Label label = strategyState.getLabel();
+
+        LoadStatistics.LoadStatisticsSnapshot snapshot = strategyState.getSnapshot();
+        int availableCapacity =
+                  snapshot.getAvailableExecutors()   // live executors
+                + snapshot.getConnectingExecutors()  // executors present but not yet connected
+                + strategyState.getPlannedCapacitySnapshot()     // capacity added by previous strategies from previous rounds
+                + strategyState.getAdditionalPlannedCapacity();  // capacity added by previous strategies _this round_
+        int currentDemand = snapshot.getQueueLength();
+        LOGGER.log(Level.FINE, "Available capacity={0}, currentDemand={1}",
+                new Object[]{availableCapacity, currentDemand});
+        if (availableCapacity < currentDemand) {
+
+            for (Cloud cloud : Jenkins.getInstance().clouds) {
+                if (!cloud.canProvision(label)) continue;
+
+                Collection<NodeProvisioner.PlannedNode> plannedNodes = cloud.provision(label, currentDemand - availableCapacity);
+                LOGGER.log(Level.FINE, "Planned {0} new nodes", plannedNodes.size());
+                strategyState.recordPendingLaunches(plannedNodes);
+                availableCapacity += plannedNodes.size();
+                LOGGER.log(Level.FINE, "After provisioning, available capacity={0}, currentDemand={1}",
+                        new Object[]{availableCapacity, currentDemand});
+                break;
+            }
+        }
+        if (availableCapacity >= currentDemand) {
+            LOGGER.log(Level.FINE, "Provisioning completed");
+            return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
+        } else {
+            LOGGER.log(Level.FINE, "Provisioning not complete, consulting remaining strategies");
+            return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/ec2/NoDelayProvisionerStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/NoDelayProvisionerStrategy.java
@@ -39,7 +39,10 @@ public class NoDelayProvisionerStrategy extends NodeProvisioner.Strategy {
         if (availableCapacity < currentDemand) {
 
             for (Cloud cloud : Jenkins.getInstance().clouds) {
+                if (!(cloud instanceof AmazonEC2Cloud)) continue;
                 if (!cloud.canProvision(label)) continue;
+                AmazonEC2Cloud ec2 = (AmazonEC2Cloud) cloud;
+                if (!ec2.isNoDelayProvisioning()) continue;
 
                 Collection<NodeProvisioner.PlannedNode> plannedNodes = cloud.provision(label, currentDemand - availableCapacity);
                 LOGGER.log(Level.FINE, "Planned {0} new nodes", plannedNodes.size());

--- a/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
@@ -40,6 +40,10 @@ THE SOFTWARE.
     <f:entry title="${%Instance Cap}" field="instanceCapStr">
       <f:textbox />
     </f:entry>
+
+    <f:entry title="${%No delay provisioning}" field="noDelayProvisioning">
+      <f:checkbox/>
+    </f:entry>
   </f:advanced>
   <f:validateButton title="${%Generate Key}" progress="${%Generate...}" method="generateKey" with="region,useInstanceProfileForCredentials,credentialsId" />
   <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="region,useInstanceProfileForCredentials,credentialsId,privateKey" />

--- a/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/help-noDelayProvisioning.html
+++ b/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/help-noDelayProvisioning.html
@@ -1,0 +1,5 @@
+By default Jenkins do estimate load to avoid over-provisioning of cloud nodes.
+With this option enabled, a new node is created on Amazon EC2 as soon as NodeProvisioner detects need for more agents.
+In worse scenarios, this will results in some extra nodes provisioned on EC2, which will be shortly terminated. EC2
+being billed by the second since 2017 this won't have a huge impact on infrastructure costs, while offering build nodes
+without unnecessary delays.


### PR DESCRIPTION
the standard `NodeProvisioner.Strategy` has been implemented to avoid over-provisioning, mostly designed at a time EC2 instances where billed by hours, which means we didn't wanted to get an extra one while jenkins might soon have available executors.
As EC2 is now billed by the minute we can just provision a new node when we miss one without delay, in worse case it will stay for few minutes then be terminated.