### PR TITLE
[JENKINS-35708] Round-robin subnet selection

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -537,7 +537,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             if (getAssociatePublicIp()) {
                 net.setSubnetId(subnetId);
             } else {
-                reRequest.setSubnetId(subnetId);
+                riRequest.setSubnetId(subnetId);
             }
 
             diFilters.add(new Filter("subnet-id").withValues(subnetId));

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -130,6 +130,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public final boolean connectUsingPublicIp;
 
+    public int nextSubnet;
+
+    public String currentSubnetId;
+
     private transient/* almost final */Set<LabelAtom> labelSet;
 
     private transient/* almost final */Set<String> securityGroupSet;
@@ -190,6 +194,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.useDedicatedTenancy = useDedicatedTenancy;
         this.connectBySSHProcess = connectBySSHProcess;
         this.monitoring = monitoring;
+        this.nextSubnet = 0;
 
         if (null == instanceCapStr || instanceCapStr.isEmpty()) {
             this.instanceCap = Integer.MAX_VALUE;
@@ -339,9 +344,27 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return amiType.isUnix() ? ((UnixData) amiType).getSlaveCommandPrefix() : "";
     }
 
+    public String chooseSubnetId() {
+        if (StringUtils.isBlank(subnetId)) {
+            return null;
+        } else {
+            String[] subnetIdList= getSubnetId().split(" ");
+
+            // Round-robin subnet selection.
+            String subnet = subnetIdList[nextSubnet];
+            currentSubnetId = subnet;
+            nextSubnet = (nextSubnet + 1) % subnetIdList.length;
+
+            return subnet;
+        }
+    }
 
     public String getSubnetId() {
         return subnetId;
+    }
+
+    public String getCurrentSubnetId() {
+        return currentSubnetId;
     }
 
     public boolean getAssociatePublicIp() {
@@ -507,15 +530,17 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             diFilters.add(new Filter("availability-zone").withValues(getZone()));
         }
 
+        String subnetId = chooseSubnetId();
+
         InstanceNetworkInterfaceSpecification net = new InstanceNetworkInterfaceSpecification();
-        if (StringUtils.isNotBlank(getSubnetId())) {
+        if (StringUtils.isNotBlank(subnetId)) {
             if (getAssociatePublicIp()) {
-                net.setSubnetId(getSubnetId());
+                net.setSubnetId(subnetId);
             } else {
-                riRequest.setSubnetId(getSubnetId());
+                reRequest.setSubnetId(subnetId);
             }
 
-            diFilters.add(new Filter("subnet-id").withValues(getSubnetId()));
+            diFilters.add(new Filter("subnet-id").withValues(subnetId));
 
             /*
              * If we have a subnet ID then we can only use VPC security groups
@@ -789,11 +814,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             }
 
             InstanceNetworkInterfaceSpecification net = new InstanceNetworkInterfaceSpecification();
-            if (StringUtils.isNotBlank(getSubnetId())) {
+            String subnetId = chooseSubnetId();
+            if (StringUtils.isNotBlank(subnetId)) {
                 if (getAssociatePublicIp()) {
-                    net.setSubnetId(getSubnetId());
+                    net.setSubnetId(subnetId);
                 } else {
-                    launchSpecification.setSubnetId(getSubnetId());
+                    launchSpecification.setSubnetId(subnetId);
                 }
 
                 /*
@@ -979,7 +1005,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 List<Filter> filters = new ArrayList<Filter>();
                 filters.add(new Filter("vpc-id").withValues(group.getVpcId()));
                 filters.add(new Filter("state").withValues("available"));
-                filters.add(new Filter("subnet-id").withValues(getSubnetId()));
+                filters.add(new Filter("subnet-id").withValues(getCurrentSubnetId()));
 
                 DescribeSubnetsRequest subnetReq = new DescribeSubnetsRequest();
                 subnetReq.withFilters(filters);

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -112,7 +112,7 @@ THE SOFTWARE.
       <f:checkbox />
     </f:entry>
 
-    <f:entry title="${%Subnet ID for VPC}" field="subnetId">
+    <f:entry title="${%Subnet IDs for VPC}" field="subnetId">
        <f:textbox />
     </f:entry>
 

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-subnetId.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-subnetId.html
@@ -1,0 +1,3 @@
+<div>
+  Space-separated list of subnet IDs to launch instances into.<br/><br/>Specify one or more subnet IDs if you're using a non-default VPC. If more than one subnet ID is provided, instances will be launched in each subnet in a round-robin fashion beginning with the first subnet in the list.
+</div>

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -274,4 +274,17 @@ public class SlaveTemplateTest {
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "amiType");
     }
+
+    @Test
+    public void testChooseSubnetId() throws Exception {
+        SlaveTemplate slaveTemplate = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123 subnet-456", null, null, true, null, "", false, false, "", false, "");
+
+        String subnet1 = slaveTemplate.chooseSubnetId();
+        String subnet2 = slaveTemplate.chooseSubnetId();
+        String subnet3 = slaveTemplate.chooseSubnetId();
+
+        assertEquals(subnet1, "subnet-123");
+        assertEquals(subnet2, "subnet-456");
+        assertEquals(subnet3, "subnet-123");
+    }
 }


### PR DESCRIPTION
[JENKINS-35708]

Allow users to supply multiple subnets for launching EC2 instances into
instead of just one. This solves the issue where you need to launch a
large amount of somewhat less available instances (e.g. GPU instances)
and need to use multiple availability zones to avoid exhausting that
instance type.

I tried to avoid breaking any backwards compatibility. I slightly
modified the behavior of the subnet ID configuration field: if you
provide a space-separated list of subnet IDs, the code will cycle
through them in order beginning with the first one. If you have one ID
it will still technically cycle through them, but the end result is that
you only launch instances into that single subnet as before, preserving
the original behavior.

I also added help text for the subnet ID field.