### PR TITLE
[JENKINS-53285] bump to latest node-iterator-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>node-iterator-api</artifactId>
-            <version>1.5</version>
+            <version>1.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
[JENKINS-53285](https://issues.jenkins-ci.org/browse/JENKINS-53285)

This version is the same as 1.5, but just got a parent pom bump, and an internal change to enable findbugs checking.

Cf. https://github.com/jenkinsci/node-iterator-api-plugin/compare/7b284cb95b1ebcd09a430b94fd75d5599e867668...f73034788d1c8752ab7bef3af6aea664f3af674e for the detailed changes from 1.5 to 1.5.0