### PR TITLE
Upgrade baseline versions of Jenkins, Java, Apache HttpClient, and BouncyCastle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>bouncycastle-api</artifactId>
-            <version>1.648.3</version>
+            <version>2.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ THE SOFTWARE.
         <changelist>-SNAPSHOT</changelist>
         <powermock.version>1.6.3</powermock.version>
         <jenkins.version>1.651.3</jenkins.version>
-        <java.level>7</java.level>
+        <java.level>8</java.level>
     </properties>
 
     <dependencies>
@@ -125,9 +125,9 @@ THE SOFTWARE.
             <version>1.5.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
+            <version>4.5.5-3.0</version>
         </dependency>
         <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ THE SOFTWARE.
         <revision>1.40</revision>
         <changelist>-SNAPSHOT</changelist>
         <powermock.version>1.6.3</powermock.version>
-        <jenkins.version>1.651.3</jenkins.version>
+        <jenkins.version>2.60.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
 


### PR DESCRIPTION
Instead of relying directly on a common dependency, this switches to the
Jenkins plugin that bundles HttpClient et al. in an easily upgradeable
Jenkins plugin. This also upgrades the base level of Java required to
1.8 as dependencies (including Jenkins) now require it.

@reviewbybees 