### PR TITLE
Jenkins 54271

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ebs/ZPoolExpandNotice.java
+++ b/src/main/java/hudson/plugins/ec2/ebs/ZPoolExpandNotice.java
@@ -46,4 +46,9 @@ public class ZPoolExpandNotice extends AdministrativeMonitor {
     public boolean isActivated() {
         return activated;
     }
+
+    @Override
+    public String getDisplayName() {
+        return Messages.ZPoolExpandNotice_DisplayName();
+    }
 }

--- a/src/main/resources/hudson/plugins/ec2/ebs/Messages.properties
+++ b/src/main/resources/hudson/plugins/ec2/ebs/Messages.properties
@@ -1,0 +1,1 @@
+ZPoolExpandNotice.DisplayName=ZFS Pool Monitor


### PR DESCRIPTION
See [JENKINS-54271](https://issues.jenkins-ci.org/browse/JENKINS-54271)

The display name for the TLS configuration administrative monitor is missing. This PR tries to fix it.

![seleccion_006](https://user-images.githubusercontent.com/31063239/47564457-5fdaeb00-d925-11e8-8f74-a41cd91709ca.png)

@reviewbybees
@jvz as maintainer of the plugin