### PR TITLE
[JENKINS-54266] Warn if no server URL and default to instance-identity instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,12 @@ THE SOFTWARE.
             <version>4.5.5-3.0</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.modules</groupId>
+            <artifactId>instance-identity</artifactId>
+            <version>2.2</version>
+            <scope>provided</scope><!-- comes from the core -->
+        </dependency>
+        <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-cps</artifactId>
                 <version>2.30</version>

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -384,6 +384,11 @@ public abstract class EC2Cloud extends Cloud {
         if (jenkinsLocation != null)
             jenkinsServerUrl = jenkinsLocation.getUrl();
 
+        if (jenkinsServerUrl == null) {
+            LOGGER.log(Level.WARNING, "No Jenkins server URL specified, using legacy instance id instead");
+            jenkinsServerUrl = Jenkins.getInstance().getLegacyInstanceId();
+        }
+
         LOGGER.log(Level.FINE, "Counting current slaves: "
             + (template != null ? (" AMI: " + template.getAmi() + " TemplateDesc: " + template.description) : " All AMIS")
             + " Jenkins Server: " + jenkinsServerUrl);

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -397,10 +397,6 @@ public abstract class EC2Cloud extends Cloud {
         if (jenkinsServerUrl == null) {
             LOGGER.log(Level.WARNING, "No Jenkins server URL specified, using instance-identity instead");
             jenkinsServerUrl = getInstanceIdentityEncodedPublicKey();
-            if (jenkinsServerUrl == null) {
-                LOGGER.log(Level.WARNING, "No instance-identity available?! Using the legacy instance id instead");
-                jenkinsServerUrl = Jenkins.getInstance().getLegacyInstanceId();
-            }
         }
 
         LOGGER.log(Level.FINE, "Counting current slaves: "


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-54266

(Also filed https://github.com/jenkinsci/instance-identity-module/pull/13 but cannot use it for now at it needs to be merged, released, and become embedded in the minimum Jenkins baseline, hence in a pretty far future.)