### PR TITLE
Reincrementalify and update to latest parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,11 @@ THE SOFTWARE.
     <parent>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plugin</artifactId>
-      <version>3.15</version>
+      <version>3.25</version>
     </parent>
 
     <artifactId>ec2</artifactId>
-    <version>1.42-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Amazon EC2 plugin</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Plugin</url>
@@ -54,7 +54,7 @@ THE SOFTWARE.
     </scm>
 
     <properties>
-        <revision>1.40</revision>
+        <revision>1.42</revision>
         <changelist>-SNAPSHOT</changelist>
         <powermock.version>1.6.3</powermock.version>
         <jenkins.version>2.60.3</jenkins.version>


### PR DESCRIPTION
This will get the [>= 3.18 parent pom](https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md#318) so that the pom.xml is automatically _reincrementalified_ on normal releases and this way the EC2 plugin still gets its incremental releases published at http://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/ec2/ as expected :)

I had filed https://issues.jenkins-ci.org/browse/INFRA-1825 before realizing the issue might be on the EC2 plugin side. Hence this PR.