### PR TITLE
Do not tag instances if no serverUrl

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -46,8 +46,6 @@ import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
-import java.nio.charset.Charset;
-import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -72,9 +70,7 @@ import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -358,12 +354,6 @@ public abstract class EC2Cloud extends Cloud {
         }
     }
 
-    // Delete when https://github.com/jenkinsci/instance-identity-module/pull/13 is released and available
-    public String getInstanceIdentityEncodedPublicKey() {
-        RSAPublicKey key = InstanceIdentity.get().getPublic();
-        return new String(Base64.encodeBase64(key.getEncoded()), Charset.forName("UTF-8"));
-    }
-
     /**
      * Counts the number of instances in EC2 that can be used with the specified image and a template. Also removes any
      * nodes associated with canceled requests.
@@ -377,8 +367,8 @@ public abstract class EC2Cloud extends Cloud {
             jenkinsServerUrl = jenkinsLocation.getUrl();
 
         if (jenkinsServerUrl == null) {
-            LOGGER.log(Level.WARNING, "No Jenkins server URL specified, using instance-identity instead");
-            jenkinsServerUrl = getInstanceIdentityEncodedPublicKey();
+            LOGGER.log(Level.WARNING, "No Jenkins server URL specified, it is strongly recommended to open /configure and set the server URL. " +
+                    "Not having has disabled the per-master instance cap counting (cf. https://github.com/jenkinsci/ec2-plugin/pull/310)");
         }
 
         LOGGER.log(Level.FINE, "Counting current slaves: "
@@ -412,8 +402,10 @@ public abstract class EC2Cloud extends Cloud {
             filters.add(new Filter("launch.image-id", values));
         }
 
+        if(jenkinsServerUrl!=null) {
         // The instances must match the jenkins server url
-        filters.add(new Filter("tag:" + EC2Tag.TAG_NAME_JENKINS_SERVER_URL + "=" + jenkinsServerUrl));
+            filters.add(new Filter("tag:" + EC2Tag.TAG_NAME_JENKINS_SERVER_URL + "=" + jenkinsServerUrl));
+        }
 
         values = new ArrayList<String>();
         values.add(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE);

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -960,7 +960,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                     slaveType, description)));
         }
         JenkinsLocationConfiguration jenkinsLocation = JenkinsLocationConfiguration.get();
-        if (!hasJenkinsServerUrlTag && jenkinsLocation != null) {
+        if (!hasJenkinsServerUrlTag && jenkinsLocation != null && jenkinsLocation.getUrl() != null) {
             instTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SERVER_URL, jenkinsLocation.getUrl()));
         }
         return instTags;


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-54266

This is probably more sensible than my previous attempt on #314, and in the end matches what [@thoulen was saying would probably have been preferrable](https://github.com/jenkinsci/ec2-plugin/pull/314#issuecomment-433432132): we just do not tag in case there's no serverUrl.

It's also a followup of #310, for inter-tracking purpose.

*Anyway* the number of production instances out there without a `serverUrl` is probably close to 0, but well.