### PR TITLE
JENKINS-53858: Fix NPE on startup due to uninitialized lock

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -198,6 +198,7 @@ public abstract class EC2Cloud extends Cloud {
     public abstract URL getS3EndpointUrl() throws IOException;
 
     protected Object readResolve() {
+        this.slaveCountingLock = new ReentrantLock();
         for (SlaveTemplate t : templates)
             t.parent = this;
         if (this.accessId != null && this.secretKey != null && credentialsId == null) {

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -173,7 +173,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
             InstanceState state = null;
             try {
                 state = c.getState();
-            } catch (AmazonClientException | InterruptedException e) {
+            } catch (AmazonClientException | InterruptedException | NullPointerException e) {
                 LOGGER.log(Level.FINE, "Error getting EC2 instance state for " + c.getName(), e);
             }
             if (!(InstanceState.PENDING.equals(state) || InstanceState.RUNNING.equals(state))) {


### PR DESCRIPTION
Also catches NPEs on startup from the node health checking thread firing
before everything's set up, which was what I saw on my production
deployment. Oddly, my staging environment was satisfied with just #318.