### PR TITLE
JENKINS-46294: Allow block reservations for spot instances

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -693,6 +693,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         List<Instance> newInstances;
         if (spotWithoutBidPrice) {
             InstanceMarketOptionsRequest instanceMarketOptionsRequest = new InstanceMarketOptionsRequest().withMarketType(MarketType.Spot);
+            if (getSpotBlockReservationDuration() != 0) {
+                SpotMarketOptions spotOptions = new SpotMarketOptions().withBlockDurationMinutes(getSpotBlockReservationDuration() * 60);
+                instanceMarketOptionsRequest.setSpotOptions(spotOptions);
+            }
             riRequest.setInstanceMarketOptions(instanceMarketOptionsRequest);
             try {
                 newInstances = ec2.runInstances(riRequest).getReservation().getInstances();

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -28,6 +28,7 @@ import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 
+
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;

--- a/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
+++ b/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
@@ -4,10 +4,23 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 public final class SpotConfiguration {
     public final String spotMaxBidPrice;
+    public final int spotBlockReservationDuration;
 
     @DataBoundConstructor
-    public SpotConfiguration(String spotMaxBidPrice) {
+    public SpotConfiguration(String spotMaxBidPrice, String spotBlockReservationDurationStr) {
         this.spotMaxBidPrice = spotMaxBidPrice;
+        if (null == spotBlockReservationDurationStr || spotBlockReservationDurationStr.isEmpty()) {
+            this.spotBlockReservationDuration = 0;
+        } else {
+            this.spotBlockReservationDuration = Integer.parseInt(spotBlockReservationDurationStr);
+        }
+    }
+
+    /*
+     * Backwards compat with the unit tests
+     */
+    public SpotConfiguration(String spotMaxBidPrice) {
+        this(spotMaxBidPrice, null);
     }
 
     @Override
@@ -17,13 +30,16 @@ public final class SpotConfiguration {
         }
         final SpotConfiguration config = (SpotConfiguration) obj;
 
+        if (this.spotBlockReservationDuration != config.spotBlockReservationDuration) {
+            return false;
+        }
         return normalizeBid(this.spotMaxBidPrice).equals(normalizeBid(config.spotMaxBidPrice));
     }
 
     /**
      * Check if the specified value is a valid bid price to make a Spot request and return the normalized string for the
      * float of the specified bid Bids must be &gt;= .001
-     * 
+     *
      * @param bid
      *            - price to check
      * @return The normalized string for a Float if possible, otherwise null

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -64,6 +64,10 @@ THE SOFTWARE.
     <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice">
       <f:textbox />
     </f:entry>
+
+    <f:entry title="${%Spot Block Reservation Duration}" field="spotBlockReservationDurationStr">
+      <f:textbox />
+    </f:entry>
   </f:optionalBlock>
 
   <f:entry title="${%Security group names}" field="securityGroups">

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-spotBlockReservationDurationStr.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-spotBlockReservationDurationStr.html
@@ -1,0 +1,7 @@
+<div>
+	Set your required Block Reservation Duration in Hours here, with 0 or null indicating that you do not want a block reservation.
+    Amazon EC2 does not terminate Spot Instances with a specified duration (also known as Spot blocks) when the Spot price changes.
+    This makes them ideal for jobs that take a finite time to complete, such as batch processing, encoding and rendering, modeling and analysis, and continuous integration.
+    You can specify a duration of 0, 1, 2, 3, 4, 5, or 6 hours
+	Find more information on Spot Blocks <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html#fixed-duration-spot-instances">here</a>.
+</div>


### PR DESCRIPTION
What it says on the tin, allows for the setting of a Spot Block when requesting a spot instance so that you get your instance for at least that duration.

https://issues.jenkins-ci.org/browse/JENKINS-46294