### PR TITLE
JENKINS-54329: allow user to choose slave connection strategy.

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ConnectionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/ConnectionStrategy.java
@@ -1,0 +1,39 @@
+package hudson.plugins.ec2;
+
+public enum ConnectionStrategy {
+    PUBLIC_DNS("Public DNS"),
+    PUBLIC_IP("Public IP"),
+    PRIVATE_DNS("Private DNS"),
+    PRIVATE_IP("Private IP");
+
+    private final String name;
+
+    ConnectionStrategy(String name) {
+        this.name = name;
+    }
+
+    public boolean equalsName(String other) {
+        return this.name.equals(other);
+    }
+
+    public String toString() {
+        return this.name;
+    }
+
+    /**
+     * For backwards compatibility.
+     * @param usePrivateDnsName whether or not to use a private dns to establish a connection.
+     * @param connectUsingPublicIp whether or not to use a public ip to establish a connection.
+     * @param associatePublicIp whether or not to associate to a public ip.
+     * @return an {@link ConnectionStrategy} based on provided parameters.
+     */
+    public static ConnectionStrategy backwardsCompatible(boolean usePrivateDnsName, boolean connectUsingPublicIp, boolean associatePublicIp) {
+        if (usePrivateDnsName && !connectUsingPublicIp) {
+            return PRIVATE_DNS;
+        } else if (connectUsingPublicIp || associatePublicIp) {
+            return PUBLIC_IP;
+        } else {
+            return PRIVATE_IP;
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/EC2HostAddressProvider.java
+++ b/src/main/java/hudson/plugins/ec2/EC2HostAddressProvider.java
@@ -1,0 +1,56 @@
+package hudson.plugins.ec2;
+
+import com.amazonaws.services.ec2.model.Instance;
+import com.google.common.net.HostAndPort;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Optional;
+
+import static hudson.plugins.ec2.ConnectionStrategy.*;
+
+public class EC2HostAddressProvider {
+    public static String unix(Instance instance, ConnectionStrategy strategy) {
+        switch (strategy) {
+            case PUBLIC_DNS:
+                return filterNonEmpty(getPublicDnsName(instance)).orElse(getPublicIpAddress(instance));
+            case PUBLIC_IP:
+                return getPublicIpAddress(instance);
+            case PRIVATE_DNS:
+                return filterNonEmpty(getPrivateDnsName(instance)).orElse(getPrivateIpAddress(instance));
+            case PRIVATE_IP:
+                return getPrivateIpAddress(instance);
+            default:
+                throw new IllegalArgumentException("Could not unix host address for strategy = " + strategy.toString());
+        }
+    }
+
+    public static HostAndPort windows(Instance instance, ConnectionStrategy strategy) {
+        if (strategy.equals(PRIVATE_DNS) || strategy.equals(PRIVATE_IP)) {
+            return HostAndPort.fromString(getPrivateIpAddress(instance));
+        } else if (strategy.equals(PUBLIC_DNS) || strategy.equals(PUBLIC_IP)) {
+            return HostAndPort.fromString(getPublicIpAddress(instance));
+        } else {
+            throw new IllegalArgumentException("Could not unix host address for strategy = " + strategy.toString());
+        }
+    }
+
+    private static String getPublicDnsName(Instance instance) {
+        return instance.getPublicDnsName();
+    }
+
+    private static String getPublicIpAddress(Instance instance) {
+        return instance.getPublicIpAddress();
+    }
+
+    private static String getPrivateDnsName(Instance instance) {
+        return instance.getPrivateDnsName();
+    }
+
+    private static String getPrivateIpAddress(Instance instance) {
+        return instance.getPrivateIpAddress();
+    }
+
+    private static Optional<String> filterNonEmpty(String value) {
+        return Optional.ofNullable(value).filter(StringUtils::isNotEmpty);
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
@@ -31,28 +31,30 @@ import com.amazonaws.services.ec2.model.*;
 public final class EC2OndemandSlave extends EC2AbstractSlave {
     private static final Logger LOGGER = Logger.getLogger(EC2OndemandSlave.class.getName());
 
+    @Deprecated
     public EC2OndemandSlave(String instanceId, String description, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
-        this(description + " (" + instanceId + ")", instanceId, description, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, Collections.emptyList(), remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, false, false, launchTimeout, amiType, -1);
+        this(instanceId, description, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, false, launchTimeout, amiType);
     }
 
-    public EC2OndemandSlave(String instanceId, String description, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType, int maxTotalUses)
+    @Deprecated
+    public EC2OndemandSlave(String instanceId, String description, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
-        this(description + " (" + instanceId + ")", instanceId, description, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, Collections.emptyList(), remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, usePrivateDnsName, useDedicatedTenancy, launchTimeout, amiType, maxTotalUses);
+        this(instanceId, description, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, false, useDedicatedTenancy, launchTimeout, amiType);
     }
 
-    public EC2OndemandSlave(String name, String instanceId, String description, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType)
+    @Deprecated
+    public EC2OndemandSlave(String instanceId, String description, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
-        this(name, instanceId, description, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, nodeProperties, remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes,
-        publicDNS, privateDNS, tags, cloudName, usePrivateDnsName, useDedicatedTenancy, launchTimeout, amiType, -1);
+        this(description + " (" + instanceId + ")", instanceId, description, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, Collections.emptyList(), remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, useDedicatedTenancy, launchTimeout, amiType, ConnectionStrategy.backwardsCompatible(usePrivateDnsName, false, false), -1);
     }
 
     @DataBoundConstructor
-    public EC2OndemandSlave(String name, String instanceId, String description, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType, int maxTotalUses)
+    public EC2OndemandSlave(String name, String instanceId, String description, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
             throws FormException, IOException {
 
         super(name, instanceId, description, remoteFS, numExecutors, mode, labelString, amiType.isWindows() ? new EC2WindowsLauncher()
-                : new EC2UnixLauncher(), new EC2RetentionStrategy(idleTerminationMinutes), initScript, tmpDir, nodeProperties, remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, tags, cloudName, usePrivateDnsName, useDedicatedTenancy, launchTimeout, amiType, maxTotalUses);
+                : new EC2UnixLauncher(), new EC2RetentionStrategy(idleTerminationMinutes), initScript, tmpDir, nodeProperties, remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, tags, cloudName, useDedicatedTenancy, launchTimeout, amiType, connectionStrategy, maxTotalUses);
 
         this.publicDNS = publicDNS;
         this.privateDNS = privateDNS;
@@ -62,7 +64,7 @@ public final class EC2OndemandSlave extends EC2AbstractSlave {
      * Constructor for debugging.
      */
     public EC2OndemandSlave(String instanceId) throws FormException, IOException {
-        this(instanceId, instanceId, "debug", "/tmp/hudson", 1, "debug", Mode.NORMAL, "", "/tmp", Collections.emptyList(), null, null, false, null, "Fake public", "Fake private", null, null, false, false, 0, new UnixData(null, null, null, null), -1);
+        this(instanceId, instanceId, "debug", "/tmp/hudson", 1, "debug", Mode.NORMAL, "", "/tmp", Collections.emptyList(), null, null, false, null, "Fake public", "Fake private", null, null, false, 0, new UnixData(null, null, null, null), ConnectionStrategy.PRIVATE_IP, -1);
     }
 
     /**

--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -32,23 +32,24 @@ public final class EC2SpotSlave extends EC2AbstractSlave implements EC2Readiness
 
     private final String spotInstanceRequestId;
 
-    public EC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout, AMITypeData amiType, int maxTotalUses)
+    @Deprecated
+    public EC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
-        this(description + " (" + name + ")", spotInstanceRequestId, description, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, Collections.emptyList(), remoteAdmin, jvmopts, idleTerminationMinutes, tags, cloudName, usePrivateDnsName, launchTimeout, amiType, maxTotalUses);
+        this(name, spotInstanceRequestId, description, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, remoteAdmin, jvmopts, idleTerminationMinutes, tags, cloudName, false, launchTimeout, amiType);
     }
 
-    public EC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout, AMITypeData amiType)
+    @Deprecated
+    public EC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
-        this(name, spotInstanceRequestId, description, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, nodeProperties, remoteAdmin, jvmopts, idleTerminationMinutes, tags, cloudName, usePrivateDnsName,
-        launchTimeout, amiType, -1);
+        this(description + " (" + name + ")", spotInstanceRequestId, description, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, Collections.emptyList(), remoteAdmin, jvmopts, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, ConnectionStrategy.backwardsCompatible(usePrivateDnsName, false, false), -1);
     }
 
     @DataBoundConstructor
-    public EC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout, AMITypeData amiType, int maxTotalUses)
+    public EC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
             throws FormException, IOException {
 
         super(name, "", description, remoteFS, numExecutors, mode, labelString, amiType.isWindows() ? new EC2WindowsLauncher() :
-                new EC2UnixLauncher(), new EC2RetentionStrategy(idleTerminationMinutes), initScript, tmpDir, nodeProperties, remoteAdmin, jvmopts, false, idleTerminationMinutes, tags, cloudName, usePrivateDnsName, false, launchTimeout, amiType, maxTotalUses);
+                new EC2UnixLauncher(), new EC2RetentionStrategy(idleTerminationMinutes), initScript, tmpDir, nodeProperties, remoteAdmin, jvmopts, false, idleTerminationMinutes, tags, cloudName, false, launchTimeout, amiType, connectionStrategy, maxTotalUses);
 
         this.name = name;
         this.spotInstanceRequestId = spotInstanceRequestId;

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -130,10 +130,6 @@ THE SOFTWARE.
        </f:repeatable>
     </f:entry>
 
-    <f:entry title="${%Use private DNS}" field="usePrivateDnsName">
-      <f:checkbox />
-    </f:entry>
-
     <f:entry title="${%Instance Cap}" field="instanceCapStr">
       <f:textbox />
     </f:entry>
@@ -162,8 +158,8 @@ THE SOFTWARE.
       <f:checkbox />
     </f:entry>
 
-    <f:entry title="${%Connect using Public IP}" field="connectUsingPublicIp">
-      <f:checkbox />
+    <f:entry title="${%Connection Strategy}" field="connectionStrategy">
+      <f:select default="${descriptor.getDefaultConnectionStrategy()}"/>
     </f:entry>
 
     <f:entry title="${%Connect by SSH Process}" field="connectBySSHProcess">

--- a/src/test/java/hudson/plugins/ec2/ConnectionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/ConnectionStrategyTest.java
@@ -1,0 +1,49 @@
+package hudson.plugins.ec2;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.*;
+
+public class ConnectionStrategyTest {
+
+    @Test
+    public void backwardsCompatible_withPrivateDns_notPublicIp() {
+        boolean usePrivateDnsName = true;
+        boolean connectUsingPublicIp = false;
+        boolean associatePublicIp = false;
+        assertThat(ConnectionStrategy.backwardsCompatible(usePrivateDnsName, connectUsingPublicIp, associatePublicIp), equalTo(ConnectionStrategy.PRIVATE_DNS));
+    }
+
+    @Test
+    public void backwardsCompatible_withPrivateDns_withPublicIp() {
+        boolean usePrivateDnsName = true;
+        boolean connectUsingPublicIp = true;
+        boolean associatePublicIp = false;
+        assertThat(ConnectionStrategy.backwardsCompatible(usePrivateDnsName, connectUsingPublicIp, associatePublicIp), equalTo(ConnectionStrategy.PUBLIC_IP));
+    }
+
+    @Test
+    public void backwardsCompatible_withPublicIp() {
+        boolean usePrivateDnsName = false;
+        boolean connectUsingPublicIp = true;
+        boolean associatePublicIp = false;
+        assertThat(ConnectionStrategy.backwardsCompatible(usePrivateDnsName, connectUsingPublicIp, associatePublicIp), equalTo(ConnectionStrategy.PUBLIC_IP));
+    }
+
+    @Test
+    public void backwardsCompatible_withAssociate() {
+        boolean usePrivateDnsName = false;
+        boolean connectUsingPublicIp = false;
+        boolean associatePublicIp = true;
+        assertThat(ConnectionStrategy.backwardsCompatible(usePrivateDnsName, connectUsingPublicIp, associatePublicIp), equalTo(ConnectionStrategy.PUBLIC_IP));
+    }
+
+    @Test
+    public void backwardsCompatible_default() {
+        boolean usePrivateDnsName = false;
+        boolean connectUsingPublicIp = false;
+        boolean associatePublicIp = false;
+        assertThat(ConnectionStrategy.backwardsCompatible(usePrivateDnsName, connectUsingPublicIp, associatePublicIp), equalTo(ConnectionStrategy.PRIVATE_IP));
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
@@ -18,7 +18,7 @@ public class EC2AbstractSlaveTest {
 
     @Test
     public void testGetLaunchTimeoutInMillisShouldNotOverflow() throws Exception {
-        EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "root", "jvm", false, "idle", null, "cloud", false, false, Integer.MAX_VALUE, new UnixData("remote", null, null, "22")) {
+        EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "root", "jvm", false, "idle", null, "cloud", false, Integer.MAX_VALUE, new UnixData("remote", null, null, "22"), ConnectionStrategy.PRIVATE_IP, -1) {
             @Override
             public void terminate() {
                 // To change body of implemented methods use File | Settings |

--- a/src/test/java/hudson/plugins/ec2/EC2HostAddressProviderTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2HostAddressProviderTest.java
@@ -1,0 +1,125 @@
+package hudson.plugins.ec2;
+
+import static hudson.plugins.ec2.EC2HostAddressProvider.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.ec2.model.Instance;
+import com.google.common.net.HostAndPort;
+import org.junit.Test;
+
+public class EC2HostAddressProviderTest {
+
+    @Test
+    public void unix_publicDnsStrategy_isPresent() {
+        Instance instance = mock(Instance.class);
+        ConnectionStrategy strategy = ConnectionStrategy.PUBLIC_DNS;
+
+        when(instance.getPublicDnsName()).thenReturn("ec2-0-0-0-0.compute-1.amazonaws.com");
+
+        assertThat(unix(instance, strategy), equalTo("ec2-0-0-0-0.compute-1.amazonaws.com"));
+    }
+
+    @Test
+    public void unix_publicDnsStrategy_notPresent() {
+        Instance instance = mock(Instance.class);
+        ConnectionStrategy strategy = ConnectionStrategy.PUBLIC_DNS;
+
+        when(instance.getPublicDnsName()).thenReturn("");
+        when(instance.getPublicIpAddress()).thenReturn("0.0.0.0");
+
+        assertThat(unix(instance, strategy), equalTo("0.0.0.0"));
+    }
+
+    @Test
+    public void unix_publicIpStrategy() {
+        Instance instance = mock(Instance.class);
+        ConnectionStrategy strategy = ConnectionStrategy.PUBLIC_IP;
+
+        when(instance.getPublicIpAddress()).thenReturn("0.0.0.0");
+
+        assertThat(unix(instance, strategy), equalTo("0.0.0.0"));
+    }
+
+    @Test
+    public void unix_privateDnsStrategy_isPresent() {
+        Instance instance = mock(Instance.class);
+        ConnectionStrategy strategy = ConnectionStrategy.PRIVATE_DNS;
+
+        when(instance.getPrivateDnsName()).thenReturn("0-0-0-0.ec2.internal");
+
+        assertThat(unix(instance, strategy), equalTo("0-0-0-0.ec2.internal"));
+    }
+
+    @Test
+    public void unix_privateDnsStrategy_notPresent() {
+        Instance instance = mock(Instance.class);
+        ConnectionStrategy strategy = ConnectionStrategy.PRIVATE_DNS;
+
+        when(instance.getPrivateDnsName()).thenReturn("");
+        when(instance.getPrivateIpAddress()).thenReturn("0.0.0.0");
+
+        assertThat(unix(instance, strategy), equalTo("0.0.0.0"));
+    }
+
+    @Test
+    public void unix_privateIpStrategy() {
+        Instance instance = mock(Instance.class);
+        ConnectionStrategy strategy = ConnectionStrategy.PRIVATE_IP;
+
+        when(instance.getPrivateIpAddress()).thenReturn("0.0.0.0");
+
+        assertThat(unix(instance, strategy), equalTo("0.0.0.0"));
+    }
+
+
+    @Test
+    public void windows_privateDnsStrategy() {
+        Instance instance = mock(Instance.class);
+        ConnectionStrategy strategy = ConnectionStrategy.PRIVATE_DNS;
+
+        when(instance.getPrivateDnsName()).thenReturn("0-0-0-0.ec2.internal");
+        when(instance.getPrivateIpAddress()).thenReturn("0.0.0.0");
+
+        HostAndPort expected = HostAndPort.fromString("0.0.0.0");
+        assertThat(windows(instance, strategy), equalTo(expected));
+    }
+
+    @Test
+    public void windows_privateIpStrategy() {
+        Instance instance = mock(Instance.class);
+        ConnectionStrategy strategy = ConnectionStrategy.PRIVATE_IP;
+
+        when(instance.getPrivateDnsName()).thenReturn("");
+        when(instance.getPrivateIpAddress()).thenReturn("0.0.0.0");
+
+        HostAndPort expected = HostAndPort.fromString("0.0.0.0");
+        assertThat(windows(instance, strategy), equalTo(expected));
+    }
+
+    @Test
+    public void windows_publicDnsStrategy() {
+        Instance instance = mock(Instance.class);
+        ConnectionStrategy strategy = ConnectionStrategy.PUBLIC_DNS;
+
+        when(instance.getPublicDnsName()).thenReturn("ec2-0-0-0-0.compute-1.amazonaws.com");
+        when(instance.getPublicIpAddress()).thenReturn("0.0.0.0");
+
+        HostAndPort expected = HostAndPort.fromString("0.0.0.0");
+        assertThat(windows(instance, strategy), equalTo(expected));
+    }
+
+    @Test
+    public void windows_publicIpStrategy() {
+        Instance instance = mock(Instance.class);
+        ConnectionStrategy strategy = ConnectionStrategy.PUBLIC_IP;
+
+        when(instance.getPublicDnsName()).thenReturn("");
+        when(instance.getPublicIpAddress()).thenReturn("0.0.0.0");
+
+        HostAndPort expected = HostAndPort.fromString("0.0.0.0");
+        assertThat(windows(instance, strategy), equalTo(expected));
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
@@ -5,6 +5,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 
 public class EC2OndemandSlaveTest {
@@ -14,10 +16,10 @@ public class EC2OndemandSlaveTest {
 
     @Test
     public void testSpecifyMode() throws Exception {
-        EC2OndemandSlave slaveNormal = new EC2OndemandSlave("instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.NORMAL, "initScript", "tmpDir", "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", null, "cloudName", false, false, 0, new UnixData("a", null, null, "b"), -1);
+        EC2OndemandSlave slaveNormal = new EC2OndemandSlave("name", "instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.NORMAL, "initScript", "tmpDir", Collections.emptyList(), "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", Collections.emptyList(), "cloudName", false,  0, new UnixData("a", null, null, "b"), ConnectionStrategy.PRIVATE_IP, -1);
         assertEquals(Node.Mode.NORMAL, slaveNormal.getMode());
 
-        EC2OndemandSlave slaveExclusive = new EC2OndemandSlave("instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.EXCLUSIVE, "initScript", "tmpDir", "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", null, "cloudName", false, false, 0, new UnixData("a", null, null, "b"), -1);
+        EC2OndemandSlave slaveExclusive = new EC2OndemandSlave("name", "instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.EXCLUSIVE, "initScript", "tmpDir", Collections.emptyList(), "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", Collections.emptyList(), "cloudName", false,  0, new UnixData("a", null, null, "b"), ConnectionStrategy.PRIVATE_IP, -1);
         assertEquals(Node.Mode.EXCLUSIVE, slaveExclusive.getMode());
     }
 

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -50,7 +50,7 @@ public class EC2RetentionStrategyTest {
     }
 
     private EC2Computer computerWithIdleTime(final int minutes, final int seconds) throws Exception {
-        final EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "remote", "jvm", false, "idle", null, "cloud", false, false, Integer.MAX_VALUE, null, -1) {
+        final EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "remote", "jvm", false, "idle", null, "cloud", false, Integer.MAX_VALUE, null, ConnectionStrategy.PRIVATE_IP, -1) {
             @Override
             public void terminate() {
             }
@@ -91,7 +91,7 @@ public class EC2RetentionStrategyTest {
         assertTrue(computer.isOnline());
         return computer;
     }
-    
+
     @Test
     public void testOnUsageCountRetention() throws Exception {
         EC2RetentionStrategy rs = new EC2RetentionStrategy("0");
@@ -124,12 +124,12 @@ public class EC2RetentionStrategyTest {
     }
 
     private EC2Computer computerWithUsageLimit(final int usageLimit) throws Exception {
-        final EC2AbstractSlave slave = new EC2AbstractSlave("name", "maxTotalUsesInstance", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "remote", "jvm", false, "idle", null, "cloud", false, false, Integer.MAX_VALUE, null, usageLimit) {
+        final EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "remote", "jvm", false, "idle", null, "cloud", false, Integer.MAX_VALUE, null, ConnectionStrategy.PRIVATE_IP, usageLimit) {
             @Override
             public void terminate() {
                 terminateCalled.set(true);
             }
-            
+
             @Override
             public String getEc2Type() {
                 return null;

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -23,21 +23,20 @@
  */
 package hudson.plugins.ec2;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import com.amazonaws.services.ec2.model.InstanceType;
+import hudson.model.Node;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import com.amazonaws.services.ec2.model.InstanceType;
-
-import hudson.model.Node;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Basic test to validate SlaveTemplate.
@@ -77,11 +76,11 @@ public class SlaveTemplateTest {
 
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
-        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,usePrivateDnsName,useEphemeralDevices,useDedicatedTenancy");
+        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,useEphemeralDevices,useDedicatedTenancy,connectionStrategy");
     }
 
     @Test
-    public void testConfigRoundtripWithPrivateDns() throws Exception {
+    public void testConfigRoundtripWithCustomConnectionStrategy() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
 
@@ -91,7 +90,7 @@ public class SlaveTemplateTest {
         tags.add(tag1);
         tags.add(tag2);
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, true, null, "", false, false, "", false, "");
+        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, null, "", true, false, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1);
 
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(orig);
@@ -101,7 +100,7 @@ public class SlaveTemplateTest {
 
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
-        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
+        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,useEphemeralDevices,useDedicatedTenancy,connectionStrategy");
     }
 
     /**
@@ -133,7 +132,7 @@ public class SlaveTemplateTest {
 
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
-        r.assertEqualBeans(orig, received, "ami,zone,spotConfig,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
+        r.assertEqualBeans(orig, received, "ami,zone,spotConfig,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,connectionStrategy");
     }
 
     /**
@@ -162,7 +161,7 @@ public class SlaveTemplateTest {
 
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
-        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,usePrivateDnsName,iamInstanceProfile");
+        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,iamInstanceProfile,connectionStrategy");
     }
 
     @Test
@@ -208,13 +207,13 @@ public class SlaveTemplateTest {
     @Test
     public void testConnectUsingPublicIpSetting() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, false, null, true, "", false, true);
-        assertTrue(st.isConnectUsingPublicIp());
+        assertEquals(st.connectionStrategy, ConnectionStrategy.PUBLIC_IP);
     }
 
     @Test
     public void testConnectUsingPublicIpSettingWithDefaultSetting() {
         SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true, "");
-        assertFalse(st.isConnectUsingPublicIp());
+        assertEquals(st.connectionStrategy, ConnectionStrategy.PUBLIC_IP);
     }
 
     @Test


### PR DESCRIPTION
This PR aims to fix the issues mentioned in: https://issues.jenkins-ci.org/browse/JENKINS-54329. Right now, the host used for connecting to the slaves is not really deterministic and restricts users as mentioned in the issue. I would like to get early feedback on this, but my plan is to also also remove the `associatePublicIp` field and use the `connectionStrategy` being used to better determine whether to associate the public IP or not. What do you guys think?