### PR TITLE
Spot instances: Fallback to on-demand when there is no capacity

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -537,7 +537,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     /**
      * Provisions an On-demand EC2 slave by launching a new instance or starting a previously-stopped instance.
      */
-    private List<EC2AbstractSlave> provisionOndemand(int number, EnumSet<ProvisionOptions> provisionOptions, Boolean spotWithoutBidPrice, Boolean fallbackSpotToOndemand)
+    private List<EC2AbstractSlave> provisionOndemand(int number, EnumSet<ProvisionOptions> provisionOptions, boolean spotWithoutBidPrice, boolean fallbackSpotToOndemand)
             throws IOException {
         AmazonEC2 ec2 = getParent().connect();
 

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javax.servlet.ServletException;
 
@@ -530,13 +531,13 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      */
     private List<EC2AbstractSlave> provisionOndemand(int number, EnumSet<ProvisionOptions> provisionOptions)
             throws IOException {
-        return provisionOndemand(number, provisionOptions, false);
+        return provisionOndemand(number, provisionOptions, false, false);
     }
 
     /**
      * Provisions an On-demand EC2 slave by launching a new instance or starting a previously-stopped instance.
      */
-    private List<EC2AbstractSlave> provisionOndemand(int number, EnumSet<ProvisionOptions> provisionOptions, Boolean spotWithoutBidPrice)
+    private List<EC2AbstractSlave> provisionOndemand(int number, EnumSet<ProvisionOptions> provisionOptions, Boolean spotWithoutBidPrice, Boolean fallbackSpotToOndemand)
             throws IOException {
         AmazonEC2 ec2 = getParent().connect();
 
@@ -545,11 +546,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         RunInstancesRequest riRequest = new RunInstancesRequest(ami, 1, number).withInstanceType(type);
         riRequest.setEbsOptimized(ebsOptimized);
         riRequest.setMonitoring(monitoring);
-
-        if (spotWithoutBidPrice) {
-            InstanceMarketOptionsRequest instanceMarketOptionsRequest = new InstanceMarketOptionsRequest().withMarketType(MarketType.Spot);
-            riRequest.setInstanceMarketOptions(instanceMarketOptionsRequest);
-        }
 
         if (t2Unlimited){
             CreditSpecificationRequest creditRequest = new CreditSpecificationRequest();
@@ -665,8 +661,25 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         Set<TagSpecification> tagSpecifications =  Collections.singleton(tagSpecification);
         riRequest.setTagSpecifications(tagSpecifications);
 
+        List<Instance> newInstances;
+        if (spotWithoutBidPrice) {
+            InstanceMarketOptionsRequest instanceMarketOptionsRequest = new InstanceMarketOptionsRequest().withMarketType(MarketType.Spot);
+            riRequest.setInstanceMarketOptions(instanceMarketOptionsRequest);
+            try {
+                newInstances = ec2.runInstances(riRequest).getReservation().getInstances();
+            } catch (AmazonEC2Exception e) {
+                if (fallbackSpotToOndemand && e.getErrorCode().equals("InsufficientInstanceCapacity")) {
+                    logProvisionInfo("There is no spot capacity available matching your request, falling back to on-demand instance.");
+                    riRequest.setInstanceMarketOptions(new InstanceMarketOptionsRequest());
+                    newInstances = ec2.runInstances(riRequest).getReservation().getInstances();
+                } else {
+                    throw e;
+                }
+            }
+        } else {
+            newInstances = ec2.runInstances(riRequest).getReservation().getInstances();
+        }
         // Have to create a new instance
-        List<Instance> newInstances = ec2.runInstances(riRequest).getReservation().getInstances();
 
         if (newInstances.isEmpty()) {
             logProvisionInfo("No new instances were created");
@@ -842,7 +855,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     private List<EC2AbstractSlave> provisionSpot(int number, EnumSet<ProvisionOptions> provisionOptions)
             throws IOException {
         if (!spotConfig.useBidPrice) {
-            return provisionOndemand(1, provisionOptions, true);
+            return provisionOndemand(1, provisionOptions, true, spotConfig.fallbackToOndemand);
         }
 
         AmazonEC2 ec2 = getParent().connect();
@@ -947,6 +960,25 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                     throw new AmazonClientException("Spot instance request is null");
                 }
                 String slaveName = spotInstReq.getSpotInstanceRequestId();
+
+                if (spotConfig.fallbackToOndemand) {
+                    for (int i = 0; i < 2 && spotInstReq.getStatus().getCode().equals("pending-evaluation"); i++) {
+                        LOGGER.info("Spot request " + slaveName + " is still pending evaluation");
+                        Thread.sleep(5000);
+                        LOGGER.info("Fetching info about spot request " + slaveName);
+                        DescribeSpotInstanceRequestsRequest describeRequest = new DescribeSpotInstanceRequestsRequest().withSpotInstanceRequestIds(slaveName);
+                        spotInstReq = ec2.describeSpotInstanceRequests(describeRequest).getSpotInstanceRequests().get(0);
+                    }
+
+                    List<String> spotRequestBadCodes = Arrays.asList("capacity-not-available", "capacity-oversubscribed", "price-too-low");
+                    if (spotRequestBadCodes.contains(spotInstReq.getStatus().getCode())) {
+                        LOGGER.info("There is no spot capacity available matching your request, falling back to on-demand instance.");
+                        List<String> requestsToCancel = reqInstances.stream().map(SpotInstanceRequest::getSpotInstanceRequestId).collect(Collectors.toList());
+                        CancelSpotInstanceRequestsRequest cancelRequest = new CancelSpotInstanceRequestsRequest(requestsToCancel);
+                        ec2.cancelSpotInstanceRequests(cancelRequest);
+                        return provisionOndemand(number, provisionOptions);
+                    }
+                }
 
                 // Now that we have our Spot request, we can set tags on it
                 updateRemoteTags(ec2, instTags, "InvalidSpotInstanceRequestID.NotFound", spotInstReq.getSpotInstanceRequestId());

--- a/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
+++ b/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
@@ -3,12 +3,14 @@ package hudson.plugins.ec2;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public final class SpotConfiguration {
-    public final Boolean useBidPrice;
+    public final boolean useBidPrice;
     public final String spotMaxBidPrice;
+    public final boolean fallbackToOndemand;
 
-    @DataBoundConstructor public SpotConfiguration(Boolean useBidPrice, String spotMaxBidPrice) {
+    @DataBoundConstructor public SpotConfiguration(boolean useBidPrice, String spotMaxBidPrice, boolean fallbackToOndemand) {
         this.useBidPrice = useBidPrice;
         this.spotMaxBidPrice = spotMaxBidPrice;
+        this.fallbackToOndemand = fallbackToOndemand;
     }
 
     @Override public boolean equals(Object obj) {
@@ -17,7 +19,7 @@ public final class SpotConfiguration {
         }
         final SpotConfiguration config = (SpotConfiguration) obj;
 
-        return this.useBidPrice == config.useBidPrice
+        return this.useBidPrice == config.useBidPrice && this.fallbackToOndemand == config.fallbackToOndemand
                 && normalizeBid(this.spotMaxBidPrice).equals(normalizeBid(config.spotMaxBidPrice));
     }
 

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -59,6 +59,9 @@ THE SOFTWARE.
   </f:entry>
 
   <f:optionalBlock name="spotConfig" title="Use Spot Instance" checked="${instance.spotConfig != null}">
+    <f:entry title="${%Fallback to on-demand instances}" >
+      <f:checkbox field="fallbackToOndemand" checked="${instance.spotConfig.fallbackToOndemand}" />
+    </f:entry>
     <f:optionalBlock name="useBidPrice" title="Set bid price" inline="true" checked="${h.defaultToTrue(instance.spotConfig.useBidPrice)}">
       <f:validateButton title="${%Check Current Spot Price}" progress="${%Checking...}" method="currentSpotPrice" with="useInstanceProfileForCredentials,credentialsId,region,type,zone,roleArn,roleSessionName" />
       <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice">

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-fallbackToOndemand.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-fallbackToOndemand.html
@@ -1,0 +1,3 @@
+<div>
+	If true and if your spot request is denied due to insufficient capacity, it will fallback to using on-demand instances
+</div>

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -122,7 +122,7 @@ public class SlaveTemplateTest {
         tags.add(tag1);
         tags.add(tag2);
 
-        SpotConfiguration spotConfig = new SpotConfiguration(true, ".05");
+        SpotConfiguration spotConfig = new SpotConfiguration(true, ".05", false);
 
         SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, true, null, "", false, false, "", false, "");
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
@@ -152,7 +152,37 @@ public class SlaveTemplateTest {
         tags.add(tag1);
         tags.add(tag2);
 
-        SpotConfiguration spotConfig = new SpotConfiguration(false, "");
+        SpotConfiguration spotConfig = new SpotConfiguration(false, "", false);
+
+        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, true, null, "", false, false, "", false, "");
+        List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
+        templates.add(orig);
+
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+        r.jenkins.clouds.add(ac);
+
+        r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(orig, received, "ami,zone,spotConfig,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
+    }
+
+    /**
+     * Tests to make sure the slave created has been configured properly. Also tests to make sure the spot max bid price
+     * has been set properly.
+     *
+     * @throws Exception - Exception that can be thrown by the Jenkins test harness
+     */
+    @Test public void testSpotConfigWithFallback() throws Exception {
+        String ami = "ami1";
+        String description = "foo ami";
+
+        EC2Tag tag1 = new EC2Tag("name1", "value1");
+        EC2Tag tag2 = new EC2Tag("name2", "value2");
+        List<EC2Tag> tags = new ArrayList<EC2Tag>();
+        tags.add(tag1);
+        tags.add(tag2);
+
+        SpotConfiguration spotConfig = new SpotConfiguration(true, "0.1", true);
 
         SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, true, null, "", false, false, "", false, "");
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();


### PR DESCRIPTION
Follow up to #331. When there is no spot capacity (either for spot instances with a bid price or without one), fallback to on-demand instances