### PR TITLE
Fix NPE that happens on a node's modification

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -154,7 +154,7 @@ public abstract class EC2AbstractSlave extends Slave {
         this.stopOnTerminate = stopOnTerminate;
         this.idleTerminationMinutes = idleTerminationMinutes;
         this.tags = tags;
-        this.usePrivateDnsName = connectionStrategy.equals(ConnectionStrategy.PRIVATE_DNS);
+        this.usePrivateDnsName = connectionStrategy != null && connectionStrategy.equals(ConnectionStrategy.PRIVATE_DNS);
         this.useDedicatedTenancy = useDedicatedTenancy;
         this.cloudName = cloudName;
         this.launchTimeout = launchTimeout;

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -154,7 +154,7 @@ public abstract class EC2AbstractSlave extends Slave {
         this.stopOnTerminate = stopOnTerminate;
         this.idleTerminationMinutes = idleTerminationMinutes;
         this.tags = tags;
-        this.usePrivateDnsName = connectionStrategy != null && connectionStrategy.equals(ConnectionStrategy.PRIVATE_DNS);
+        this.usePrivateDnsName = connectionStrategy == ConnectionStrategy.PRIVATE_DNS;
         this.useDedicatedTenancy = useDedicatedTenancy;
         this.cloudName = cloudName;
         this.launchTimeout = launchTimeout;


### PR DESCRIPTION
```
java.lang.NullPointerException
	at hudson.plugins.ec2.EC2AbstractSlave.<init>(EC2AbstractSlave.java:157)
	at hudson.plugins.ec2.EC2OndemandSlave.<init>(EC2OndemandSlave.java:56)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.kohsuke.stapler.RequestImpl.invokeConstructor(RequestImpl.java:529)
	at org.kohsuke.stapler.RequestImpl.instantiate(RequestImpl.java:784)
	at org.kohsuke.stapler.RequestImpl.access$200(RequestImpl.java:83)
	at org.kohsuke.stapler.RequestImpl$TypePair.convertJSON(RequestImpl.java:678)
	at org.kohsuke.stapler.RequestImpl.bindJSON(RequestImpl.java:478)
	at org.kohsuke.stapler.RequestImpl.bindJSON(RequestImpl.java:474)
	at hudson.model.Descriptor.newInstance(Descriptor.java:597)
Caused: java.lang.Error: Failed to instantiate class hudson.plugins.ec2.EC2OndemandSlave from {
```