### PR TITLE
Add RelativePath annotation to doFillZoneItems query parameters

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 
 import javax.servlet.ServletException;
 
+import hudson.RelativePath;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
@@ -1374,9 +1375,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             return FormValidation.error("Launch Timeout must be a non-negative integer (or null)");
         }
 
-        public ListBoxModel doFillZoneItems(@QueryParameter boolean useInstanceProfileForCredentials,
-                @QueryParameter String credentialsId, @QueryParameter String region, @QueryParameter String roleArn,
-                @QueryParameter String roleSessionName)
+        public ListBoxModel doFillZoneItems(@QueryParameter @RelativePath("..") boolean useInstanceProfileForCredentials,
+                                            @QueryParameter @RelativePath("..") String credentialsId,
+                                            @QueryParameter @RelativePath("..") String region,
+                                            @QueryParameter @RelativePath("..") String roleArn,
+                                            @QueryParameter @RelativePath("..") String roleSessionName)
                 throws IOException, ServletException {
             AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId, roleArn, roleSessionName, region);
             return EC2AbstractSlave.fillZoneItems(credentialsProvider, region);

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -52,10 +52,7 @@ THE SOFTWARE.
   </f:entry>
 
   <f:entry title="${%Availability Zone}" field="zone">
-    <!-- this is preferred but there is a problem with making it work FRU 22 Feb 12
-         See: https://groups.google.com/group/jenkinsci-dev/t/af37fa7fe2769b0c -->
-    <!-- <f:select/>-->
-    <f:textbox/>
+    <f:select/>
   </f:entry>
 
   <f:optionalBlock name="spotConfig" title="Use Spot Instance" checked="${instance.spotConfig != null}">


### PR DESCRIPTION
This is a simple fix to make the availability zone a select control containing the AZs in the current region, instead of a text box.