### PR TITLE
Use non-deprecated get() and remove some unneeded null checks

### DIFF
--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -159,7 +159,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
 
             String cloudId = createCloudId(value);
             int found = 0;
-            for (Cloud c : Jenkins.getInstance().clouds) {
+            for (Cloud c : Jenkins.get().clouds) {
                 if (c.name.equals(cloudId)) {
                     found++;
                 }

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -189,7 +189,7 @@ public abstract class EC2AbstractSlave extends Slave {
     }
 
     public EC2Cloud getCloud() {
-        return (EC2Cloud) Jenkins.getInstance().getCloud(cloudName);
+        return (EC2Cloud) Jenkins.get().getCloud(cloudName);
     }
 
     /**
@@ -396,7 +396,7 @@ public abstract class EC2AbstractSlave extends Slave {
         } catch (AmazonClientException e) {
             LOGGER.log(Level.WARNING, "Failed to stop EC2 instance: " + getInstanceId(), e);
         }
-        
+
     }
 
     boolean terminateInstance() {
@@ -725,7 +725,7 @@ public abstract class EC2AbstractSlave extends Slave {
         }
 
         public List<Descriptor<AMITypeData>> getAMITypeDescriptors() {
-            return Jenkins.getInstance().getDescriptorList(AMITypeData.class);
+            return Jenkins.get().getDescriptorList(AMITypeData.class);
         }
     }
 

--- a/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
@@ -25,7 +25,7 @@ import com.amazonaws.services.ec2.model.*;
 
 /**
  * Slave running on EC2.
- * 
+ *
  * @author Kohsuke Kawaguchi
  */
 public final class EC2OndemandSlave extends EC2AbstractSlave {
@@ -83,7 +83,7 @@ public final class EC2OndemandSlave extends EC2AbstractSlave {
                 ec2.terminateInstances(request);
                 LOGGER.info("Terminated EC2 instance (terminated): " + getInstanceId());
             }
-            Jenkins.getInstance().removeNode(this);
+            Jenkins.get().removeNode(this);
             LOGGER.info("Removed EC2 instance from jenkins master: " + getInstanceId());
         } catch (AmazonClientException | IOException e) {
             LOGGER.log(Level.WARNING, "Failed to terminate EC2 instance: " + getInstanceId(), e);
@@ -99,7 +99,7 @@ public final class EC2OndemandSlave extends EC2AbstractSlave {
         if (!isAlive(true)) {
             LOGGER.info("EC2 instance terminated externally: " + getInstanceId());
             try {
-                Jenkins.getInstance().removeNode(this);
+                Jenkins.get().removeNode(this);
             } catch (IOException ioe) {
                 LOGGER.log(Level.WARNING, "Attempt to reconfigure EC2 instance which has been externally terminated: "
                         + getInstanceId(), ioe);

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -204,7 +204,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
     @Override
     public void start(EC2Computer c) {
         //Jenkins is in the process of starting up
-        if (Jenkins.getInstance().getInitLevel() != InitMilestone.COMPLETED) {
+        if (Jenkins.get().getInitLevel() != InitMilestone.COMPLETED) {
             InstanceState state = null;
             try {
                 state = c.getState();

--- a/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java
@@ -36,7 +36,7 @@ public class EC2SlaveMonitor extends AsyncPeriodicWork {
 
     @Override
     protected void execute(TaskListener listener) throws IOException, InterruptedException {
-        for (Node node : Jenkins.getInstance().getNodes()) {
+        for (Node node : Jenkins.get().getNodes()) {
             if (node instanceof EC2AbstractSlave) {
                 final EC2AbstractSlave ec2Slave = (EC2AbstractSlave) node;
                 try {
@@ -54,7 +54,7 @@ public class EC2SlaveMonitor extends AsyncPeriodicWork {
 
     private void removeNode(EC2AbstractSlave ec2Slave) {
         try {
-            Jenkins.getInstance().removeNode(ec2Slave);
+            Jenkins.get().removeNode(ec2Slave);
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Failed to remove node: " + ec2Slave.getInstanceId());
         }

--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -106,7 +106,7 @@ public final class EC2SpotSlave extends EC2AbstractSlave implements EC2Readiness
 			// manually or a spot instance was killed due to pricing. If we don't remove the node,
 			// we screw up auto-scaling, since it will continue to count against the quota.
 			try {
-				Jenkins.getInstance().removeNode(this);
+				Jenkins.get().removeNode(this);
 			} catch (IOException e) {
 				LOGGER.log(Level.WARNING, "Failed to remove slave: " + name, e);
 			}

--- a/src/main/java/hudson/plugins/ec2/NoDelayProvisionerStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/NoDelayProvisionerStrategy.java
@@ -37,21 +37,19 @@ public class NoDelayProvisionerStrategy extends NodeProvisioner.Strategy {
         LOGGER.log(Level.FINE, "Available capacity={0}, currentDemand={1}",
                 new Object[]{availableCapacity, currentDemand});
         if (availableCapacity < currentDemand) {
-            Jenkins jenkinsInstance = Jenkins.getInstance();
-            if (jenkinsInstance != null) {
-                for (Cloud cloud : jenkinsInstance.clouds) {
-                    if (!(cloud instanceof AmazonEC2Cloud)) continue;
-                    if (!cloud.canProvision(label)) continue;
-                    AmazonEC2Cloud ec2 = (AmazonEC2Cloud) cloud;
-                    if (!ec2.isNoDelayProvisioning()) continue;
+            Jenkins jenkinsInstance = Jenkins.get();
+            for (Cloud cloud : jenkinsInstance.clouds) {
+                if (!(cloud instanceof AmazonEC2Cloud)) continue;
+                if (!cloud.canProvision(label)) continue;
+                AmazonEC2Cloud ec2 = (AmazonEC2Cloud) cloud;
+                if (!ec2.isNoDelayProvisioning()) continue;
 
-                    Collection<NodeProvisioner.PlannedNode> plannedNodes = cloud.provision(label, currentDemand - availableCapacity);
-                    LOGGER.log(Level.FINE, "Planned {0} new nodes", plannedNodes.size());
-                    strategyState.recordPendingLaunches(plannedNodes);
-                    availableCapacity += plannedNodes.size();
-                    LOGGER.log(Level.FINE, "After provisioning, available capacity={0}, currentDemand={1}", new Object[]{availableCapacity, currentDemand});
-                    break;
-                }
+                Collection<NodeProvisioner.PlannedNode> plannedNodes = cloud.provision(label, currentDemand - availableCapacity);
+                LOGGER.log(Level.FINE, "Planned {0} new nodes", plannedNodes.size());
+                strategyState.recordPendingLaunches(plannedNodes);
+                availableCapacity += plannedNodes.size();
+                LOGGER.log(Level.FINE, "After provisioning, available capacity={0}, currentDemand={1}", new Object[]{availableCapacity, currentDemand});
+                break;
             }
         }
         if (availableCapacity >= currentDemand) {

--- a/src/main/java/hudson/plugins/ec2/PluginImpl.java
+++ b/src/main/java/hudson/plugins/ec2/PluginImpl.java
@@ -46,11 +46,11 @@ public class PluginImpl extends Plugin implements Describable<PluginImpl> {
     }
 
     public DescriptorImpl getDescriptor() {
-        return (DescriptorImpl) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (DescriptorImpl) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     public static PluginImpl get() {
-        return Jenkins.getInstance().getPlugin(PluginImpl.class);
+        return Jenkins.get().getPlugin(PluginImpl.class);
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -177,10 +177,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         if(StringUtils.isNotBlank(remoteAdmin) || StringUtils.isNotBlank(jvmopts) || StringUtils.isNotBlank(tmpDir)){
             LOGGER.log(Level.FINE, "As remoteAdmin, jvmopts or tmpDir is not blank, we must ensure the user has RUN_SCRIPTS rights.");
-            Jenkins j = Jenkins.getInstance();
-            if(j != null){
-                j.checkPermission(Jenkins.RUN_SCRIPTS);
-            }
+            Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
         }
 
         this.ami = ami;
@@ -1049,7 +1046,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                     slaveType, description)));
         }
         JenkinsLocationConfiguration jenkinsLocation = JenkinsLocationConfiguration.get();
-        if (!hasJenkinsServerUrlTag && jenkinsLocation != null && jenkinsLocation.getUrl() != null) {
+        if (!hasJenkinsServerUrlTag && jenkinsLocation.getUrl() != null) {
             instTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SERVER_URL, jenkinsLocation.getUrl()));
         }
         return instTags;
@@ -1173,7 +1170,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * Initializes data structure that we don't persist.
      */
     protected Object readResolve() {
-        Jenkins.getInstance().checkPermission(Jenkins.RUN_SCRIPTS);
+        Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
 
         labelSet = Label.parse(labels);
         securityGroupSet = parseSecurityGroups();
@@ -1193,7 +1190,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         if (amiType == null) {
             amiType = new UnixData(rootCommandPrefix, slaveCommandPrefix, slaveCommandSuffix, sshPort);
         }
-        
+
          // 1.43 new parameters
         if (connectionStrategy == null )  {
             connectionStrategy = ConnectionStrategy.backwardsCompatible(usePrivateDnsName, connectUsingPublicIp, associatePublicIp);
@@ -1202,12 +1199,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         if (maxTotalUses == 0) {
             maxTotalUses = -1;
         }
-        
+
         return this;
     }
 
     public Descriptor<SlaveTemplate> getDescriptor() {
-        return Jenkins.getInstance().getDescriptor(getClass());
+        return Jenkins.get().getDescriptor(getClass());
     }
 
     public int getLaunchTimeout() {
@@ -1247,7 +1244,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
 
         public List<Descriptor<AMITypeData>> getAMITypeDescriptors() {
-            return Jenkins.getInstance().getDescriptorList(AMITypeData.class);
+            return Jenkins.get().getDescriptorList(AMITypeData.class);
         }
 
         /**
@@ -1258,13 +1255,13 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             String p = super.getHelpFile(fieldName);
             if (p != null)
                 return p;
-            Descriptor slaveDescriptor = Jenkins.getInstance().getDescriptor(EC2OndemandSlave.class);
+            Descriptor slaveDescriptor = Jenkins.get().getDescriptor(EC2OndemandSlave.class);
             if (slaveDescriptor != null) {
                 p = slaveDescriptor.getHelpFile(fieldName);
                 if (p != null)
                     return p;
             }
-            slaveDescriptor = Jenkins.getInstance().getDescriptor(EC2SpotSlave.class);
+            slaveDescriptor = Jenkins.get().getDescriptor(EC2SpotSlave.class);
             if (slaveDescriptor != null)
                 return slaveDescriptor.getHelpFile(fieldName);
             return null;
@@ -1272,7 +1269,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         @Restricted(NoExternalUse.class)
         public FormValidation doCheckRemoteAdmin(@QueryParameter String value){
-            if(StringUtils.isBlank(value) || Jenkins.getInstance().hasPermission(Jenkins.RUN_SCRIPTS)){
+            if(StringUtils.isBlank(value) || Jenkins.get().hasPermission(Jenkins.RUN_SCRIPTS)){
                 return FormValidation.ok();
             }else{
                 return FormValidation.error(Messages.General_MissingPermission());
@@ -1281,7 +1278,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         @Restricted(NoExternalUse.class)
         public FormValidation doCheckTmpDir(@QueryParameter String value){
-            if(StringUtils.isBlank(value) || Jenkins.getInstance().hasPermission(Jenkins.RUN_SCRIPTS)){
+            if(StringUtils.isBlank(value) || Jenkins.get().hasPermission(Jenkins.RUN_SCRIPTS)){
                 return FormValidation.ok();
             }else{
                 return FormValidation.error(Messages.General_MissingPermission());
@@ -1290,7 +1287,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         @Restricted(NoExternalUse.class)
         public FormValidation doCheckJvmopts(@QueryParameter String value){
-            if(StringUtils.isBlank(value) || Jenkins.getInstance().hasPermission(Jenkins.RUN_SCRIPTS)){
+            if(StringUtils.isBlank(value) || Jenkins.get().hasPermission(Jenkins.RUN_SCRIPTS)){
                 return FormValidation.ok();
             }else{
                 return FormValidation.error(Messages.General_MissingPermission());
@@ -1484,7 +1481,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                     if (ec2Type == null) {
                         return FormValidation.error("Could not resolve instance type: " + type);
                     }
-                    
+
                     if (!ami.isEmpty()) {
                         Image img = getAmiImage(ec2, ami);
                         if (img != null) {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -177,7 +177,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         if(StringUtils.isNotBlank(remoteAdmin) || StringUtils.isNotBlank(jvmopts) || StringUtils.isNotBlank(tmpDir)){
             LOGGER.log(Level.FINE, "As remoteAdmin, jvmopts or tmpDir is not blank, we must ensure the user has RUN_SCRIPTS rights.");
-            Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
+            // Can be null during tests
+            Jenkins j = Jenkins.getInstanceOrNull();
+            if (j != null)
+                j.checkPermission(Jenkins.RUN_SCRIPTS);
         }
 
         this.ami = ami;

--- a/src/main/java/hudson/plugins/ec2/UnixData.java
+++ b/src/main/java/hudson/plugins/ec2/UnixData.java
@@ -28,7 +28,7 @@ public class UnixData extends AMITypeData {
     }
 
     protected Object readResolve() {
-        Jenkins.getInstance().checkPermission(Jenkins.RUN_SCRIPTS);
+        Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
         return this;
     }
 
@@ -51,7 +51,7 @@ public class UnixData extends AMITypeData {
 
         @Restricted(NoExternalUse.class)
         public FormValidation doCheckRootCommandPrefix(@QueryParameter String value){
-            if(StringUtils.isBlank(value) || Jenkins.getInstance().hasPermission(Jenkins.RUN_SCRIPTS)){
+            if(StringUtils.isBlank(value) || Jenkins.get().hasPermission(Jenkins.RUN_SCRIPTS)){
                 return FormValidation.ok();
             }else{
                 return FormValidation.error(Messages.General_MissingPermission());
@@ -60,7 +60,7 @@ public class UnixData extends AMITypeData {
 
         @Restricted(NoExternalUse.class)
         public FormValidation doCheckSlaveCommandPrefix(@QueryParameter String value){
-            if(StringUtils.isBlank(value) || Jenkins.getInstance().hasPermission(Jenkins.RUN_SCRIPTS)){
+            if(StringUtils.isBlank(value) || Jenkins.get().hasPermission(Jenkins.RUN_SCRIPTS)){
                 return FormValidation.ok();
             }else{
                 return FormValidation.error(Messages.General_MissingPermission());
@@ -69,7 +69,7 @@ public class UnixData extends AMITypeData {
 
         @Restricted(NoExternalUse.class)
         public FormValidation doCheckSlaveCommandSuffix(@QueryParameter String value){
-            if(StringUtils.isBlank(value) || Jenkins.getInstance().hasPermission(Jenkins.RUN_SCRIPTS)){
+            if(StringUtils.isBlank(value) || Jenkins.get().hasPermission(Jenkins.RUN_SCRIPTS)){
                 return FormValidation.ok();
             }else{
                 return FormValidation.error(Messages.General_MissingPermission());

--- a/src/main/java/hudson/plugins/ec2/ebs/ZPoolMonitor.java
+++ b/src/main/java/hudson/plugins/ec2/ebs/ZPoolMonitor.java
@@ -52,7 +52,7 @@ public class ZPoolMonitor extends PeriodicWork {
     @Override
     protected void doRun() {
         ZPoolExpandNotice zen = AdministrativeMonitor.all().get(ZPoolExpandNotice.class);
-        Jenkins jenkinsInstance = Jenkins.getInstance();
+        Jenkins jenkinsInstance = Jenkins.getInstanceOrNull();
         ZFSFileSystem fs = null;
         try {
             if (isInsideEC2() && jenkinsInstance != null)

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -229,7 +229,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
 
             // Always copy so we get the most recent slave.jar
             logInfo(computer, listener, "Copying remoting.jar to: " + tmpDir);
-            scp.put(Jenkins.getInstance().getJnlpJars("remoting.jar").readFully(), "remoting.jar", tmpDir);
+            scp.put(Jenkins.get().getJnlpJars("remoting.jar").readFully(), "remoting.jar", tmpDir);
 
             String jvmopts = node.jvmopts;
             String prefix = computer.getSlaveCommandPrefix();
@@ -375,7 +375,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 logInfo(computer, listener, "Connecting to " + host + " on port " + port + ", with timeout " + slaveConnectTimeout
                         + ".");
                 Connection conn = new Connection(host, port);
-                ProxyConfiguration proxyConfig = Jenkins.getInstance().proxy;
+                ProxyConfiguration proxyConfig = Jenkins.get().proxy;
                 Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(host);
                 if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
                     InetSocketAddress address = (InetSocketAddress) proxy.address();

--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -68,7 +68,7 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
             }
 
             OutputStream agentJar = connection.putFile(tmpDir + AGENT_JAR);
-            agentJar.write(Jenkins.getInstance().getJnlpJars(AGENT_JAR).readFully());
+            agentJar.write(Jenkins.get().getJnlpJars(AGENT_JAR).readFully());
 
             logger.println("remoting.jar sent remotely. Bootstrapping it");
 


### PR DESCRIPTION
## Notes
- JenkinsLocationConfiguration.get() is marked `@Nonnull` so removing null checks
- Not certain about the case in ZPoolMonitor
- Some cases seem to have null checks but will produce weird behaviour if null so likely letting `get()` throw seems reasonable