### PR TITLE
Reduce lock hotness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.44</version>
+        <version>3.46</version>
     </parent>
 
     <artifactId>ec2</artifactId>


### PR DESCRIPTION
- Reduce the lock scope to when we need to modify the connection
- This change is aimed at reducing the time we hold the `Queue.lock` and `NodeProvisioner.provisioningLock` causing UI performance issues.