### PR TITLE
[JENKINS-58160] Don't use Guava Beta APIs

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2HostAddressProvider.java
+++ b/src/main/java/hudson/plugins/ec2/EC2HostAddressProvider.java
@@ -1,7 +1,6 @@
 package hudson.plugins.ec2;
 
 import com.amazonaws.services.ec2.model.Instance;
-import com.google.common.net.HostAndPort;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.Optional;
@@ -24,11 +23,11 @@ public class EC2HostAddressProvider {
         }
     }
 
-    public static HostAndPort windows(Instance instance, ConnectionStrategy strategy) {
+    public static String windows(Instance instance, ConnectionStrategy strategy) {
         if (strategy.equals(PRIVATE_DNS) || strategy.equals(PRIVATE_IP)) {
-            return HostAndPort.fromString(getPrivateIpAddress(instance));
+            return getPrivateIpAddress(instance);
         } else if (strategy.equals(PUBLIC_DNS) || strategy.equals(PUBLIC_IP)) {
-            return HostAndPort.fromString(getPublicIpAddress(instance));
+            return getPublicIpAddress(instance);
         } else {
             throw new IllegalArgumentException("Could not unix host address for strategy = " + strategy.toString());
         }

--- a/src/main/java/hudson/plugins/ec2/util/Closeables.java
+++ b/src/main/java/hudson/plugins/ec2/util/Closeables.java
@@ -1,0 +1,28 @@
+package hudson.plugins.ec2.util;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class Closeables {
+    private static Logger log = Logger.getLogger(Closeables.class.getCanonicalName());
+
+    /**
+     * Quietly close a {@link Closeable}, logging any {@link IOException}s instead of throwing them.
+     *
+     * @param closeable The {@link Closeable} to close quietly. If <code>null</code>, then this method is a no-op.
+     */
+    public static void closeQuietly(@Nullable Closeable closeable) {
+        if (closeable == null) {
+            return;
+        }
+
+        try {
+            closeable.close();
+        } catch (IOException e) {
+            log.log(Level.WARNING, "Failed to close resource, ignoring", e);
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -1,6 +1,5 @@
 package hudson.plugins.ec2.win;
 
-import com.google.common.net.HostAndPort;
 import hudson.model.Descriptor;
 import hudson.model.TaskListener;
 import hudson.plugins.ec2.EC2AbstractSlave;
@@ -121,7 +120,7 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
                             + " seconds of waiting for winrm to be connected");
                 }
                 Instance instance = computer.updateInstanceDescription();
-                String host = EC2HostAddressProvider.windows(instance, computer.getSlaveTemplate().connectionStrategy).getHostText();
+                String host = EC2HostAddressProvider.windows(instance, computer.getSlaveTemplate().connectionStrategy);
 
                 if ("0.0.0.0".equals(host)) {
                     logger.println("Invalid host 0.0.0.0, your host is most likely waiting for an ip address.");

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
@@ -1,6 +1,6 @@
 package hudson.plugins.ec2.win.winrm;
 
-import com.google.common.io.Closeables;
+import hudson.plugins.ec2.util.Closeables;
 import hudson.remoting.FastPipedInputStream;
 import hudson.remoting.FastPipedOutputStream;
 import java.io.IOException;

--- a/src/test/java/hudson/plugins/ec2/EC2HostAddressProviderTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2HostAddressProviderTest.java
@@ -83,8 +83,7 @@ public class EC2HostAddressProviderTest {
         when(instance.getPrivateDnsName()).thenReturn("0-0-0-0.ec2.internal");
         when(instance.getPrivateIpAddress()).thenReturn("0.0.0.0");
 
-        HostAndPort expected = HostAndPort.fromString("0.0.0.0");
-        assertThat(windows(instance, strategy), equalTo(expected));
+        assertThat(windows(instance, strategy), equalTo("0.0.0.0"));
     }
 
     @Test
@@ -95,8 +94,7 @@ public class EC2HostAddressProviderTest {
         when(instance.getPrivateDnsName()).thenReturn("");
         when(instance.getPrivateIpAddress()).thenReturn("0.0.0.0");
 
-        HostAndPort expected = HostAndPort.fromString("0.0.0.0");
-        assertThat(windows(instance, strategy), equalTo(expected));
+        assertThat(windows(instance, strategy), equalTo("0.0.0.0"));
     }
 
     @Test
@@ -107,8 +105,7 @@ public class EC2HostAddressProviderTest {
         when(instance.getPublicDnsName()).thenReturn("ec2-0-0-0-0.compute-1.amazonaws.com");
         when(instance.getPublicIpAddress()).thenReturn("0.0.0.0");
 
-        HostAndPort expected = HostAndPort.fromString("0.0.0.0");
-        assertThat(windows(instance, strategy), equalTo(expected));
+        assertThat(windows(instance, strategy), equalTo("0.0.0.0"));
     }
 
     @Test
@@ -119,7 +116,6 @@ public class EC2HostAddressProviderTest {
         when(instance.getPublicDnsName()).thenReturn("");
         when(instance.getPublicIpAddress()).thenReturn("0.0.0.0");
 
-        HostAndPort expected = HostAndPort.fromString("0.0.0.0");
-        assertThat(windows(instance, strategy), equalTo(expected));
+        assertThat(windows(instance, strategy), equalTo("0.0.0.0"));
     }
 }


### PR DESCRIPTION
The EC2 plug-in currently uses Guava Beta APIs. Using Guava's Beta APIs is [strongly discouraged](https://github.com/google/guava#important-warnings) as they can change at any time.

In fact, this issue is blocking me from finishing [JENKINS-56839](https://issues.jenkins-ci.org/browse/JENKINS-56839): Jenkins core provides Guava 11, but a test dependency I am using pulls in Guava 20. While a bit messy, this wouldn't usually be an issue due to [Guava's API stability guarantee](https://github.com/google/guava#important-warnings); however, because the EC2 plug-in is using Guava Beta APIs that work differently in Guava 20 than they did in Guava 11, my tests for [JENKINS-56839](https://issues.jenkins-ci.org/browse/JENKINS-56839) break.

## Changes

I changed the following classes so that they don't rely on Guava Beta APIs anymore:

- `EC2HostAddressProvider` uses the [`HostAndPort`](https://guava.dev/releases/11.0.1/api/docs/com/google/common/net/HostAndPort.html) Beta API, but for no clear reason: The IP addresses that are parsed seem always to be plain IPv4 addresses without a port. Use a plain `String` instead.
- `WindowsProcess` uses the [`Closeables`](https://guava.dev/releases/11.0.1/api/docs/com/google/common/io/Closeables.html) Beta API to close resources quietly, without throwing an exception. What the `Closeables.closeQuietly()` method does is very easy to re-implement ourselves, so do just that.