### PR TITLE
[JENKINS-58163][JENKINS-58193] Add fallback when remoteFS is blank

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -235,7 +235,8 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
             final String prefix = computer.getSlaveCommandPrefix();
             final String suffix = computer.getSlaveCommandSuffix();
             final String remoteFS = node.getRemoteFS();
-            String launchString = prefix + " java " + (jvmopts != null ? jvmopts : "") + " -jar " + tmpDir + "/remoting.jar -workDir " + remoteFS + suffix;
+            final String workDir = Util.fixEmptyAndTrim(remoteFS) != null ? remoteFS : tmpDir;
+            String launchString = prefix + " java " + (jvmopts != null ? jvmopts : "") + " -jar " + tmpDir + "/remoting.jar -workDir " + workDir + suffix;
            // launchString = launchString.trim();
 
             SlaveTemplate slaveTemplate = computer.getSlaveTemplate();


### PR DESCRIPTION
Before when remoteFS is blank
```
INFO: Copying remoting.jar to: /home/jenkins
Jun 25, 2019 8:26:36 PM hudson.plugins.ec2.EC2Cloud
INFO: Launching remoting agent (via Trilead SSH2 Connection):  java -Djava.io.tmpdir=/home/jenkins/tmp -jar /home/jenkins/remoting.jar -workDir 
ERROR: unexpected stream termination
java.io.EOFException: unexpected stream termination
	at hudson.remoting.ChannelBuilder.negotiate(ChannelBuilder.java:411)
	at hudson.remoting.ChannelBuilder.build(ChannelBuilder.java:356)
	at hudson.slaves.SlaveComputer.setChannel(SlaveComputer.java:431)
	at hudson.plugins.ec2.ssh.EC2UnixLauncher.launchScript(EC2UnixLauncher.java:262)
	at hudson.plugins.ec2.EC2ComputerLauncher.launch(EC2ComputerLauncher.java:48)
	at hudson.slaves.SlaveComputer$1.call(SlaveComputer.java:294)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:71)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

After when remoteFS is blank
```
Jun 25, 2019 8:55:19 PM hudson.plugins.ec2.EC2Cloud
INFO: Copying remoting.jar to: /home/jenkins
Jun 25, 2019 8:55:19 PM hudson.plugins.ec2.EC2Cloud
INFO: Launching remoting agent (via Trilead SSH2 Connection):  java -Djava.io.tmpdir=/home/jenkins/tmp -jar /home/jenkins/remoting.jar -workDir /home/jenkins
Both error and output logs will be printed to /home/jenkins/remoting
<===[JENKINS REMOTING CAPACITY]===>Remoting version: 3.27
This is a Unix agent
NOTE: Relative remote path resolved to: /home/jenkins
Evacuated stdout
Agent successfully connected and online
```