### PR TITLE
Only check credentials once a minute

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -985,7 +985,7 @@ public abstract class EC2Cloud extends Cloud {
                 for (Cloud cloud : instance.clouds) {
                     if (cloud instanceof EC2Cloud) {
                         EC2Cloud ec2_cloud = (EC2Cloud) cloud;
-                        LOGGER.finer("Checking EC2 Connection on: " + ec2_cloud.getDisplayName());
+                        LOGGER.finer(() -> "Checking EC2 Connection on: " + ec2_cloud.getDisplayName());
                         try {
                             if(ec2_cloud.connection != null) {
                                 ec2_cloud.connection.describeInstances();

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -991,7 +991,7 @@ public abstract class EC2Cloud extends Cloud {
                                 ec2_cloud.connection.describeInstances();
                             }
                         } catch (AmazonClientException e) {
-                            LOGGER.finer("Reconnecting to EC2 on: " + ec2_cloud.getDisplayName());
+                            LOGGER.finer(() -> "Reconnecting to EC2 on: " + ec2_cloud.getDisplayName());
                             ec2_cloud.reconnectToEc2();
                         }
                     }

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -985,9 +985,13 @@ public abstract class EC2Cloud extends Cloud {
                 for (Cloud cloud : instance.clouds) {
                     if (cloud instanceof EC2Cloud) {
                         EC2Cloud ec2_cloud = (EC2Cloud) cloud;
+                        LOGGER.finer("Checking EC2 Connection on: " + ec2_cloud.getDisplayName());
                         try {
-                            ec2_cloud.connection.describeInstances();
+                            if(ec2_cloud.connection != null) {
+                                ec2_cloud.connection.describeInstances();
+                            }
                         } catch (AmazonClientException e) {
+                            LOGGER.finer("Reconnecting to EC2 on: " + ec2_cloud.getDisplayName());
                             ec2_cloud.reconnectToEc2();
                         }
                     }

--- a/src/test/java/hudson/plugins/ec2/EC2StepTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2StepTest.java
@@ -2,6 +2,7 @@ package hudson.plugins.ec2;
 
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.AmazonEC2Exception;
+import hudson.model.PeriodicWork;
 import hudson.model.Result;
 import hudson.plugins.ec2.util.PluginTestRule;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -18,12 +19,12 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
@@ -72,7 +73,6 @@ public class EC2StepTest {
         when(cl.connect()).thenCallRealMethod();
         when(cl.getEc2EndpointUrl()).thenCallRealMethod();
         when(cl.createCredentialsProvider()).thenCallRealMethod();
-        cl.clock = Clock.systemUTC();
 
         // not expired ec2 client
         AmazonEC2 notExpiredClient = mock(AmazonEC2.class);
@@ -90,7 +90,9 @@ public class EC2StepTest {
 
         AmazonEC2 expiredClient = mock(AmazonEC2.class, new ThrowsException(expiredException));
         cl.connection = expiredClient;
-        cl.checkAfter = -1;
+        PeriodicWork work = PeriodicWork.all().get(EC2Cloud.EC2ConnectionUpdater.class);
+        assertNotNull(work);
+        work.run();
         assertNotSame("EC2 client should be re-created when it is expired", expiredClient, cl.connect());
     }
 

--- a/src/test/java/hudson/plugins/ec2/EC2StepTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2StepTest.java
@@ -18,6 +18,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -51,7 +52,7 @@ public class EC2StepTest {
     private EC2AbstractSlave instance;
 
     @Before
-    public void setup () throws Exception {
+    public void setup() throws Exception {
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
         templates.add(st);
 
@@ -71,6 +72,7 @@ public class EC2StepTest {
         when(cl.connect()).thenCallRealMethod();
         when(cl.getEc2EndpointUrl()).thenCallRealMethod();
         when(cl.createCredentialsProvider()).thenCallRealMethod();
+        cl.clock = Clock.systemUTC();
 
         // not expired ec2 client
         AmazonEC2 notExpiredClient = mock(AmazonEC2.class);
@@ -88,6 +90,7 @@ public class EC2StepTest {
 
         AmazonEC2 expiredClient = mock(AmazonEC2.class, new ThrowsException(expiredException));
         cl.connection = expiredClient;
+        cl.checkAfter = -1;
         assertNotSame("EC2 client should be re-created when it is expired", expiredClient, cl.connect());
     }
 
@@ -132,9 +135,7 @@ public class EC2StepTest {
     }
 
     @After
-    public void teardown () {
+    public void teardown() {
         r.jenkins.clouds.clear();
     }
-
-
 }


### PR DESCRIPTION
- Fix an issue introduced in #360 where calling `describeInstances` too often will eventually lead to locks being held for excessive time. This will cause `connect` to only check the credentials once a minute.
- #365 was attempting to mitigate this but the bottleneck changed to the `describeInstance` call