### PR TITLE
Remove test code in production code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@ THE SOFTWARE.
         <jenkins.version>2.150.1</jenkins.version>
         <java.level>8</java.level>
         <jcasc.version>1.22</jcasc.version>
+        <aws-java-sdk.version>1.11.562</aws-java-sdk.version>
     </properties>
 
     <dependencies>
@@ -101,7 +102,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.562</version>
+            <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -235,6 +236,17 @@ THE SOFTWARE.
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bom</artifactId>
+                <version>${aws-java-sdk.version}</version>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <repositories>
         <repository>

--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -28,6 +28,7 @@ import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Failure;
+import hudson.plugins.ec2.util.AmazonEC2Factory;
 import hudson.slaves.Cloud;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
@@ -65,8 +66,6 @@ public class AmazonEC2Cloud extends EC2Cloud {
 
     public static final String CLOUD_ID_PREFIX = "ec2-";
 
-    // Used when running unit tests
-    private static boolean testMode = false;
     private boolean noDelayProvisioning;
 
     @DataBoundConstructor
@@ -134,14 +133,6 @@ public class AmazonEC2Cloud extends EC2Cloud {
         return createCredentialsProvider(isUseInstanceProfileForCredentials(), getCredentialsId(), getRoleArn(), getRoleSessionName(), getRegion());
     }
 
-    public static void setTestMode(boolean newTestMode) {
-        testMode = newTestMode;
-    }
-
-    public static boolean isTestMode() {
-        return testMode;
-    }
-
     @Extension
     public static class DescriptorImpl extends EC2Cloud.DescriptorImpl {
 
@@ -178,15 +169,11 @@ public class AmazonEC2Cloud extends EC2Cloud {
                 throws IOException, ServletException {
 
             ListBoxModel model = new ListBoxModel();
-            if (testMode) {
-                model.add(DEFAULT_EC2_HOST);
-                return model;
-            }
 
             try {
                 AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials,
                         credentialsId);
-                AmazonEC2 client = connect(credentialsProvider, determineEC2EndpointURL(altEC2Endpoint));
+                AmazonEC2 client = AmazonEC2Factory.getInstance().connect(credentialsProvider, determineEC2EndpointURL(altEC2Endpoint));
                 DescribeRegionsResult regions = client.describeRegions();
                 List<Region> regionList = regions.getRegions();
                 for (Region r : regionList) {

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -29,6 +29,7 @@ import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Node;
 import hudson.model.Slave;
+import hudson.plugins.ec2.util.AmazonEC2Factory;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.RetentionStrategy;
@@ -699,13 +700,9 @@ public abstract class EC2AbstractSlave extends Slave {
 
     public static ListBoxModel fillZoneItems(AWSCredentialsProvider credentialsProvider, String region) {
         ListBoxModel model = new ListBoxModel();
-        if (AmazonEC2Cloud.isTestMode()) {
-            model.add(TEST_ZONE);
-            return model;
-        }
 
         if (!StringUtils.isEmpty(region)) {
-            AmazonEC2 client = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
+            AmazonEC2 client = AmazonEC2Factory.getInstance().connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
             DescribeAvailabilityZonesResult zones = client.describeAvailabilityZones();
             List<AvailabilityZone> zoneList = zones.getAvailabilityZones();
             model.add("<not specified>", "");

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -193,7 +193,7 @@ public abstract class EC2Cloud extends Cloud {
 
     public abstract URL getS3EndpointUrl() throws IOException;
 
-    private Object readResolve() {
+    protected Object readResolve() {
         this.slaveCountingLock = new ReentrantLock();
         for (SlaveTemplate t : templates)
             t.parent = this;

--- a/src/main/java/hudson/plugins/ec2/Eucalyptus.java
+++ b/src/main/java/hudson/plugins/ec2/Eucalyptus.java
@@ -42,8 +42,8 @@ import org.kohsuke.stapler.StaplerResponse;
  * @author Kohsuke Kawaguchi
  */
 public class Eucalyptus extends EC2Cloud {
-    public final URL ec2endpoint;
-    public final URL s3endpoint;
+    private final URL ec2endpoint;
+    private final URL s3endpoint;
 
     @DataBoundConstructor
     public Eucalyptus(URL ec2endpoint, URL s3endpoint, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String instanceCapStr, List<SlaveTemplate> templates, String roleArn, String roleSessionName)

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -28,10 +28,9 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-
 import javax.servlet.ServletException;
 
-
+import hudson.plugins.ec2.util.AmazonEC2Factory;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
@@ -1370,9 +1369,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId, roleArn, roleSessionName, region);
             AmazonEC2 ec2;
             if (region != null) {
-                ec2 = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
+                ec2 = AmazonEC2Factory.getInstance().connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
             } else {
-                ec2 = EC2Cloud.connect(credentialsProvider, new URL(ec2endpoint));
+                ec2 = AmazonEC2Factory.getInstance().connect(credentialsProvider, new URL(ec2endpoint));
             }
             try {
                 Image img = getAmiImage(ec2, ami);
@@ -1502,7 +1501,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             // Connect to the EC2 cloud with the access id, secret key, and
             // region queried from the created cloud
             AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId, roleArn, roleSessionName, region);
-            AmazonEC2 ec2 = EC2Cloud.connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
+            AmazonEC2 ec2 = AmazonEC2Factory.getInstance().connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
 
             if (ec2 != null) {
 

--- a/src/main/java/hudson/plugins/ec2/util/AmazonEC2Factory.java
+++ b/src/main/java/hudson/plugins/ec2/util/AmazonEC2Factory.java
@@ -1,0 +1,27 @@
+package hudson.plugins.ec2.util;
+
+import java.net.URL;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ec2.AmazonEC2;
+
+import hudson.ExtensionPoint;
+import jenkins.model.Jenkins;
+
+public interface AmazonEC2Factory extends ExtensionPoint {
+
+    static AmazonEC2Factory getInstance() {
+        AmazonEC2Factory instance = null;
+        for (AmazonEC2Factory implementation : Jenkins.get().getExtensionList(AmazonEC2Factory.class)) {
+            if (instance != null) {
+                throw new IllegalStateException("Multiple implementations of " + AmazonEC2Factory.class.getName()
+                        + " found. If overriding, please consider using ExtensionFilter");
+            }
+            instance = implementation;
+        }
+        return instance;
+    }
+
+    AmazonEC2 connect(AWSCredentialsProvider credentialsProvider, URL ec2Endpoint);
+
+}

--- a/src/main/java/hudson/plugins/ec2/util/AmazonEC2FactoryImpl.java
+++ b/src/main/java/hudson/plugins/ec2/util/AmazonEC2FactoryImpl.java
@@ -1,0 +1,21 @@
+package hudson.plugins.ec2.util;
+
+import java.net.URL;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+
+import hudson.Extension;
+import hudson.plugins.ec2.EC2Cloud;
+
+@Extension
+public class AmazonEC2FactoryImpl implements AmazonEC2Factory {
+
+    @Override
+    public AmazonEC2 connect(AWSCredentialsProvider credentialsProvider, URL ec2Endpoint) {
+        AmazonEC2 client = new AmazonEC2Client(credentialsProvider, EC2Cloud.createClientConfiguration(ec2Endpoint.getHost()));
+        client.setEndpoint(ec2Endpoint.toString());
+        return client;
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
@@ -23,13 +23,15 @@
  */
 package hudson.plugins.ec2;
 
+import com.amazonaws.services.ec2.AmazonEC2;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
-import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
@@ -49,20 +51,23 @@ public class AmazonEC2CloudTest {
 
     @Before
     public void setUp() throws Exception {
-        AmazonEC2Cloud.setTestMode(true);
         cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", "ghi", "3", Collections.emptyList(), "roleArn", "roleSessionName");
         r.jenkins.clouds.add(cloud);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        AmazonEC2Cloud.setTestMode(false);
     }
 
     @Test
     public void testConfigRoundtrip() throws Exception {
         r.submit(getConfigForm());
         r.assertEqualBeans(cloud, r.jenkins.clouds.get(AmazonEC2Cloud.class), "cloudName,region,useInstanceProfileForCredentials,privateKey,instanceCap,roleArn,roleSessionName");
+    }
+
+    @Test
+    public void testAmazonEC2FactoryGetInstance() throws Exception {
+        r.configRoundtrip();
+        AmazonEC2Cloud cloud = r.jenkins.clouds.get(AmazonEC2Cloud.class);
+        AmazonEC2 connection = cloud.connect();
+        Assert.assertNotNull(connection);
+        Assert.assertTrue(Mockito.mockingDetails(connection).isMock());
     }
 
     @Test

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudUnitTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudUnitTest.java
@@ -50,7 +50,7 @@ public class AmazonEC2CloudUnitTest {
         AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1",
                                                     "{}", null, Collections.emptyList(),
                                                     "roleArn", "roleSessionName");
-        assertEquals(cloud.instanceCap, Integer.MAX_VALUE);
+        assertEquals(cloud.getInstanceCap(), Integer.MAX_VALUE);
         assertEquals(cloud.getInstanceCapStr(), "");
 
         final int cap = 3;
@@ -58,7 +58,7 @@ public class AmazonEC2CloudUnitTest {
         cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1",
                                     "{}", capStr, Collections.emptyList(),
                                     "roleArn", "roleSessionName");
-        assertEquals(cloud.instanceCap, cap);
+        assertEquals(cloud.getInstanceCap(), cap);
         assertEquals(cloud.getInstanceCapStr(), capStr);
     }
 }

--- a/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
@@ -6,13 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.Before;
-import org.junit.After;
 import org.jvnet.hudson.test.JenkinsRule;
 import com.amazonaws.services.ec2.model.InstanceType;
-
-
-import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
 
@@ -21,17 +16,7 @@ public class EC2AbstractSlaveTest {
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
-    int timeoutInSecs = Integer.MAX_VALUE;
-
-    @Before
-    public void setUp() throws Exception {
-        AmazonEC2Cloud.setTestMode(true);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        AmazonEC2Cloud.setTestMode(false);
-    }
+    private int timeoutInSecs = Integer.MAX_VALUE;
 
     @Test
     public void testGetLaunchTimeoutInMillisShouldNotOverflow() throws Exception {

--- a/src/test/java/hudson/plugins/ec2/EC2StepTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2StepTest.java
@@ -3,6 +3,7 @@ package hudson.plugins.ec2;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.AmazonEC2Exception;
 import hudson.model.Result;
+import hudson.plugins.ec2.util.AmazonEC2FactoryMockImpl;
 import hudson.plugins.ec2.util.PluginTestRule;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -28,7 +29,6 @@ import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -73,8 +73,8 @@ public class EC2StepTest {
         when(cl.createCredentialsProvider()).thenCallRealMethod();
 
         // not expired ec2 client
-        AmazonEC2 notExpiredClient = mock(AmazonEC2.class);
-        cl.connection = notExpiredClient;
+        AmazonEC2 notExpiredClient = AmazonEC2FactoryMockImpl.createAmazonEC2Mock();
+        AmazonEC2FactoryMockImpl.mock = notExpiredClient;
         assertSame("EC2 client not expired should be reused", notExpiredClient, cl.connect());
 
         // expired ec2 client
@@ -86,8 +86,8 @@ public class EC2StepTest {
         expiredException.setErrorCode("RequestExpired");
         expiredException.setRequestId("00000000-0000-0000-0000-000000000000");
 
-        AmazonEC2 expiredClient = mock(AmazonEC2.class, new ThrowsException(expiredException));
-        cl.connection = expiredClient;
+        AmazonEC2 expiredClient = AmazonEC2FactoryMockImpl.createAmazonEC2Mock(new ThrowsException(expiredException));
+        AmazonEC2FactoryMockImpl.mock = expiredClient;
         assertNotSame("EC2 client should be re-created when it is expired", expiredClient, cl.connect());
     }
 
@@ -135,6 +135,5 @@ public class EC2StepTest {
     public void teardown () {
         r.jenkins.clouds.clear();
     }
-
 
 }

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -45,16 +45,6 @@ public class SlaveTemplateTest {
 
     @Rule public JenkinsRule r = new JenkinsRule();
 
-    @Before
-    public void setUp() throws Exception {
-        AmazonEC2Cloud.setTestMode(true);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        AmazonEC2Cloud.setTestMode(false);
-    }
-
     @Test
     public void testConfigRoundtrip() throws Exception {
         String ami = "ami1";
@@ -141,7 +131,8 @@ public class SlaveTemplateTest {
      *
      * @throws Exception - Exception that can be thrown by the Jenkins test harness
      */
-    @Test public void testSpotConfigWithoutBidPrice() throws Exception {
+    @Test
+    public void testSpotConfigWithoutBidPrice() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
 
@@ -171,7 +162,8 @@ public class SlaveTemplateTest {
      *
      * @throws Exception - Exception that can be thrown by the Jenkins test harness
      */
-    @Test public void testSpotConfigWithFallback() throws Exception {
+    @Test
+    public void testSpotConfigWithFallback() throws Exception {
         String ami = "ami1";
         String description = "foo ami";
 

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
@@ -24,21 +24,14 @@ import static org.junit.Assert.assertTrue;
 
 public class SlaveTemplateUnitTest {
 
-    Logger logger;
-    TestHandler handler;
+    private Logger logger;
+    private TestHandler handler;
 
     @Before
     public void setUp() throws Exception {
-        AmazonEC2Cloud.setTestMode(true);
-
         handler = new TestHandler();
         logger = Logger.getLogger(SlaveTemplate.class.getName());
         logger.addHandler(handler);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        AmazonEC2Cloud.setTestMode(false);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/ec2/util/AmazonEC2FactoryExtensionFilter.java
+++ b/src/test/java/hudson/plugins/ec2/util/AmazonEC2FactoryExtensionFilter.java
@@ -1,0 +1,20 @@
+package hudson.plugins.ec2.util;
+
+import hudson.Extension;
+import hudson.ExtensionComponent;
+import jenkins.ExtensionFilter;
+
+/**
+ * The sole purpose of this class is to filter out {@link AmazonEC2FactoryImpl} so as to avoid doing real calls to EC2
+ * when running tests.
+ */
+@Extension
+public class AmazonEC2FactoryExtensionFilter extends ExtensionFilter {
+    @Override
+    public <T> boolean allows(Class<T> type, ExtensionComponent<T> component) {
+        if (!type.isAssignableFrom(AmazonEC2Factory.class)) {
+            return true;
+        }
+        return !(component.getInstance().getClass().isAssignableFrom(AmazonEC2FactoryImpl.class));
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/util/AmazonEC2FactoryMockImpl.java
+++ b/src/test/java/hudson/plugins/ec2/util/AmazonEC2FactoryMockImpl.java
@@ -1,0 +1,67 @@
+package hudson.plugins.ec2.util;
+
+import java.net.URL;
+import java.util.Collections;
+
+import javax.annotation.Nullable;
+
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.DescribeRegionsResult;
+import com.amazonaws.services.ec2.model.Region;
+
+import hudson.Extension;
+import hudson.plugins.ec2.EC2Cloud;
+
+@Extension
+public class AmazonEC2FactoryMockImpl implements AmazonEC2Factory {
+
+    /**
+     * public static to allow supplying own mock to tests.
+     */
+    public static AmazonEC2 mock;
+
+    /**
+     * public static to provide a default mock for modifications from tests.
+     *
+     * @return mocked AmazonEC2
+     */
+    public static AmazonEC2 createAmazonEC2Mock() {
+        return createAmazonEC2Mock(null);
+    }
+
+    /**
+     * public static to provide a default mock for modifications from tests.
+     *
+     * @param defaultAnswer
+     *            nullable
+     * @return mocked AmazonEC2
+     */
+    public static AmazonEC2 createAmazonEC2Mock(@Nullable Answer defaultAnswer) {
+        AmazonEC2 mock;
+        if (defaultAnswer != null) {
+            mock = Mockito.mock(AmazonEC2.class, defaultAnswer);
+        } else {
+            mock = Mockito.mock(AmazonEC2.class);
+        }
+        Mockito.doReturn(createDescribeRegionsResultMock()).when(mock).describeRegions();
+        return mock;
+    }
+
+    private static DescribeRegionsResult createDescribeRegionsResultMock() {
+        DescribeRegionsResult mock = Mockito.mock(DescribeRegionsResult.class);
+        Mockito.doReturn(Collections.singletonList(new Region().withRegionName(EC2Cloud.DEFAULT_EC2_HOST))).when(mock).getRegions();
+        return mock;
+    }
+
+    @Override
+    public AmazonEC2 connect(AWSCredentialsProvider credentialsProvider, URL ec2Endpoint) {
+        if (mock == null) {
+            mock = createAmazonEC2Mock();
+        }
+        return mock;
+    }
+}


### PR DESCRIPTION
@jvz Please checkout this review, as per our discussion in #343 

I've broken out the EC2Cloud.connect() method to a factory that's injected with Guice and created a custom Guice module for binding that factory. That way, the actual implementation is overridable using a System property and tests can use a factory that mocks AmazonEC2.

I also refactored a bit of the existing production code and tests, getting rid of the isTestMode() in AmazonEC2Cloud and reduced the visibility of a few fields that were accessed directly from tests.