### PR TITLE
Allow defining node properties on template

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -153,7 +153,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public int maxTotalUses;
 
-    public /* almost final */DescribableList<NodeProperty<?>, NodePropertyDescriptor> nodeProperties;
+    private /* lazily initialized */ DescribableList<NodeProperty<?>, NodePropertyDescriptor> nodeProperties;
 
     public int nextSubnet;
 
@@ -586,8 +586,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     public DescribableList<NodeProperty<?>, NodePropertyDescriptor> getNodeProperties() {
-        assert nodeProperties != null;
-    	return nodeProperties;
+    	return Objects.requireNonNull(nodeProperties);
     }
 
     public enum ProvisionOptions { ALLOW_CREATE, FORCE_CREATE }

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -1329,7 +1329,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             maxTotalUses = -1;
         }
 
-         // 1.45 new parameters
         if (nodeProperties == null) {
             nodeProperties = new DescribableList<>(Saveable.NOOP);
         }

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -229,7 +229,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.useDedicatedTenancy = useDedicatedTenancy;
         this.connectBySSHProcess = connectBySSHProcess;
         this.maxTotalUses = maxTotalUses;
-        this.nodeProperties = new DescribableList<NodeProperty<?>,NodePropertyDescriptor>(Saveable.NOOP, nodeProperties);
+        this.nodeProperties = new DescribableList<>(Saveable.NOOP, Util.fixNull(nodeProperties));
         this.monitoring = monitoring;
         this.nextSubnet = 0;
 

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -32,6 +32,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -67,6 +67,9 @@ import hudson.Util;
 import hudson.model.*;
 import hudson.model.Descriptor.FormException;
 import hudson.model.labels.LabelAtom;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
+import hudson.util.DescribableList;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 
@@ -150,6 +153,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public int maxTotalUses;
 
+    public /* almost final */DescribableList<NodeProperty<?>, NodePropertyDescriptor> nodeProperties;
+
     public int nextSubnet;
 
     public String currentSubnetId;
@@ -187,8 +192,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             String instanceCapStr, String iamInstanceProfile, boolean deleteRootOnTermination,
             boolean useEphemeralDevices, boolean useDedicatedTenancy, String launchTimeoutStr, boolean associatePublicIp,
             String customDeviceMapping, boolean connectBySSHProcess, boolean monitoring,
-            boolean t2Unlimited, ConnectionStrategy connectionStrategy, int maxTotalUses) {
-
+            boolean t2Unlimited, ConnectionStrategy connectionStrategy, int maxTotalUses,
+            List<? extends NodeProperty<?>> nodeProperties) {
         if(StringUtils.isNotBlank(remoteAdmin) || StringUtils.isNotBlank(jvmopts) || StringUtils.isNotBlank(tmpDir)){
             LOGGER.log(Level.FINE, "As remoteAdmin, jvmopts or tmpDir is not blank, we must ensure the user has RUN_SCRIPTS rights.");
             // Can be null during tests
@@ -223,6 +228,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.useDedicatedTenancy = useDedicatedTenancy;
         this.connectBySSHProcess = connectBySSHProcess;
         this.maxTotalUses = maxTotalUses;
+        this.nodeProperties = new DescribableList<NodeProperty<?>,NodePropertyDescriptor>(Saveable.NOOP, nodeProperties);
         this.monitoring = monitoring;
         this.nextSubnet = 0;
 
@@ -250,6 +256,22 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.t2Unlimited = t2Unlimited;
 
         readResolve(); // initialize
+    }
+
+    @Deprecated
+    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+            InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
+            String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts,
+            boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, int minimumNumberOfInstances,
+            String instanceCapStr, String iamInstanceProfile, boolean deleteRootOnTermination,
+            boolean useEphemeralDevices, boolean useDedicatedTenancy, String launchTimeoutStr, boolean associatePublicIp,
+            String customDeviceMapping, boolean connectBySSHProcess, boolean monitoring,
+            boolean t2Unlimited, ConnectionStrategy connectionStrategy, int maxTotalUses) {
+        this(ami, zone, spotConfig, securityGroups, remoteFS, type, ebsOptimized, labelString, mode, description, initScript,
+                tmpDir, userData, numExecutors, remoteAdmin, amiType, jvmopts, stopOnTerminate, subnetId, tags,
+                idleTerminationMinutes, minimumNumberOfInstances, instanceCapStr, iamInstanceProfile, deleteRootOnTermination,
+                useEphemeralDevices, useDedicatedTenancy, launchTimeoutStr, associatePublicIp, customDeviceMapping,
+                connectBySSHProcess, monitoring, t2Unlimited, connectionStrategy, maxTotalUses, Collections.emptyList());
     }
 
     @Deprecated
@@ -557,6 +579,15 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public int getMaxTotalUses() {
         return maxTotalUses;
+    }
+
+    public List<NodePropertyDescriptor> getNodePropertyDescriptors() {
+        return NodePropertyDescriptor.for_(NodeProperty.all(), EC2AbstractSlave.class);
+    }
+
+    public DescribableList<NodeProperty<?>, NodePropertyDescriptor> getNodeProperties() {
+        assert nodeProperties != null;
+    	return nodeProperties;
     }
 
     public enum ProvisionOptions { ALLOW_CREATE, FORCE_CREATE }
@@ -1120,7 +1151,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             .withMode(mode)
             .withInitScript(initScript)
             .withTmpDir(tmpDir)
-            .withNodeProperties(Collections.emptyList())
+            .withNodeProperties(nodeProperties.toList())
             .withRemoteAdmin(remoteAdmin)
             .withJvmopts(jvmopts)
             .withStopOnTerminate(stopOnTerminate)
@@ -1149,7 +1180,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             .withInitScript(initScript)
             .withTmpDir(tmpDir)
             .withLabelString(labels)
-            .withNodeProperties(Collections.emptyList())
+            .withNodeProperties(nodeProperties.toList())
             .withRemoteAdmin(remoteAdmin)
             .withJvmopts(jvmopts)
             .withIdleTerminationMinutes(idleTerminationMinutes)
@@ -1296,6 +1327,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         if (maxTotalUses == 0) {
             maxTotalUses = -1;
+        }
+
+         // 1.45 new parameters
+        if (nodeProperties == null) {
+            nodeProperties = new DescribableList<>(Saveable.NOOP);
         }
 
         return this;

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -182,6 +182,8 @@ THE SOFTWARE.
       <f:textbox default="-1"/>
     </f:entry>
 
+    <f:descriptorList title="${%Node Properties}" field="nodeProperties" descriptors="${it.getNodePropertyDescriptors()}" />
+
   </f:advanced>
 
   <f:entry title="">


### PR DESCRIPTION
Proposal to allow defining node properties (environment variables, tool locations, etc.) that will be applied to created slaves.

`EC2AbstractSlave` and children already take a `nodeProperties` parameter, so we just need to add the field to `SlaveTemplate`.