### PR TITLE
Close stdin once shell is deleted

### DIFF
--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -49,7 +49,12 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
                     : "C:\\Windows\\Temp\\");
 
             logger.println("Creating tmp directory if it does not exist");
-            connection.execute("if not exist " + tmpDir + " mkdir " + tmpDir);
+            WindowsProcess mkdirProcess = connection.execute("if not exist " + tmpDir + " mkdir " + tmpDir);
+            int exitCode = mkdirProcess.waitFor();
+            if (exitCode != 0) {
+                logger.println("Creating tmpdir failed=" + exitCode);
+                return;
+            }
 
             if (initScript != null && initScript.trim().length() > 0 && !connection.exists(tmpDir + ".jenkins-init")) {
                 logger.println("Executing init script");

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
@@ -72,6 +72,7 @@ public class WindowsProcess {
             } finally {
                 client.deleteShell();
                 terminated = true;
+                Closeables.closeQuietly(toCallersStdin);
             }
             return client.exitCode();
         } catch (InterruptedException exc) {


### PR DESCRIPTION
When using windows instances there are useless threads for `input copy: if not exist C:\Windows\Temp\ mkdir C:\Windows\Temp\` ensure that these get cleaned up also improve logging in windows