### PR TITLE
Ensure external facing streams are closed

### DIFF
--- a/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
@@ -89,8 +89,8 @@ public class WindowsProcess {
         client.deleteShell();
         terminated = true;
         Closeables.closeQuietly(toCallersStdout);
-        Closeables.closeQuietly(toCcallersStdin);
-        Closeables.closeQuietly(toCcallersStderr);
+        Closeables.closeQuietly(toCallersStdin);
+        Closeables.closeQuietly(toCallersStderr);
         Closeables.closeQuietly(callersStdout);
         Closeables.closeQuietly(callersStdin);
         Closeables.closeQuietly(callersStderr);

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
@@ -88,6 +88,9 @@ public class WindowsProcess {
         client.signal();
         client.deleteShell();
         terminated = true;
+        Closeables.closeQuietly(toCallersStdout);
+        Closeables.closeQuietly(toCcallersStdin);
+        Closeables.closeQuietly(toCcallersStderr);
         Closeables.closeQuietly(callersStdout);
         Closeables.closeQuietly(callersStdin);
         Closeables.closeQuietly(callersStderr);

--- a/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
+++ b/src/main/java/hudson/plugins/ec2/win/winrm/WindowsProcess.java
@@ -88,6 +88,9 @@ public class WindowsProcess {
         client.signal();
         client.deleteShell();
         terminated = true;
+        Closeables.closeQuietly(callersStdout);
+        Closeables.closeQuietly(callersStdin);
+        Closeables.closeQuietly(callersStderr);
     }
 
     private void startStdoutCopyThread() {


### PR DESCRIPTION
- When process is destroyed close all external facing streams
This is partly to defend against any weird channel issues where it still thinks the streams are alive