### PR TITLE
Bump JCasC version to test against security advisory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.47</version>
+        <version>3.48</version>
     </parent>
 
     <artifactId>ec2</artifactId>
@@ -79,7 +79,7 @@ THE SOFTWARE.
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.150.1</jenkins.version>
         <java.level>8</java.level>
-        <jcasc.version>1.22</jcasc.version>
+        <jcasc.version>1.27</jcasc.version>
         <aws-java-sdk.version>1.11.594</aws-java-sdk.version>
     </properties>
 


### PR DESCRIPTION
Seems like this still works but we should use the new version to prevent forward compat issues