### PR TITLE
[JENKINS-57795] Retry when creating planned nodes

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -688,7 +688,7 @@ public abstract class EC2Cloud extends Cloud {
                                 if (attempts++ < 4) {
                                     LOGGER.log(Level.FINE, "{0}. Node {1} is neither pending, neither running, it's {2}. retrying attempt: {3}",
                                                 new Object[]{t, slave.getNodeName(), state, attempts});
-                                    Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+                                    TimeUnit.SECONDS.sleep(5);
                                     continue;
                                 }
                                 LOGGER.log(Level.WARNING, "{0}. Node {1} is neither pending, neither running, it's {2}. Terminate provisioning",


### PR DESCRIPTION
Due to eventual consistency in EC2 API a node started from a stopped state can and will return a stopped state after just being started add a few retries to ensure that nodes do not just fall off due to that.

A second follow up to this might be to search for orphans periodically.