### PR TITLE
[JENKINS-57795] Retry when waking up orphans or creating new nodes 

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -643,7 +643,7 @@ public abstract class EC2Cloud extends Cloud {
         return new PlannedNode(t.getDisplayName(),
                 Computer.threadPoolForRemoting.submit(new Callable<Node>() {
                     int retryCount     = 0;
-                    int DESCRIBE_LIMIT = 1;
+                    final int DESCRIBE_LIMIT = 2;
                     public Node call() throws Exception {
                         while (true) {
                             String instanceId = slave.getInstanceId();

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -643,7 +643,7 @@ public abstract class EC2Cloud extends Cloud {
         return new PlannedNode(t.getDisplayName(),
                 Computer.threadPoolForRemoting.submit(new Callable<Node>() {
                     int retryCount     = 0;
-                    final int DESCRIBE_LIMIT = 2;
+                    private static final int DESCRIBE_LIMIT = 2;
                     public Node call() throws Exception {
                         while (true) {
                             String instanceId = slave.getInstanceId();

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -164,11 +164,6 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
 
             final long idleMilliseconds = this.clock.millis() - computer.getIdleStartMilliseconds();
 
-            //Stopped instance restarted and Idletime has not be reset
-            if ( uptime <  idleMilliseconds) {
-                return 1;
-            }
-
 
             if (idleTerminationMinutes > 0) {
                 // TODO: really think about the right strategy here, see


### PR DESCRIPTION
Root Cause Analysis:
The use of threadpool at times causes some threads to return old values of instance state when making the getState() call. I was able to replicate similar thing using a ruby script (preferred language) that started a stopped instance and used about 10 threads to poll the state method, few threads still returned stopped for a millisecond interval although the instance had already moved to pending. This causes some instances to be started on AWS but are never connected and also, never stopped/terminated
Solution:
1. Add a retry logic on receiving `stopped`  state from the `getstate()` method. The thread will wait for 5 seconds before retrying.  I have been testing this fix in our internal environment and a retry attempt of 1 seems to work perfectly. The retry count can be increased but that can keep the thread waiting for long.
2. Remove the `uptime <  idleMilliseconds` check from EC2RetentionStrategy.java. For planned stopped nodes that are started but not connected,  `idleMilliseconds`  will be counted from the time even before when it was last stopped and will be always greater than `uptime`. This prevents such faulty nodes from being terminated and also incurs AWS costs.  The condition is ideally true for instances in the launching phase that haven't been connected yet. However, this is already taken care of by the condition [here](https://github.com/jenkinsci/ec2-plugin/blob/master/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java#L161) which protects termination of launching nodes from getting terminated before 30 minutes (STARTUP_TIMEOUT)