### PR TITLE
[JENKINS-59459] Revert both fields from being transient

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -170,10 +170,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public transient String slaveCommandSuffix;
 
     @Deprecated
-    public transient boolean usePrivateDnsName;
+    public boolean usePrivateDnsName;
 
     @Deprecated
-    public transient boolean connectUsingPublicIp;
+    public boolean connectUsingPublicIp;
 
     @DataBoundConstructor
     public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -23,20 +23,21 @@
  */
 package hudson.plugins.ec2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import com.amazonaws.services.ec2.model.InstanceType;
 import hudson.model.Node;
-import org.junit.After;
-import org.junit.Before;
+import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 
 /**
  * Basic test to validate SlaveTemplate.
@@ -337,5 +338,14 @@ public class SlaveTemplateTest {
         assertEquals(subnet1, "subnet-123");
         assertEquals(subnet2, "subnet-456");
         assertEquals(subnet3, "subnet-123");
+    }
+
+    @Test
+    public void testConnectionStrategyDeprecatedFieldsAreExported() {
+        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", Collections.singletonList(new EC2Tag("name1", "value1")), null, false, null, "", true, false, "", false, "");
+
+        String exported = Jenkins.XSTREAM.toXML(template);
+        assertThat(exported, containsString("usePrivateDnsName"));
+        assertThat(exported, containsString("connectUsingPublicIp"));
     }
 }

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -28,6 +28,7 @@ import hudson.model.Node;
 import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.ArrayList;
@@ -340,6 +341,7 @@ public class SlaveTemplateTest {
         assertEquals(subnet3, "subnet-123");
     }
 
+    @Issue("JENKINS-59460")
     @Test
     public void testConnectionStrategyDeprecatedFieldsAreExported() {
         SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", Collections.singletonList(new EC2Tag("name1", "value1")), null, false, null, "", true, false, "", false, "");


### PR DESCRIPTION
[JENKINS-59459](https://issues.jenkins-ci.org/browse/JENKINS-59459)

Revert both fields from being transient so that they are exported and thus older version of the plugins are still able to import the template.

@dgarzon 