### PR TITLE
Allow 0 in form validation for minimum number of instances

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -1509,7 +1509,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 return FormValidation.ok();
             try {
                 int val = Integer.parseInt(value);
-                if (val > 0) {
+                if (val >= 0) {
                     int instanceCap;
                     try {
                         instanceCap = Integer.parseInt(instanceCapStr);


### PR DESCRIPTION
I realized that 0 was not a valid number for minimum number of instances after I tried out the new release.

Only a form validation error, so it's still possible to continue despite having 0 as the value, but this fixes that issue.