### PR TITLE
Support limiting minimum instances to a time range

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -135,7 +135,10 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
         if (slaveTemplate != null) {
             long numberOfCurrentInstancesForTemplate = MinimumInstanceChecker.countCurrentNumberOfAgents(slaveTemplate);
             if (numberOfCurrentInstancesForTemplate > 0 && numberOfCurrentInstancesForTemplate <= slaveTemplate.getMinimumNumberOfInstances()) {
-                return 1;
+                //Check if we're in an active time-range for keeping minimum number of instances
+                if (MinimumInstanceChecker.minimumInstancesActive(slaveTemplate.getMinimumNumberOfInstancesTimeRangeConfig())) {
+                    return 1;
+                }
             }
         }
 

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -130,6 +130,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     private int minimumNumberOfInstances;
 
+    private MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig;
+
     public final boolean stopOnTerminate;
 
     private final List<EC2Tag> tags;
@@ -506,6 +508,15 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public int getMinimumNumberOfInstances() {
         return minimumNumberOfInstances;
+    }
+
+    public MinimumNumberOfInstancesTimeRangeConfig getMinimumNumberOfInstancesTimeRangeConfig() {
+        return minimumNumberOfInstancesTimeRangeConfig;
+    }
+
+    @DataBoundSetter
+    public void setMinimumNumberOfInstancesTimeRangeConfig(MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig) {
+        this.minimumNumberOfInstancesTimeRangeConfig = minimumNumberOfInstancesTimeRangeConfig;
     }
 
     public int getInstanceCap() {
@@ -1501,6 +1512,38 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             } catch (NumberFormatException ignore) {
             }
             return FormValidation.error("Minimum number of instances must be a non-negative integer (or null)");
+        }
+
+        public FormValidation doCheckMinimumNoInstancesActiveTimeRangeFrom(@QueryParameter String value) {
+            try {
+                MinimumNumberOfInstancesTimeRangeConfig.validateLocalTimeString(value);
+                return FormValidation.ok();
+            } catch (IllegalArgumentException e) {
+                return FormValidation.error("Please enter value in format 'h:mm a' or 'HH:mm'");
+            }
+        }
+
+        public FormValidation doCheckMinimumNoInstancesActiveTimeRangeTo(@QueryParameter String value) {
+            try {
+                MinimumNumberOfInstancesTimeRangeConfig.validateLocalTimeString(value);
+                return FormValidation.ok();
+            } catch (IllegalArgumentException e) {
+                return FormValidation.error("Please enter value in format 'h:mm a' or 'HH:mm'");
+            }
+        }
+
+        // For some reason, all days will validate against this method so no need to repeat for each day.
+        public FormValidation doCheckMonday(@QueryParameter boolean monday,
+                                            @QueryParameter boolean tuesday,
+                                            @QueryParameter boolean wednesday,
+                                            @QueryParameter boolean thursday,
+                                            @QueryParameter boolean friday,
+                                            @QueryParameter boolean saturday,
+                                            @QueryParameter boolean sunday) {
+            if (!(monday || tuesday || wednesday || thursday || friday || saturday || sunday)) {
+                return FormValidation.warning("At least one day should be checked or minimum number of instances won't be active");
+            }
+            return FormValidation.ok();
         }
 
         public FormValidation doCheckInstanceCapStr(@QueryParameter String value) {

--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -1,5 +1,6 @@
 package hudson.plugins.ec2.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.plugins.ec2.EC2Cloud;
 import hudson.plugins.ec2.EC2Computer;
 import hudson.plugins.ec2.SlaveTemplate;
@@ -8,11 +9,17 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Objects;
 
 @Restricted(NoExternalUse.class)
 public class MinimumInstanceChecker {
+
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Needs to be overridden from tests")
+    public static Clock clock = Clock.systemDefaultZone();
 
     public static int countCurrentNumberOfAgents(@Nonnull SlaveTemplate slaveTemplate) {
         return (int) Arrays.stream(Jenkins.get().getComputers()).filter(computer -> {
@@ -33,14 +40,50 @@ public class MinimumInstanceChecker {
             .forEach(cloud -> {
                 cloud.getTemplates().forEach(slaveTemplate -> {
                     if (slaveTemplate.getMinimumNumberOfInstances() > 0) {
-                        int currentNumberOfSlavesForTemplate = countCurrentNumberOfAgents(slaveTemplate);
-                        int numberToProvision = slaveTemplate.getMinimumNumberOfInstances()
+                        if (minimumInstancesActive(slaveTemplate.getMinimumNumberOfInstancesTimeRangeConfig())) {
+                            int currentNumberOfSlavesForTemplate = countCurrentNumberOfAgents(slaveTemplate);
+                            int numberToProvision = slaveTemplate.getMinimumNumberOfInstances()
                                 - currentNumberOfSlavesForTemplate;
-                        if (numberToProvision > 0) {
-                            cloud.provision(slaveTemplate, numberToProvision);
+                            if (numberToProvision > 0) {
+                                cloud.provision(slaveTemplate, numberToProvision);
+                            }
                         }
                     }
                 });
         });
+    }
+
+    public static boolean minimumInstancesActive(
+        MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig) {
+        if (minimumNumberOfInstancesTimeRangeConfig == null) {
+            return true;
+        }
+        LocalTime fromTime = minimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeFromAsTime();
+        LocalTime toTime = minimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeToAsTime();
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalTime nowTime = LocalTime.from(now); //No date. Easier for comparison on time only.
+
+        boolean passingMidnight = false;
+        if (toTime.isBefore(fromTime)) {
+            passingMidnight = true;
+        }
+
+        if (passingMidnight) {
+            if (nowTime.isAfter(fromTime)) {
+                String today = now.getDayOfWeek().name().toLowerCase();
+                return minimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeDays().get(today);
+            } else if (nowTime.isBefore(toTime)) {
+                //We've gone past midnight and want to check yesterday's setting.
+                String yesterday = now.minusDays(1).getDayOfWeek().name().toLowerCase();
+                return minimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeDays().get(yesterday);
+            }
+        } else {
+            if (nowTime.isAfter(fromTime) && nowTime.isBefore(toTime)) {
+                String today = now.getDayOfWeek().name().toLowerCase();
+                return minimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeDays().get(today);
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/hudson/plugins/ec2/util/MinimumNumberOfInstancesTimeRangeConfig.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumNumberOfInstancesTimeRangeConfig.java
@@ -1,0 +1,90 @@
+package hudson.plugins.ec2.util;
+
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class MinimumNumberOfInstancesTimeRangeConfig {
+
+    private String minimumNoInstancesActiveTimeRangeFrom;
+    private String minimumNoInstancesActiveTimeRangeTo;
+    private Map<String, Boolean> minimumNoInstancesActiveTimeRangeDays;
+
+    @DataBoundConstructor
+    public MinimumNumberOfInstancesTimeRangeConfig() {
+    }
+
+    private static Map<String, Boolean> parseDays(JSONObject days) {
+        Map<String, Boolean> map = new HashMap<>();
+        map.put("monday", days.getBoolean("monday"));
+        map.put("tuesday", days.getBoolean("tuesday"));
+        map.put("wednesday", days.getBoolean("wednesday"));
+        map.put("thursday", days.getBoolean("thursday"));
+        map.put("friday", days.getBoolean("friday"));
+        map.put("saturday", days.getBoolean("saturday"));
+        map.put("sunday", days.getBoolean("sunday"));
+        return map;
+    }
+
+    private static LocalTime getLocalTime(String value) {
+        try {
+            return LocalTime.parse(value, DateTimeFormatter.ofPattern("h:mm a", Locale.ENGLISH));
+        } catch (DateTimeParseException e) {
+            try {
+                return LocalTime.parse(value, DateTimeFormatter.ofPattern("HH:mm", Locale.ENGLISH));
+            } catch (DateTimeParseException ignore) {
+            }
+        }
+        return null;
+    }
+
+    public static void validateLocalTimeString(String value) {
+        if (getLocalTime(value) == null) {
+            throw new IllegalArgumentException("Value " + value + " is not valid time format, ([h:mm a] or [HH:mm])");
+        }
+    }
+
+    public String getMinimumNoInstancesActiveTimeRangeFrom() {
+        return minimumNoInstancesActiveTimeRangeFrom;
+    }
+
+    @DataBoundSetter
+    public void setMinimumNoInstancesActiveTimeRangeFrom(String minimumNoInstancesActiveTimeRangeFrom) {
+        validateLocalTimeString(minimumNoInstancesActiveTimeRangeFrom);
+        this.minimumNoInstancesActiveTimeRangeFrom = minimumNoInstancesActiveTimeRangeFrom;
+    }
+
+    public LocalTime getMinimumNoInstancesActiveTimeRangeFromAsTime() {
+        return getLocalTime(minimumNoInstancesActiveTimeRangeFrom);
+    }
+
+    public String getMinimumNoInstancesActiveTimeRangeTo() {
+        return minimumNoInstancesActiveTimeRangeTo;
+    }
+
+    @DataBoundSetter
+    public void setMinimumNoInstancesActiveTimeRangeTo(String minimumNoInstancesActiveTimeRangeTo) {
+        validateLocalTimeString(minimumNoInstancesActiveTimeRangeTo);
+        this.minimumNoInstancesActiveTimeRangeTo = minimumNoInstancesActiveTimeRangeTo;
+    }
+
+    public LocalTime getMinimumNoInstancesActiveTimeRangeToAsTime() {
+        return getLocalTime(minimumNoInstancesActiveTimeRangeTo);
+    }
+
+    public Map<String, Boolean> getMinimumNoInstancesActiveTimeRangeDays() {
+        return minimumNoInstancesActiveTimeRangeDays;
+    }
+
+    @DataBoundSetter
+    public void setMinimumNoInstancesActiveTimeRangeDays(JSONObject minimumNoInstancesActiveTimeRangeDays) {
+        this.minimumNoInstancesActiveTimeRangeDays = parseDays(minimumNoInstancesActiveTimeRangeDays);
+    }
+}

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -142,6 +142,34 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
 
+    <f:optionalBlock name="minimumNumberOfInstancesTimeRangeConfig"
+                     title="${%Only apply minimum number of instances during specific time range}" checked="${instance.minimumNumberOfInstancesTimeRangeConfig != null}"
+        help="/descriptor/hudson.plugins.ec2.SlaveTemplate/help/minimumNumberOfInstancesTimeRangeConfig" >
+      <f:entry title="${%From/to}" description="${%''13:00'' or ''1:00 PM'' format supported}">
+        From: <f:textbox style="width: 25%;" field="minimumNoInstancesActiveTimeRangeFrom" value="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeFrom}" />
+        To: <f:textbox style="width: 25%;" field="minimumNoInstancesActiveTimeRangeTo" value="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeTo}" />
+      </f:entry>
+      <f:rowSet name="minimumNoInstancesActiveTimeRangeDays">
+          <f:entry title="${%On days}" >
+              <f:checkbox field="monday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.monday}"/>
+              <label>${%Monday}</label>
+              <f:checkbox field="tuesday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.tuesday}"/>
+              <label>${%Tuesday}</label>
+              <f:checkbox field="wednesday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.wednesday}"/>
+              <label>${%Wednesday}</label>
+              <f:checkbox field="thursday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.thursday}"/>
+              <label>${%Thursday}</label>
+              <f:checkbox field="friday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.friday}"/>
+              <label>${%Friday}</label>
+              <f:checkbox field="saturday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.saturday}"/>
+              <label>${%Saturday}</label>
+              <f:checkbox field="sunday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.sunday}"/>
+              <label>${%Sunday}</label>
+          </f:entry>
+      </f:rowSet>
+    </f:optionalBlock>
+    <f:entry />
+
     <f:entry title="${%Instance Cap}" field="instanceCapStr">
       <f:textbox />
     </f:entry>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-minimumNumberOfInstancesTimeRangeConfig.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-minimumNumberOfInstancesTimeRangeConfig.html
@@ -1,0 +1,5 @@
+<div>
+    Choose the timespan and on which days a minimum number of instances should be kept alive. If the To-time is before the From-time, the time range will wrap around to the next day.
+
+    E.g. From 23:00 to 06:00 with Monday selected would mean that the instance(s) would be kept up from 23:00 on Monday evening until 06:00 Tuesday morning.
+</div>

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -4,17 +4,22 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.ec2.model.InstanceType;
 
 import hudson.plugins.ec2.util.AmazonEC2FactoryMockImpl;
+import hudson.plugins.ec2.util.MinimumInstanceChecker;
+import hudson.plugins.ec2.util.MinimumNumberOfInstancesTimeRangeConfig;
 import hudson.plugins.ec2.util.PrivateKeyHelper;
 import hudson.slaves.NodeProperty;
 import hudson.model.Executor;
 import hudson.model.Node;
 
+import net.sf.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.Month;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -255,5 +260,215 @@ public class EC2RetentionStrategyTest {
         // Should have two slaves after check
         assertEquals(2, computers.size());
         assertEquals(2, AmazonEC2FactoryMockImpl.instances.size());
+    }
+
+    @Test
+    public void testRetentionDespiteIdleWithMinimumInstanceActiveTimeRange() throws Exception {
+        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo",
+            InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null,
+            "-Xmx1g", false, "subnet 456", null, null, 2, "10", null, true, true, false, "", false, "", false, false,
+            true, ConnectionStrategy.PRIVATE_IP, 0);
+
+        MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig = new MinimumNumberOfInstancesTimeRangeConfig();
+        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeFrom("11:00");
+        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeTo("15:00");
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("monday", false);
+        jsonObject.put("tuesday", true);
+        jsonObject.put("wednesday", false);
+        jsonObject.put("thursday", false);
+        jsonObject.put("friday", false);
+        jsonObject.put("saturday", false);
+        jsonObject.put("sunday", false);
+        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeDays(jsonObject);
+        template.setMinimumNumberOfInstancesTimeRangeConfig(minimumNumberOfInstancesTimeRangeConfig);
+
+        LocalDateTime localDateTime = LocalDateTime.of(2019, Month.SEPTEMBER, 24, 12, 0); //Tuesday
+
+        //Set fixed clock to be able to test properly
+        MinimumInstanceChecker.clock = Clock.fixed(localDateTime.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3",
+            Collections
+                .singletonList(template), "roleArn", "roleSessionName");
+        r.jenkins.clouds.add(cloud);
+        r.configRoundtrip();
+
+        List<EC2Computer> computers = Arrays.stream(r.jenkins.getComputers())
+            .filter(computer -> computer instanceof EC2Computer)
+            .map(computer -> (EC2Computer) computer)
+            .collect(Collectors.toList());
+
+        // Should have two slaves before any checking
+        assertEquals(2, computers.size());
+
+        Instant now = Instant.now();
+        Clock clock = Clock.fixed(now, zoneId);
+        EC2RetentionStrategy rs = new EC2RetentionStrategy("-2", clock, now.toEpochMilli() - 1);
+        rs.check(computers.get(0));
+
+        computers = Arrays.stream(r.jenkins.getComputers())
+            .filter(computer -> computer instanceof EC2Computer)
+            .map(computer -> (EC2Computer) computer)
+            .collect(Collectors.toList());
+
+        // Should have two slaves after check too
+        assertEquals(2, computers.size());
+        assertEquals(2, AmazonEC2FactoryMockImpl.instances.size());
+
+    }
+
+    @Test
+    public void testRetentionIdleWithMinimumInstanceInactiveTimeRange() throws Exception {
+        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo",
+            InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null,
+            "-Xmx1g", false, "subnet 456", null, null, 2, "10", null, true, true, false, "", false, "", false, false,
+            true, ConnectionStrategy.PRIVATE_IP, 0);
+
+        MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig = new MinimumNumberOfInstancesTimeRangeConfig();
+        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeFrom("11:00");
+        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeTo("15:00");
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("monday", false);
+        jsonObject.put("tuesday", true);
+        jsonObject.put("wednesday", false);
+        jsonObject.put("thursday", false);
+        jsonObject.put("friday", false);
+        jsonObject.put("saturday", false);
+        jsonObject.put("sunday", false);
+        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeDays(jsonObject);
+        template.setMinimumNumberOfInstancesTimeRangeConfig(minimumNumberOfInstancesTimeRangeConfig);
+
+        LocalDateTime localDateTime = LocalDateTime.of(2019, Month.SEPTEMBER, 24, 10, 0); //Tuesday before range
+
+        //Set fixed clock to be able to test properly
+        MinimumInstanceChecker.clock = Clock.fixed(localDateTime.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3",
+            Collections
+                .singletonList(template), "roleArn", "roleSessionName");
+        r.jenkins.clouds.add(cloud);
+        r.configRoundtrip();
+
+        List<EC2Computer> computers = Arrays.stream(r.jenkins.getComputers())
+            .filter(computer -> computer instanceof EC2Computer)
+            .map(computer -> (EC2Computer) computer)
+            .collect(Collectors.toList());
+
+        // Should have zero slaves
+        assertEquals(0, computers.size());
+    }
+
+    @Test
+    public void testRetentionDespiteIdleWithMinimumInstanceActiveTimeRangeAfterMidnight() throws Exception {
+        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo",
+            InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null,
+            "-Xmx1g", false, "subnet 456", null, null, 2, "10", null, true, true, false, "", false, "", false, false,
+            true, ConnectionStrategy.PRIVATE_IP, 0);
+
+        MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig = new MinimumNumberOfInstancesTimeRangeConfig();
+        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeFrom("15:00");
+        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeTo("03:00");
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("monday", false);
+        jsonObject.put("tuesday", true);
+        jsonObject.put("wednesday", false);
+        jsonObject.put("thursday", false);
+        jsonObject.put("friday", false);
+        jsonObject.put("saturday", false);
+        jsonObject.put("sunday", false);
+        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeDays(jsonObject);
+        template.setMinimumNumberOfInstancesTimeRangeConfig(minimumNumberOfInstancesTimeRangeConfig);
+
+        LocalDateTime localDateTime = LocalDateTime.of(2019, Month.SEPTEMBER, 25, 1, 0); //Wednesday
+
+        //Set fixed clock to be able to test properly
+        MinimumInstanceChecker.clock = Clock.fixed(localDateTime.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3",
+            Collections
+                .singletonList(template), "roleArn", "roleSessionName");
+        r.jenkins.clouds.add(cloud);
+        r.configRoundtrip();
+
+        List<EC2Computer> computers = Arrays.stream(r.jenkins.getComputers())
+            .filter(computer -> computer instanceof EC2Computer)
+            .map(computer -> (EC2Computer) computer)
+            .collect(Collectors.toList());
+
+        // Should have two slaves before any checking
+        assertEquals(2, computers.size());
+
+        Instant now = Instant.now();
+        Clock clock = Clock.fixed(now, zoneId);
+        EC2RetentionStrategy rs = new EC2RetentionStrategy("-2", clock, now.toEpochMilli() - 1);
+        rs.check(computers.get(0));
+
+        computers = Arrays.stream(r.jenkins.getComputers())
+            .filter(computer -> computer instanceof EC2Computer)
+            .map(computer -> (EC2Computer) computer)
+            .collect(Collectors.toList());
+
+        // Should have two slaves after check too
+        assertEquals(2, computers.size());
+        assertEquals(2, AmazonEC2FactoryMockImpl.instances.size());
+    }
+
+    @Test
+    public void testRetentionStopsAfterActiveRangeEnds() throws Exception {
+        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo",
+            InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null,
+            "-Xmx1g", false, "subnet 456", null, null, 2, "10", null, true, true, false, "", false, "", false, false,
+            true, ConnectionStrategy.PRIVATE_IP, 0);
+
+        MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig = new MinimumNumberOfInstancesTimeRangeConfig();
+        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeFrom("11:00");
+        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeTo("15:00");
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("monday", false);
+        jsonObject.put("tuesday", true);
+        jsonObject.put("wednesday", false);
+        jsonObject.put("thursday", false);
+        jsonObject.put("friday", false);
+        jsonObject.put("saturday", false);
+        jsonObject.put("sunday", false);
+        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeDays(jsonObject);
+        template.setMinimumNumberOfInstancesTimeRangeConfig(minimumNumberOfInstancesTimeRangeConfig);
+
+        //Set fixed clock to be able to test properly
+        LocalDateTime localDateTime = LocalDateTime.of(2019, Month.SEPTEMBER, 24, 14, 0); //Tuesday
+        MinimumInstanceChecker.clock = Clock.fixed(localDateTime.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3",
+            Collections
+                .singletonList(template), "roleArn", "roleSessionName");
+        r.jenkins.clouds.add(cloud);
+        r.configRoundtrip();
+
+        List<EC2Computer> computers = Arrays.stream(r.jenkins.getComputers())
+            .filter(computer -> computer instanceof EC2Computer)
+            .map(computer -> (EC2Computer) computer)
+            .collect(Collectors.toList());
+
+        // Should have two slaves before any checking
+        assertEquals(2, computers.size());
+
+        //Set fixed clock to after active period
+        localDateTime = LocalDateTime.of(2019, Month.SEPTEMBER, 24, 16, 0); //Tuesday
+        MinimumInstanceChecker.clock = Clock.fixed(localDateTime.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+
+        Instant now = Instant.now();
+        Clock clock = Clock.fixed(now, zoneId);
+        EC2RetentionStrategy rs = new EC2RetentionStrategy("-2", clock, now.toEpochMilli() - 1);
+        rs.check(computers.get(0));
+
+        computers = Arrays.stream(r.jenkins.getComputers())
+            .filter(computer -> computer instanceof EC2Computer)
+            .map(computer -> (EC2Computer) computer)
+            .collect(Collectors.toList());
+
+        // Should have 1 slaves after check
+        assertEquals(1, computers.size());
+        assertEquals(1, AmazonEC2FactoryMockImpl.instances.size());
     }
 }


### PR DESCRIPTION
Follow-up to PR #401, this PR adds the option to limit minimum number of instances to a specific time range.

I got some wishes for that from work so that we don't have build agents up and running all weekend when no one is working.

![image](https://user-images.githubusercontent.com/2339213/65834788-e2f78480-e2de-11e9-94cc-c3393871d572.png)
