### PR TITLE
Bump aws-sdk and pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.48</version>
+        <version>3.50</version>
     </parent>
 
     <artifactId>ec2</artifactId>
@@ -80,7 +80,7 @@ THE SOFTWARE.
         <jenkins.version>2.150.1</jenkins.version>
         <java.level>8</java.level>
         <jcasc.version>1.30</jcasc.version>
-        <aws-java-sdk.version>1.11.594</aws-java-sdk.version>
+        <aws-java-sdk.version>1.11.636</aws-java-sdk.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Bump to latest pom and aws-sdk.
Latest aws-sdk has support for new GPU g4 instances.