### PR TITLE
Allow custom definition of tool locations and node properties of AWS EC2 slaves

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -182,6 +182,8 @@ THE SOFTWARE.
       <f:textbox default="-1"/>
     </f:entry>
 
+    <f:descriptorList title="${%Node Properties}" field="nodeProperties" descriptors="${it.getNodePropertyDescriptors()}" />
+
   </f:advanced>
 
   <f:entry title="">

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -203,7 +203,7 @@ public class EC2RetentionStrategyTest {
         SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo",
           InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null,
           "-Xmx1g", false, "subnet 456", null, null, 2, "10", null, true, true, false, "", false, "", false, false,
-          true, ConnectionStrategy.PRIVATE_IP, 0);
+          true, ConnectionStrategy.PRIVATE_IP, 0, Collections.emptyList());
         AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3",
           Collections
             .singletonList(template), "roleArn", "roleSessionName");

--- a/src/test/java/hudson/plugins/ec2/EC2SlaveMonitorTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2SlaveMonitorTest.java
@@ -21,7 +21,7 @@ public class EC2SlaveMonitorTest {
 
     @Test
     public void testMinimumNumberOfInstances() throws Exception {
-        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 2, null, null, true, true, false, "", false, "", false, false, true, ConnectionStrategy.PRIVATE_IP, 0);
+        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 2, null, null, true, true, false, "", false, "", false, false, true, ConnectionStrategy.PRIVATE_IP, 0, Collections.emptyList());
         AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3", Collections.singletonList(template), "roleArn", "roleSessionName");
         r.jenkins.clouds.add(cloud);
         r.configRoundtrip();


### PR DESCRIPTION
- manually tested the changes in both our UAT & PROD environment, plugin loads & works as expected. 
- fixed failing unit tests.

Also, this solves https://issues.jenkins-ci.org/browse/JENKINS-51581

Would be great if we could have this in the next release