### PR TITLE
Bump dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>trilead-api</artifactId>
-            <version>1.0.3</version><!-- TODO: BUMP when trilead split is in LTS and is the baseline -->
+            <version>1.0.4</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.temp.jelly</groupId>


### PR DESCRIPTION
While looking at upgrading too `2.190.2` from `2.176.4` I saw the Trilead breakout and noticed it's already been accounted for. However, I did see this. Not sure if it's time yet for this bump or not but here you go anyway!