### PR TITLE
Add Per-AMI Spare Instance parameter

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -468,6 +468,11 @@ public abstract class EC2AbstractSlave extends Slave {
         }
     }
 
+    void launchTimeout(){
+        LOGGER.info("EC2 instance failed to launch: " + getInstanceId());
+        terminate();
+    }
+
     public long getLaunchTimeoutInMillis() {
         // this should be fine as long as launchTimeout remains an int type
         return launchTimeout * 1000L;

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -142,6 +142,10 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
 
+    <f:entry title="${%Minimum number of spare instances}" field="minimumNumberOfSpareInstances">
+      <f:textbox />
+    </f:entry>
+
     <f:optionalBlock name="minimumNumberOfInstancesTimeRangeConfig"
                      title="${%Only apply minimum number of instances during specific time range}" checked="${instance.minimumNumberOfInstancesTimeRangeConfig != null}"
         help="/descriptor/hudson.plugins.ec2.SlaveTemplate/help/minimumNumberOfInstancesTimeRangeConfig" >

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-minimumNumberOfSpareInstances.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-minimumNumberOfSpareInstances.html
@@ -1,0 +1,16 @@
+<div>
+    <p>Set a minimum number of spare instances to make available.</p>
+
+    <p>The idea is that up to the instance cap, there will always be this number
+    of instances unused and waiting for builds.</p>
+
+   <p>This is different from the minimum number of instances, which only guarantees
+    that n instances exist, not whether there is any available capacity.</p>
+
+    <p>If this value is set 1, there will be one instance available, then if that
+    instance is used by a build, another will be provisoned. The idea being that
+    there is always a waiting instance ready for an incoming build. If you
+    have a high rate of incoming builds this value can be set higher.</p>
+
+   <p>Note that value is local to this specific AMI and associated configurations.</p>
+</div>

--- a/src/test/java/hudson/plugins/ec2/EC2SlaveMonitorTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2SlaveMonitorTest.java
@@ -28,4 +28,22 @@ public class EC2SlaveMonitorTest {
 
         Assert.assertEquals(2, Arrays.stream(Jenkins.get().getComputers()).filter(computer -> computer instanceof EC2Computer).count());
     }
+
+    @Test
+    public void testMinimumNumberOfSpareInstances() throws Exception {
+        // Arguments split onto newlines matching the construtor definition to make figuring which is which easier.
+        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "defaultsecgroup", "remotefs",
+                                                   InstanceType.M1Large, false, "label", Node.Mode.NORMAL, "description", "init script",
+                                                   "tmpdir", "userdata", "10", "remoteadmin", null, "-Xmx1g",
+                                                   false, "subnet 456", null, "0", 0,
+                                                   2, null, null, true,
+                                                   true, false, "", false,
+                                                   "", false, false,
+                                                   true, ConnectionStrategy.PRIVATE_IP, 0,
+                                                   null);
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3", Collections.singletonList(template), "roleArn", "roleSessionName");
+        r.jenkins.clouds.add(cloud);
+        r.configRoundtrip();
+        Assert.assertEquals(2, Arrays.stream(Jenkins.get().getComputers()).filter(computer -> computer instanceof EC2Computer).count());
+    }
 }

--- a/src/test/resources/hudson/plugins/ec2/UnixDataExport.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixDataExport.yml
@@ -17,6 +17,7 @@
       labelString: "linux ubuntu"
       maxTotalUses: -1
       minimumNumberOfInstances: 0
+      minimumNumberOfSpareInstances: 0
       mode: NORMAL
       monitoring: false
       numExecutors: 1


### PR DESCRIPTION
Currently there is a parameter for minimum number of instances for an AMI,
if you set it to n, there will always be at least n instances.

This PR adds minimum spare instances, if you set this to n, there will
always be n unsused instances waiting for new builds (unless the
instance cap is reached). This prevents new builds from having to wait
for provisioning, while also meaning that you don't need to set a high
absolute minimum.

Related: conjurinc/ops#401