### PR TITLE
Update EC2Slave and SlaveTemplate help text

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/EC2Slave/help-stopOnTerminate.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Slave/help-stopOnTerminate.html
@@ -27,4 +27,5 @@ THE SOFTWARE.
     You would use this option to preserve the state of the instance, including that of the
     EBS volume connections.</p>
     <p>Note that instance store content is lost, as are running processes and the contents of memory.</p>
+    <p><b>For Windows agents, stopping and starting an instance starts a new hourly billing cycle, so short stop timeouts are counterproductive.</b></p>
 </div>

--- a/src/main/resources/hudson/plugins/ec2/EC2Slave/help-stopOnTerminate.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Slave/help-stopOnTerminate.html
@@ -27,5 +27,4 @@ THE SOFTWARE.
     You would use this option to preserve the state of the instance, including that of the
     EBS volume connections.</p>
     <p>Note that instance store content is lost, as are running processes and the contents of memory.</p>
-    <p><b>Stopping and starting an instance starts a new hourly billing cycle, so short stop timeouts are counterproductive.</b></p>
 </div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-stopOnTerminate.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-stopOnTerminate.html
@@ -27,4 +27,5 @@ THE SOFTWARE.
     You would use this option to preserve the state of the instance, including that of the
     EBS volume connections.</p>
     <p>Note that instance store content is lost, as are running processes and the contents of memory.</p>
+    <p><b>For Windows agents, stopping and starting an instance starts a new hourly billing cycle, so short stop timeouts are counterproductive.</b></p>
 </div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-stopOnTerminate.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-stopOnTerminate.html
@@ -27,5 +27,4 @@ THE SOFTWARE.
     You would use this option to preserve the state of the instance, including that of the
     EBS volume connections.</p>
     <p>Note that instance store content is lost, as are running processes and the contents of memory.</p>
-    <p><b>Stopping and starting an instance starts a new hourly billing cycle, so short stop timeouts are counterproductive.</b></p>
 </div>


### PR DESCRIPTION
~Remove obsolete help text for help-stopOnTerminate.html. EC2 is now billed per second (min 60 seconds), so short stop timeouts are no longer counterproductive.~

Add clarification that short stop timeouts only matter for windows agents.