### PR TITLE
Make the default EC2 endpoint use HTTPS

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -127,7 +127,7 @@ public abstract class EC2Cloud extends Cloud {
 
     public static final String DEFAULT_EC2_HOST = "us-east-1";
 
-    public static final String DEFAULT_EC2_ENDPOINT = "http://ec2.amazonaws.com";
+    public static final String DEFAULT_EC2_ENDPOINT = "https://ec2.amazonaws.com";
 
     public static final String AWS_URL_HOST = "amazonaws.com";
 


### PR DESCRIPTION
We have a problem where the environment in which we run Jenkins isn't allowed to talk to HTTP endpoints, only HTTPS, which means the region picker doesn't work unless we supply the alternative EC2 endpoint URL. This gets around the problem but any time someone saves the Jenkins config and forgets to put the alternative endpoint URL in (even when changing unrelated config) it fails to get the region list and therefore saves an empty region into the config which causes issues when trying to spin up EC2 instances using the plugin.

The quickest, easiest solution I could come up with is to change the default endpoint to use HTTPS instead of HTTP—this should benefit everyone by protecting against e.g. MITM attacks whilst also solving our issue. The other solution would be to store the alternative EC2 endpoint URL but I was less confident in implementing that change.