### PR TITLE
Exclude other bouncy castle version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>bouncycastle-api</artifactId>
-            <version>2.17</version>
+            <version>2.18</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@ THE SOFTWARE.
             <groupId>com.hierynomus</groupId>
             <artifactId>smbj</artifactId>
             <version>0.10.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Exclude the other bouncy castle version that gets pulled in as a transitive dependency from smbj.

Multiple versions can cause problems. Without excluding it
there can be test failures with bouncycastle-api 2.18
(bouncy castle 1.64).

Also update to latest bouncy castle.