### PR TITLE
Handle cases where SlaveTemplate has been removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,8 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.55</version>
+        <version>3.56</version>
+        <relativePath/>
     </parent>
 
     <artifactId>ec2</artifactId>

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -33,8 +33,6 @@ import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.Domain;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.plugins.ec2.util.AmazonEC2Factory;
 import hudson.security.ACL;
 
@@ -64,6 +62,7 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 
+import javax.annotation.CheckForNull;
 import javax.servlet.ServletException;
 
 import hudson.Extension;
@@ -285,6 +284,7 @@ public abstract class EC2Cloud extends Cloud {
         return Collections.unmodifiableList(templates);
     }
 
+    @CheckForNull
     public SlaveTemplate getTemplate(String template) {
         for (SlaveTemplate t : templates) {
             if (t.description.equals(template)) {
@@ -799,7 +799,7 @@ public abstract class EC2Cloud extends Cloud {
     }
 
     @CheckForNull
-    private static AmazonWebServicesCredentials getCredentials(@Nullable String credentialsId) {
+    private static AmazonWebServicesCredentials getCredentials(@CheckForNull String credentialsId) {
         if (StringUtils.isBlank(credentialsId)) {
             return null;
         }

--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -79,6 +79,7 @@ public class EC2Computer extends SlaveComputer {
         return node == null ? null : node.getCloud();
     }
 
+    @CheckForNull
     public SlaveTemplate getSlaveTemplate() {
         EC2AbstractSlave node = getNode();
         if (node != null) {


### PR DESCRIPTION
Recently we encoutered an issue where when a SlaveTemplate is removed but an old Instance that uses this slave template still exists it will throw an NPE.

This PR annotates the methods and reworks the code to handle such scenarios more gracefully.