### PR TITLE
Update Spare Instance parameter to consider idle executors

### DIFF
--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -41,7 +41,7 @@ public class MinimumInstanceChecker {
 
     public static int countCurrentNumberOfSpareAgents(@Nonnull SlaveTemplate agentTemplate) {
         return (int) agentsForTemplate(agentTemplate)
-            .filter(computer -> computer.countBusy() == 0)
+            .filter(computer -> computer.countIdle() > 0)
             .filter(computer -> computer.isOnline())
             .count();
     }


### PR DESCRIPTION
If we're using more than 1 executor per agent and the scheduling
strategy spreads builds across the existing agents, we could end up
scaling up many more agents than we need.