### PR TITLE
Added null-check in MinimumInstanceChecker

### DIFF
--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -64,6 +64,7 @@ public class MinimumInstanceChecker {
             .getBuildableItems()
             .stream()
             .map((Queue.Item item) -> item.getAssignedLabel())
+            .filter(Objects::nonNull)
             .filter((Label label) -> label.matches(agentTemplate.getLabelSet()))
             .count();
     }


### PR DESCRIPTION
Since https://javadoc.jenkins-ci.org/hudson/model/Queue.Item.html#getAssignedLabel-- can return
null, it is unsafe to call 'label.matches(...)'. Removing all null elements from the stream
before the unsafe call prevents the NPE reported in https://issues.jenkins-ci.org/browse/JENKINS-61146