### PR TITLE
Demonstrate adding findsecbugs to spotbugs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,6 +426,13 @@ THE SOFTWARE.
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.h3xstream.findsecbugs</groupId>
+                            <artifactId>findsecbugs-plugin</artifactId>
+                            <version>1.10.1</version>
+                        </plugin>
+                    </plugins>
                     <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
                 </configuration>
             </plugin>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -6,4 +6,15 @@
       <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
     </Or>
   </Match>
+    
+  <Match>
+    <!--We don't care about this behavior.-->
+    <Bug pattern="CRLF_INJECTION_LOGS"/>
+  </Match>
+
+  <Match>
+    <!--We don't care about this behavior.-->
+    <Bug pattern="INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE"/>
+  </Match>
+
 </FindBugsFilter>

--- a/src/main/java/hudson/os/WindowsUtil.java
+++ b/src/main/java/hudson/os/WindowsUtil.java
@@ -88,35 +88,4 @@ public class WindowsUtil {
         return CMD_METACHARS.matcher(quoteArgument(argument)).replaceAll("^$0");
     }
 
-    /**
-     * Executes a command and arguments using {@code cmd.exe /C ...}.
-     */
-    public static @Nonnull Process execCmd(String... argv) throws IOException {
-        String command = Arrays.stream(argv).map(WindowsUtil::quoteArgumentForCmd).collect(Collectors.joining(" "));
-        return Runtime.getRuntime().exec(new String[]{"cmd.exe", "/C", command});
-    }
-
-    /**
-     * Creates an NTFS junction point if supported. Similar to symbolic links, NTFS provides junction points which
-     * provide different features than symbolic links.
-     * @param junction NTFS junction point to create
-     * @param target target directory to junction
-     * @return the newly created junction point
-     * @throws IOException if the call to mklink exits with a non-zero status code
-     * @throws InterruptedException if the call to mklink is interrupted before completing
-     * @throws UnsupportedOperationException if this method is called on a non-Windows platform
-     */
-    public static @Nonnull File createJunction(@Nonnull File junction, @Nonnull File target) throws IOException, InterruptedException {
-        if(Functions.isWindows() == false) {
-            throw new UnsupportedOperationException("Can only be called on windows platform");
-        }
-        Process mklink = execCmd("mklink", "/J", junction.getAbsolutePath(), target.getAbsolutePath());
-        int result = mklink.waitFor();
-        if (result != 0) {
-            String stderr = IOUtils.toString(mklink.getErrorStream());
-            String stdout = IOUtils.toString(mklink.getInputStream());
-            throw new IOException("Process exited with " + result + "\nStandard Output:\n" + stdout + "\nError Output:\n" + stderr);
-        }
-        return junction;
-    }
 }

--- a/src/main/java/hudson/plugins/ec2/ssh/HostKeyVerifierImpl.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/HostKeyVerifierImpl.java
@@ -26,6 +26,8 @@ package hudson.plugins.ec2.ssh;
 import java.util.logging.Logger;
 
 import com.trilead.ssh2.ServerHostKeyVerifier;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.security.MessageDigest;
 
 public class HostKeyVerifierImpl implements ServerHostKeyVerifier {
@@ -37,6 +39,7 @@ public class HostKeyVerifierImpl implements ServerHostKeyVerifier {
         this.console = console;
     }
 
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Used for tracking, not security.")
     private String getFingerprint(byte[] serverHostKey) throws Exception {
         MessageDigest md5 = MessageDigest.getInstance("MD5");
 

--- a/src/main/java/hudson/plugins/ec2/win/WinConnection.java
+++ b/src/main/java/hudson/plugins/ec2/win/WinConnection.java
@@ -1,5 +1,6 @@
 package hudson.plugins.ec2.win;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.plugins.ec2.win.winrm.WinRM;
 import hudson.plugins.ec2.win.winrm.WindowsProcess;
 
@@ -101,6 +102,7 @@ public class WinConnection {
         return path.substring(3);
     }
 
+    @SuppressFBWarnings(value = "UNENCRYPTED_SOCKET", justification = "Socket is opened and closed to check connection without sending any data.")
     public boolean ping() {
         log.log(Level.FINE, "checking SMB connection to " + host);
         try {


### PR DESCRIPTION
Demonstrate adding findsecbugs to spotbugs. This commit is a demonstration and is not intended to be merged as-is.

Findsecbugs reports several findings for this plugin, but all of them can be safely suppressed. There are a few that could be a concern, but examination shows that as currently used they do not introduce a vulnerability. While the MD5 usage here is used for tracking and not security, this serves a reminder that it would be better to migrate to a better algorithm. See [JENKINS-60563](https://issues.jenkins-ci.org/browse/JENKINS-60563).

This also uses the exclude file for a couple of finding types that are fairly common in Jenkins but not considered a concern.

---

My plan is to add findsecbugs at the plugin pom after sufficient testing and communication. At that point, it would make sense to add the suppressions, but not the pom file changes from this PR.