### PR TITLE
Offload terminates to separate thread

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -30,6 +30,7 @@ import hudson.model.Descriptor.FormException;
 import hudson.model.Node;
 import hudson.model.Slave;
 import hudson.plugins.ec2.util.AmazonEC2Factory;
+import hudson.plugins.ec2.util.ResettableCountDownLatch;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.RetentionStrategy;
@@ -41,13 +42,11 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
-import javax.annotation.concurrent.GuardedBy;
 
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
@@ -114,9 +113,8 @@ public abstract class EC2AbstractSlave extends Slave {
     protected transient long lastFetchTime;
 
     /** Terminate was scheduled */
-    @GuardedBy("this")
     @Nonnull
-    protected transient volatile CountDownLatch terminateScheduled = new CountDownLatch(0);
+    protected transient ResettableCountDownLatch terminateScheduled = new ResettableCountDownLatch(1, false);
 
     /*
      * The time (in milliseconds) after which we will always re-fetch externally changeable EC2 data when we are asked

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -45,6 +45,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -108,6 +110,10 @@ public abstract class EC2AbstractSlave extends Slave {
 
     /* The time at which we fetched the last instance data */
     protected transient long lastFetchTime;
+
+    /** Terminate was scheduled */
+    @GuardedBy("this")
+    protected transient volatile boolean terminateScheduled = false;
 
     /*
      * The time (in milliseconds) after which we will always re-fetch externally changeable EC2 data when we are asked

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -465,6 +465,11 @@ public abstract class EC2AbstractSlave extends Slave {
         return null;
     }
 
+    @Override
+    public boolean isAcceptingTasks() {
+        return !terminateScheduled;
+    }
+
     void idleTimeout() {
         LOGGER.info("EC2 instance idle time expired: " + getInstanceId());
         if (!stopOnTerminate) {

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -41,10 +41,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 
 import hudson.util.Secret;
@@ -113,7 +115,8 @@ public abstract class EC2AbstractSlave extends Slave {
 
     /** Terminate was scheduled */
     @GuardedBy("this")
-    protected transient volatile boolean terminateScheduled = false;
+    @Nonnull
+    protected transient volatile CountDownLatch terminateScheduled = new CountDownLatch(0);
 
     /*
      * The time (in milliseconds) after which we will always re-fetch externally changeable EC2 data when we are asked
@@ -467,7 +470,7 @@ public abstract class EC2AbstractSlave extends Slave {
 
     @Override
     public boolean isAcceptingTasks() {
-        return !terminateScheduled;
+        return terminateScheduled.getCount() == 0;
     }
 
     void idleTimeout() {

--- a/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
@@ -2,6 +2,7 @@ package hudson.plugins.ec2;
 
 import hudson.Extension;
 import hudson.model.Descriptor.FormException;
+import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.plugins.ec2.ssh.EC2UnixLauncher;
 import hudson.plugins.ec2.win.EC2WindowsLauncher;
@@ -71,22 +72,34 @@ public class EC2OndemandSlave extends EC2AbstractSlave {
      * Terminates the instance in EC2.
      */
     public void terminate() {
-        try {
-            if (!isAlive(true)) {
-                /*
-                 * The node has been killed externally, so we've nothing to do here
-                 */
-                LOGGER.info("EC2 instance already terminated: " + getInstanceId());
-            } else {
-                AmazonEC2 ec2 = getCloud().connect();
-                TerminateInstancesRequest request = new TerminateInstancesRequest(Collections.singletonList(getInstanceId()));
-                ec2.terminateInstances(request);
-                LOGGER.info("Terminated EC2 instance (terminated): " + getInstanceId());
+        if (!terminateScheduled) {
+            synchronized(this) {
+                if (!terminateScheduled) {
+                    Computer.threadPoolForRemoting.submit(() -> {
+                        try {
+                            if (!isAlive(true)) {
+                                /*
+                                * The node has been killed externally, so we've nothing to do here
+                                */
+                                LOGGER.info("EC2 instance already terminated: " + getInstanceId());
+                            } else {
+                                AmazonEC2 ec2 = getCloud().connect();
+                                TerminateInstancesRequest request = new TerminateInstancesRequest(Collections.singletonList(getInstanceId()));
+                                ec2.terminateInstances(request);
+                                LOGGER.info("Terminated EC2 instance (terminated): " + getInstanceId());
+                            }
+                            Jenkins.get().removeNode(this);
+                            LOGGER.info("Removed EC2 instance from jenkins master: " + getInstanceId());
+                        } catch (AmazonClientException | IOException e) {
+                            LOGGER.log(Level.WARNING, "Failed to terminate EC2 instance: " + getInstanceId(), e);
+                            synchronized(this) {
+                                terminateScheduled = false;
+                            }
+                        }
+                    });
+                    terminateScheduled = true;
+                }
             }
-            Jenkins.get().removeNode(this);
-            LOGGER.info("Removed EC2 instance from jenkins master: " + getInstanceId());
-        } catch (AmazonClientException | IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to terminate EC2 instance: " + getInstanceId(), e);
         }
     }
 

--- a/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
@@ -92,6 +92,7 @@ public class EC2OndemandSlave extends EC2AbstractSlave {
                             LOGGER.info("Removed EC2 instance from jenkins master: " + getInstanceId());
                         } catch (AmazonClientException | IOException e) {
                             LOGGER.log(Level.WARNING, "Failed to terminate EC2 instance: " + getInstanceId(), e);
+                        } finally {
                             synchronized(this) {
                                 terminateScheduled = false;
                             }

--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -20,6 +20,7 @@ import com.amazonaws.services.ec2.model.SpotInstanceState;
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 
 import hudson.Extension;
+import hudson.model.Computer;
 import hudson.model.Descriptor.FormException;
 import hudson.plugins.ec2.ssh.EC2UnixLauncher;
 import hudson.plugins.ec2.win.EC2WindowsLauncher;
@@ -65,52 +66,64 @@ public class EC2SpotSlave extends EC2AbstractSlave implements EC2Readiness {
      */
     @Override
     public void terminate() {
-		try {
-			// Cancel the spot request
-			AmazonEC2 ec2 = getCloud().connect();
+        if (!terminateScheduled) {
+            synchronized(this) {
+                if (!terminateScheduled) {
+                    Computer.threadPoolForRemoting.submit(() -> {
+                        try {
+                            // Cancel the spot request
+                            AmazonEC2 ec2 = getCloud().connect();
 
-			String instanceId = getInstanceId();
-			List<String> requestIds = Collections.singletonList(spotInstanceRequestId);
-			CancelSpotInstanceRequestsRequest cancelRequest = new CancelSpotInstanceRequestsRequest(requestIds);
-			try {
-				ec2.cancelSpotInstanceRequests(cancelRequest);
-				LOGGER.info("Canceled Spot request: " + spotInstanceRequestId);
-			} catch (AmazonClientException e) {
-				// Spot request is no longer valid
-				LOGGER.log(Level.WARNING, "Failed to cancel Spot request: " + spotInstanceRequestId, e);
-            }
+                            String instanceId = getInstanceId();
+                            List<String> requestIds = Collections.singletonList(spotInstanceRequestId);
+                            CancelSpotInstanceRequestsRequest cancelRequest = new CancelSpotInstanceRequestsRequest(requestIds);
+                            try {
+                                ec2.cancelSpotInstanceRequests(cancelRequest);
+                                LOGGER.info("Canceled Spot request: " + spotInstanceRequestId);
+                            } catch (AmazonClientException e) {
+                                // Spot request is no longer valid
+                                LOGGER.log(Level.WARNING, "Failed to cancel Spot request: " + spotInstanceRequestId, e);
+                            }
 
-            // Terminate the slave if it is running
-            if (instanceId != null && !instanceId.equals("")) {
-                if (!super.isAlive(true)) {
-                    /*
-                     * The node has been killed externally, so we've nothing to do here
-                     */
-                    LOGGER.info("EC2 instance already terminated: " + instanceId);
-                } else {
-                    TerminateInstancesRequest request = new TerminateInstancesRequest(Collections.singletonList(instanceId));
-                    try {
-                        ec2.terminateInstances(request);
-                        LOGGER.info("Terminated EC2 instance (terminated): " + instanceId);
-                    } catch (AmazonClientException e) {
-                        // Spot request is no longer valid
-                        LOGGER.log(Level.WARNING, "Failed to terminate the Spot instance: " + instanceId, e);
-                    }
+                            // Terminate the slave if it is running
+                            if (instanceId != null && !instanceId.equals("")) {
+                                if (!super.isAlive(true)) {
+                                    /*
+                                    * The node has been killed externally, so we've nothing to do here
+                                    */
+                                    LOGGER.info("EC2 instance already terminated: " + instanceId);
+                                } else {
+                                    TerminateInstancesRequest request = new TerminateInstancesRequest(Collections.singletonList(instanceId));
+                                    try {
+                                        ec2.terminateInstances(request);
+                                        LOGGER.info("Terminated EC2 instance (terminated): " + instanceId);
+                                    } catch (AmazonClientException e) {
+                                        // Spot request is no longer valid
+                                        LOGGER.log(Level.WARNING, "Failed to terminate the Spot instance: " + instanceId, e);
+                                    }
+                                }
+                            }
+                        } catch (Exception e) {
+                            LOGGER.log(Level.WARNING,"Failed to remove slave: ", e);
+                        } finally {
+                            // Remove the instance even if deletion failed, otherwise it will hang around forever in
+                            // the nodes page. One way for this to occur is that an instance was terminated
+                            // manually or a spot instance was killed due to pricing. If we don't remove the node,
+                            // we screw up auto-scaling, since it will continue to count against the quota.
+                            try {
+                                Jenkins.get().removeNode(this);
+                            } catch (IOException e) {
+                                LOGGER.log(Level.WARNING, "Failed to remove slave: " + name, e);
+                            }
+                            synchronized(this) {
+                                terminateScheduled = false;
+                            }
+                        }
+                    });
+                    terminateScheduled = true;
                 }
             }
-		} catch (Exception e) {
-			LOGGER.log(Level.WARNING,"Failed to remove slave: ", e);
-		} finally {
-			// Remove the instance even if deletion failed, otherwise it will hang around forever in
-			// the nodes page. One way for this to occur is that an instance was terminated
-			// manually or a spot instance was killed due to pricing. If we don't remove the node,
-			// we screw up auto-scaling, since it will continue to count against the quota.
-			try {
-				Jenkins.get().removeNode(this);
-			} catch (IOException e) {
-				LOGGER.log(Level.WARNING, "Failed to remove slave: " + name, e);
-			}
-		}
+        }
     }
 
     /**

--- a/src/main/java/hudson/plugins/ec2/util/ResettableCountDownLatch.java
+++ b/src/main/java/hudson/plugins/ec2/util/ResettableCountDownLatch.java
@@ -4,6 +4,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.accmod.Restricted;
+
+@Restricted(NoExternalUse.class)
 public class ResettableCountDownLatch {
     private final int count;
     private final AtomicReference<CountDownLatch> latchHolder = new AtomicReference<>();

--- a/src/main/java/hudson/plugins/ec2/util/ResettableCountDownLatch.java
+++ b/src/main/java/hudson/plugins/ec2/util/ResettableCountDownLatch.java
@@ -1,0 +1,43 @@
+package hudson.plugins.ec2.util;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ResettableCountDownLatch {
+    private final int count;
+    private final AtomicReference<CountDownLatch> latchHolder = new AtomicReference<>();
+
+    public ResettableCountDownLatch(int count) {
+        this(count, true);
+    }
+
+    public ResettableCountDownLatch(int count, boolean setInitialState) {
+        this.count = count;
+        if (setInitialState) {
+            latchHolder.set(new CountDownLatch(count));
+        } else {
+            latchHolder.set(new CountDownLatch(0));
+        }
+    }
+
+    public void countDown() {
+        latchHolder.get().countDown();
+    }
+
+    public void reset() {
+        latchHolder.set(new CountDownLatch(count));
+    }
+
+    public void await() throws InterruptedException {
+        latchHolder.get().await();
+    }
+
+    public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+        return latchHolder.get().await(timeout, unit);
+    }
+
+    public long getCount() {
+        return latchHolder.get().getCount();
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -476,7 +476,6 @@ public class EC2RetentionStrategyTest {
     private static void checkRetentionStrategy(EC2RetentionStrategy rs, EC2Computer c) throws InterruptedException {
         rs.check(c);
         EC2AbstractSlave node = c.getNode();
-        while (node.terminateScheduled)
-            Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+        assertTrue(node.terminateScheduled.await(10, TimeUnit.SECONDS));
     }
 }

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -59,7 +60,7 @@ public class EC2RetentionStrategyTest {
             int[] t = upTime.get(i);
             EC2Computer computer = computerWithIdleTime(t[0], t[1]);
             EC2RetentionStrategy rs = new EC2RetentionStrategy("-2");
-            rs.check(computer);
+            checkRetentionStrategy(rs, computer);
             assertEquals("Expected " + t[0] + "m" + t[1] + "s to be " + expected.get(i), (boolean) expected.get(i), idleTimeoutCalled.get());
             // reset the assumption
             idleTimeoutCalled.set(false);
@@ -195,7 +196,7 @@ public class EC2RetentionStrategyTest {
             } else {
                 rs = new EC2RetentionStrategy("1");
             }
-            rs.check(computer);
+            checkRetentionStrategy(rs, computer);
             String action = expected.get(i) ? "call" : "not call";
             long newNextCheckAfter = rs.getNextCheckAfter();
             assertEquals(String.format("Expected elapsed time of %s ms to %s internalCheck.", startingUptime, action), expectCallCheck, nextCheckAfter != newNextCheckAfter);
@@ -226,7 +227,7 @@ public class EC2RetentionStrategyTest {
         Instant now = Instant.now();
         Clock clock = Clock.fixed(now, zoneId);
         EC2RetentionStrategy rs = new EC2RetentionStrategy("-2", clock, now.toEpochMilli() - 1);
-        rs.check(computers.get(0));
+        checkRetentionStrategy(rs, computers.get(0));
 
         computers = Arrays.stream(r.jenkins.getComputers())
           .filter(computer -> computer instanceof EC2Computer)
@@ -250,7 +251,7 @@ public class EC2RetentionStrategyTest {
         assertEquals(3, AmazonEC2FactoryMockImpl.instances.size());
 
         rs = new EC2RetentionStrategy("-2", clock, now.toEpochMilli() - 1);
-        rs.check(computers.get(0));
+        checkRetentionStrategy(rs, computers.get(0));
 
         computers = Arrays.stream(r.jenkins.getComputers())
           .filter(computer -> computer instanceof EC2Computer)
@@ -305,7 +306,7 @@ public class EC2RetentionStrategyTest {
         Instant now = Instant.now();
         Clock clock = Clock.fixed(now, zoneId);
         EC2RetentionStrategy rs = new EC2RetentionStrategy("-2", clock, now.toEpochMilli() - 1);
-        rs.check(computers.get(0));
+        checkRetentionStrategy(rs, computers.get(0));
 
         computers = Arrays.stream(r.jenkins.getComputers())
             .filter(computer -> computer instanceof EC2Computer)
@@ -402,7 +403,7 @@ public class EC2RetentionStrategyTest {
         Instant now = Instant.now();
         Clock clock = Clock.fixed(now, zoneId);
         EC2RetentionStrategy rs = new EC2RetentionStrategy("-2", clock, now.toEpochMilli() - 1);
-        rs.check(computers.get(0));
+        checkRetentionStrategy(rs, computers.get(0));
 
         computers = Arrays.stream(r.jenkins.getComputers())
             .filter(computer -> computer instanceof EC2Computer)
@@ -460,7 +461,7 @@ public class EC2RetentionStrategyTest {
         Instant now = Instant.now();
         Clock clock = Clock.fixed(now, zoneId);
         EC2RetentionStrategy rs = new EC2RetentionStrategy("-2", clock, now.toEpochMilli() - 1);
-        rs.check(computers.get(0));
+        checkRetentionStrategy(rs, computers.get(0));
 
         computers = Arrays.stream(r.jenkins.getComputers())
             .filter(computer -> computer instanceof EC2Computer)
@@ -470,5 +471,12 @@ public class EC2RetentionStrategyTest {
         // Should have 1 slaves after check
         assertEquals(1, computers.size());
         assertEquals(1, AmazonEC2FactoryMockImpl.instances.size());
+    }
+
+    private static void checkRetentionStrategy(EC2RetentionStrategy rs, EC2Computer c) throws InterruptedException {
+        rs.check(c);
+        EC2AbstractSlave node = c.getNode();
+        while (node.terminateScheduled)
+            Thread.sleep(TimeUnit.SECONDS.toMillis(1));
     }
 }


### PR DESCRIPTION
Offload termination of agents so as to not stall `NodeProvisioner.update` when NodeProvisioner.update is called it will hold the queue lock. In order to reduce the hotness of this lock schedule all terminates to be off thread