### PR TITLE
Fix Javascript error with Node Properties that prevented config display

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -214,7 +214,7 @@ THE SOFTWARE.
       <f:textbox default="-1"/>
     </f:entry>
 
-    <f:descriptorList title="${%Node Properties}" field="nodeProperties" descriptors="${it.getNodePropertyDescriptors()}" />
+    <f:descriptorList title="${%Node Properties}" field="nodeProperties" descriptors="${descriptor.getNodePropertyDescriptors()}" />
 
   </f:advanced>
 


### PR DESCRIPTION
This fixes the bug reported in https://issues.jenkins-ci.org/browse/JENKINS-60890 that prevented configuration options from displaying.