### PR TITLE
JENKINS-60482 Alternate Endpoint fix

### DIFF
--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -24,10 +24,6 @@
 package hudson.plugins.ec2;
 
 import com.amazonaws.SdkClientException;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.model.DescribeRegionsResult;
-import com.amazonaws.services.ec2.model.Region;
 import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.Util;
@@ -36,6 +32,7 @@ import hudson.plugins.ec2.util.AmazonEC2Factory;
 import hudson.slaves.Cloud;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -43,11 +40,18 @@ import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nullable;
 import javax.servlet.ServletException;
+
 import jenkins.model.Jenkins;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.DescribeRegionsResult;
+import com.amazonaws.services.ec2.model.Region;
 
 /**
  * The original implementation of {@link EC2Cloud}.

--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -24,6 +24,10 @@
 package hudson.plugins.ec2;
 
 import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.DescribeRegionsResult;
+import com.amazonaws.services.ec2.model.Region;
 import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.Util;
@@ -32,7 +36,6 @@ import hudson.plugins.ec2.util.AmazonEC2Factory;
 import hudson.slaves.Cloud;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -40,18 +43,11 @@ import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nullable;
 import javax.servlet.ServletException;
-
 import jenkins.model.Jenkins;
-
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
-
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.model.DescribeRegionsResult;
-import com.amazonaws.services.ec2.model.Region;
 
 /**
  * The original implementation of {@link EC2Cloud}.
@@ -63,6 +59,8 @@ public class AmazonEC2Cloud extends EC2Cloud {
      * Represents the region. Can be null for backward compatibility reasons.
      */
     private String region;
+
+    private String altEC2Endpoint;
 
     public static final String CLOUD_ID_PREFIX = "ec2-";
 
@@ -132,6 +130,15 @@ public class AmazonEC2Cloud extends EC2Cloud {
     @DataBoundSetter
     public void setNoDelayProvisioning(boolean noDelayProvisioning) {
         this.noDelayProvisioning = noDelayProvisioning;
+    }
+
+    public String getAltEC2Endpoint() {
+        return altEC2Endpoint;
+    }
+
+    @DataBoundSetter
+    public void setAltEC2Endpoint(String altEC2Endpoint) {
+        this.altEC2Endpoint = altEC2Endpoint;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -101,17 +101,21 @@ public class AmazonEC2Cloud extends EC2Cloud {
         return region;
     }
 
-    public static URL getEc2EndpointUrl(String region) {
+    public static URL getEc2EndpointUrl(String altEC2Endpoint, String region) {
         try {
-            return new URL("https://ec2." + region + "." + AWS_URL_HOST + "/");
+            if (Util.fixEmpty(altEC2Endpoint) == null) {
+                return new URL("https://ec2." + region + "." + AWS_URL_HOST + "/");
+            } else {
+                return new URL(altEC2Endpoint);
+            }
         } catch (MalformedURLException e) {
-            throw new Error(e); // Impossible
+            throw new Error(e);
         }
     }
 
     @Override
     public URL getEc2EndpointUrl() {
-        return getEc2EndpointUrl(getRegion());
+        return getEc2EndpointUrl( altEC2Endpoint, getRegion() );
     }
 
     @Override
@@ -143,7 +147,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
 
     @Override
     protected AWSCredentialsProvider createCredentialsProvider() {
-        return createCredentialsProvider(isUseInstanceProfileForCredentials(), getCredentialsId(), getRoleArn(), getRoleSessionName(), getRegion());
+        return createCredentialsProvider(isUseInstanceProfileForCredentials(), getCredentialsId(), getRoleArn(), getRoleSessionName(), getAltEC2Endpoint(), getRegion());
     }
 
     @Extension
@@ -214,6 +218,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
 
         @RequirePOST
         public FormValidation doTestConnection(
+                @QueryParameter String altEC2Endpoint,
                 @QueryParameter String region,
                 @QueryParameter boolean useInstanceProfileForCredentials,
                 @QueryParameter String credentialsId,
@@ -227,7 +232,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
                 region = DEFAULT_EC2_HOST;
             }
 
-            return super.doTestConnection(getEc2EndpointUrl(region), useInstanceProfileForCredentials, credentialsId, sshKeysCredentialsId, roleArn, roleSessionName, region);
+            return super.doTestConnection(getEc2EndpointUrl(altEC2Endpoint, region), useInstanceProfileForCredentials, credentialsId, sshKeysCredentialsId, roleArn, roleSessionName, region);
         }
     }
 }

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -740,11 +740,11 @@ public abstract class EC2AbstractSlave extends Slave {
         return amiType.isWindows() && ((WindowsData) amiType).isAllowSelfSignedCertificate();
     }
 
-    public static ListBoxModel fillZoneItems(AWSCredentialsProvider credentialsProvider, String region) {
+    public static ListBoxModel fillZoneItems(AWSCredentialsProvider credentialsProvider, String altEC2Endpoint, String region) {
         ListBoxModel model = new ListBoxModel();
 
         if (!StringUtils.isEmpty(region)) {
-            AmazonEC2 client = AmazonEC2Factory.getInstance().connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
+            AmazonEC2 client = AmazonEC2Factory.getInstance().connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(altEC2Endpoint, region));
             DescribeAvailabilityZonesResult zones = client.describeAvailabilityZones();
             List<AvailabilityZone> zoneList = zones.getAvailabilityZones();
             model.add("<not specified>", "");
@@ -772,11 +772,12 @@ public abstract class EC2AbstractSlave extends Slave {
 
         public ListBoxModel doFillZoneItems(@QueryParameter boolean useInstanceProfileForCredentials,
                                             @QueryParameter String credentialsId,
+                                            @QueryParameter String altEC2Endpoint,
                                             @QueryParameter String region,
                                             @QueryParameter String roleArn,
                                             @QueryParameter String roleSessionName) {
-            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId, roleArn, roleSessionName, region);
-            return fillZoneItems(credentialsProvider, region);
+            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId, roleArn, roleSessionName, altEC2Endpoint, region);
+            return fillZoneItems(credentialsProvider, altEC2Endpoint, region);
         }
 
         public List<Descriptor<AMITypeData>> getAMITypeDescriptors() {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -284,7 +284,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     private final List<EC2Tag> tags;
 
     public ConnectionStrategy connectionStrategy;
-    
+
     public HostKeyVerificationStrategyEnum hostKeyVerificationStrategy;
 
     public final boolean associatePublicIp;
@@ -404,8 +404,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.customDeviceMapping = customDeviceMapping;
         this.t2Unlimited = t2Unlimited;
 
-        this.hostKeyVerificationStrategy = hostKeyVerificationStrategy != null ? hostKeyVerificationStrategy : HostKeyVerificationStrategyEnum.CHECK_NEW_SOFT; 
-        
+        this.hostKeyVerificationStrategy = hostKeyVerificationStrategy != null ? hostKeyVerificationStrategy : HostKeyVerificationStrategyEnum.CHECK_NEW_SOFT;
+
         readResolve(); // initialize
     }
 
@@ -780,14 +780,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     @DataBoundSetter
     public void setHostKeyVerificationStrategy(HostKeyVerificationStrategyEnum hostKeyVerificationStrategy) {
-        this.hostKeyVerificationStrategy = (hostKeyVerificationStrategy != null) ? hostKeyVerificationStrategy : HostKeyVerificationStrategyEnum.CHECK_NEW_SOFT; 
+        this.hostKeyVerificationStrategy = (hostKeyVerificationStrategy != null) ? hostKeyVerificationStrategy : HostKeyVerificationStrategyEnum.CHECK_NEW_SOFT;
     }
-    
+
     @NonNull
     public HostKeyVerificationStrategyEnum getHostKeyVerificationStrategy() {
         return hostKeyVerificationStrategy != null ? hostKeyVerificationStrategy : HostKeyVerificationStrategyEnum.CHECK_NEW_SOFT;
     }
-    
+
     @Override
     public String toString() {
         return "SlaveTemplate{" +
@@ -1738,10 +1738,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 @QueryParameter String region, final @QueryParameter String ami, @QueryParameter String roleArn,
                 @QueryParameter String roleSessionName) throws IOException {
             checkPermission(EC2Cloud.PROVISION);
-            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId, roleArn, roleSessionName, region);
+            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId, roleArn, roleSessionName, ec2endpoint, region);
             AmazonEC2 ec2;
             if (region != null) {
-                ec2 = AmazonEC2Factory.getInstance().connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
+                ec2 = AmazonEC2Factory.getInstance().connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(ec2endpoint, region));
             } else {
                 ec2 = AmazonEC2Factory.getInstance().connect(credentialsProvider, new URL(ec2endpoint));
             }
@@ -1917,12 +1917,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         @RequirePOST
         public ListBoxModel doFillZoneItems(@QueryParameter boolean useInstanceProfileForCredentials,
-                @QueryParameter String credentialsId, @QueryParameter String region, @QueryParameter String roleArn,
+                @QueryParameter String credentialsId, @QueryParameter String altEC2Endpoint, @QueryParameter String region, @QueryParameter String roleArn,
                 @QueryParameter String roleSessionName)
                 throws IOException, ServletException {
             checkPermission(EC2Cloud.PROVISION);
-            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId, roleArn, roleSessionName, region);
-            return EC2AbstractSlave.fillZoneItems(credentialsProvider, region);
+            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId, roleArn, roleSessionName, altEC2Endpoint, region);
+            return EC2AbstractSlave.fillZoneItems(credentialsProvider, altEC2Endpoint, region);
         }
 
         /*
@@ -1962,7 +1962,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                     .map(s -> FormValidation.ok())
                     .orElse(FormValidation.error("Could not find selected connection strategy"));
         }
-        
+
         public String getDefaultHostKeyVerificationStrategy() {
             // new templates default to the most secure strategy
             return HostKeyVerificationStrategyEnum.CHECK_NEW_HARD.name();

--- a/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
+++ b/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
@@ -134,7 +134,7 @@ public final class SpotConfiguration extends AbstractDescribableImpl<SpotConfigu
          */
         @RequirePOST
         public FormValidation doCurrentSpotPrice(@QueryParameter boolean useInstanceProfileForCredentials,
-                @QueryParameter String credentialsId, @QueryParameter String region,
+                @QueryParameter String credentialsId, @QueryParameter String altEC2Endpoint, @QueryParameter String region,
                 @QueryParameter String type, @QueryParameter String zone, @QueryParameter String roleArn,
                 @QueryParameter String roleSessionName, @QueryParameter String ami) throws IOException, ServletException {
 
@@ -145,8 +145,8 @@ public final class SpotConfiguration extends AbstractDescribableImpl<SpotConfigu
 
             // Connect to the EC2 cloud with the access id, secret key, and
             // region queried from the created cloud
-            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId, roleArn, roleSessionName, region);
-            AmazonEC2 ec2 = AmazonEC2Factory.getInstance().connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(region));
+            AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId, roleArn, roleSessionName, altEC2Endpoint, region);
+            AmazonEC2 ec2 = AmazonEC2Factory.getInstance().connect(credentialsProvider, AmazonEC2Cloud.getEc2EndpointUrl(altEC2Endpoint, region));
 
             if (ec2 != null) {
 

--- a/src/main/java/hudson/plugins/ec2/util/AmazonEC2FactoryImpl.java
+++ b/src/main/java/hudson/plugins/ec2/util/AmazonEC2FactoryImpl.java
@@ -8,11 +8,13 @@ import com.amazonaws.services.ec2.AmazonEC2Client;
 
 import hudson.Extension;
 import hudson.plugins.ec2.EC2Cloud;
+import javax.annotation.CheckForNull;
 
 @Extension
 public class AmazonEC2FactoryImpl implements AmazonEC2Factory {
 
     @Override
+    @CheckForNull
     public AmazonEC2 connect(AWSCredentialsProvider credentialsProvider, URL ec2Endpoint) {
         if (ec2Endpoint != null && ec2Endpoint.toString().trim().length() > 0) {
             AmazonEC2 client = new AmazonEC2Client(credentialsProvider, EC2Cloud.createClientConfiguration(ec2Endpoint.getHost()));

--- a/src/main/java/hudson/plugins/ec2/util/AmazonEC2FactoryImpl.java
+++ b/src/main/java/hudson/plugins/ec2/util/AmazonEC2FactoryImpl.java
@@ -14,8 +14,11 @@ public class AmazonEC2FactoryImpl implements AmazonEC2Factory {
 
     @Override
     public AmazonEC2 connect(AWSCredentialsProvider credentialsProvider, URL ec2Endpoint) {
-        AmazonEC2 client = new AmazonEC2Client(credentialsProvider, EC2Cloud.createClientConfiguration(ec2Endpoint.getHost()));
-        client.setEndpoint(ec2Endpoint.toString());
-        return client;
+        if (ec2Endpoint != null && ec2Endpoint.toString().trim().length() > 0) {
+            AmazonEC2 client = new AmazonEC2Client(credentialsProvider, EC2Cloud.createClientConfiguration(ec2Endpoint.getHost()));
+            client.setEndpoint( ec2Endpoint.toString() );
+            return client;
+        }
+        return null;
     }
 }

--- a/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
@@ -53,5 +53,5 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
   </f:advanced>
-  <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="region,useInstanceProfileForCredentials,credentialsId,sshKeysCredentialsId,roleArn,roleSessionName" />
+  <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="altEC2Endpoint,region,useInstanceProfileForCredentials,credentialsId,sshKeysCredentialsId,roleArn,roleSessionName" />
 </j:jelly>

--- a/src/main/resources/hudson/plugins/ec2/SpotConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SpotConfiguration/config.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
   </f:entry>
 
   <f:optionalBlock name="useBidPrice" title="Set bid price" inline="true" checked="${h.defaultToTrue(instance.useBidPrice)}" field="useBidPrice">
-    <f:validateButton title="${%Check Current Spot Price}" progress="${%Checking...}" method="currentSpotPrice" with="useInstanceProfileForCredentials,credentialsId,region,type,zone,roleArn,roleSessionName,ami" />
+    <f:validateButton title="${%Check Current Spot Price}" progress="${%Checking...}" method="currentSpotPrice" with="useInstanceProfileForCredentials,credentialsId,altEC2Endpoint,region,type,zone,roleArn,roleSessionName,ami" />
     <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice">
       <f:textbox />
     </f:entry>


### PR DESCRIPTION
This fixes a bug in the EC2 Alternate URL endpoint configuration reported in https://issues.jenkins-ci.org/browse/JENKINS-60482. Additionally, small bug fix to fix cases if an empty endpoint got passed to the AmazonEC2 client initialization.

~This PR has https://github.com/jenkinsci/ec2-plugin/pull/438 as a parent, as my configuration required that fix to be in place in order to make this fix.~
This has been fixed in master, so that PR was no longer needed.