### PR TITLE
[JENKINS-36544] Fix Node Properties on Jenkins 2.205+

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -616,10 +616,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return maxTotalUses;
     }
 
-    public List<NodePropertyDescriptor> getNodePropertyDescriptors() {
-        return NodePropertyDescriptor.for_(NodeProperty.all(), EC2AbstractSlave.class);
-    }
-
     public DescribableList<NodeProperty<?>, NodePropertyDescriptor> getNodeProperties() {
     	return Objects.requireNonNull(nodeProperties);
     }
@@ -1796,6 +1792,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         public String getDefaultConnectionStrategy() {
             return ConnectionStrategy.PRIVATE_IP.toString();
+        }
+
+        public List<NodePropertyDescriptor> getNodePropertyDescriptors() {
+            return NodePropertyDescriptor.for_(NodeProperty.all(), EC2AbstractSlave.class);
         }
 
         public ListBoxModel doFillConnectionStrategyItems(@QueryParameter String connectionStrategy) {

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -214,7 +214,7 @@ THE SOFTWARE.
       <f:textbox default="-1"/>
     </f:entry>
 
-    <f:descriptorList title="${%Node Properties}" field="nodeProperties" descriptors="${app.getNodePropertyDescriptors()}" />
+    <f:descriptorList title="${%Node Properties}" field="nodeProperties" descriptors="${descriptor.nodePropertyDescriptors}" />
 
   </f:advanced>
 

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -214,7 +214,7 @@ THE SOFTWARE.
       <f:textbox default="-1"/>
     </f:entry>
 
-    <f:descriptorList title="${%Node Properties}" field="nodeProperties" descriptors="${it.getNodePropertyDescriptors()}" />
+    <f:descriptorList title="${%Node Properties}" field="nodeProperties" descriptors="${app.getNodePropertyDescriptors()}" />
 
   </f:advanced>
 


### PR DESCRIPTION
This is a follow-up fix for PR #382.

In 2.204, the "Configure Clouds" screen was on the main /configure system
configuration page. As a result, `${it}` referred to the global system
object, aka the Hudson instance.

In 2.205, PR jenkinsci/jenkins#4339 merged, which moves the Configure Clouds
section to a new page: /configureClouds. As a result of that change, `${it}`
no longer refers to the Hudson instance, but to a new
GlobalCloudConfiguration object. That object does not have the
`getNodePropertyDescriptors()` method, so it is not able to populate the
"Node Properties" block.

Switching that to `${app}` gives it a correct reference to the Hudson object,
and that allows it to show the Node Properties block on all Jenkins versions,
both before and after v2.205.