### PR TITLE
[JENKINS-62043] Fix NPE which broke Jenkins builds

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -6,4 +6,9 @@
       <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
     </Or>
   </Match>
+  <Match>
+      <!-- Ignore false positive NPE check which occurs in EC2AbstractSlave due to Spotbugs not quite -->
+      <!-- understanding how Java serialization works. -->
+      <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
+  </Match>
 </FindBugsFilter>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -6,9 +6,4 @@
       <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
     </Or>
   </Match>
-  <Match>
-      <!-- Ignore false positive NPE check which occurs in EC2AbstractSlave due to Spotbugs not quite -->
-      <!-- understanding how Java serialization works. -->
-      <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
-  </Match>
 </FindBugsFilter>

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -46,8 +46,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.annotation.Nonnull;
-
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -113,7 +111,6 @@ public abstract class EC2AbstractSlave extends Slave {
     protected transient long lastFetchTime;
 
     /** Terminate was scheduled */
-    @Nonnull
     protected transient ResettableCountDownLatch terminateScheduled = new ResettableCountDownLatch(1, false);
 
     /*

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -204,6 +204,16 @@ public abstract class EC2AbstractSlave extends Slave {
                 }
             }
         }
+        
+        /*
+         * If this field is null (as it would be if this object is deserialized and not constructed normally) then
+         * we need to explicitly initialize it, otherwise we will cause major blocker issues such as this one which
+         * made Jenkins entirely unusable for some in the 1.50 release:
+         * https://issues.jenkins-ci.org/browse/JENKINS-62043
+         */
+        if (terminateScheduled == null) {
+            terminateScheduled = new ResettableCountDownLatch(1, false);
+        }
 
         return this;
     }


### PR DESCRIPTION
In PR #433, which was released in AWS EC2 Plugin 1.50, a bug was introduced due to improper
handling of an important transient field which is accessed very frequently by the Jenkins server
due to it being referenced in `EC2AbstractSlave.isAcceptingTasks()`. This broke any Jenkins
user which had running EC2 Nodes during the update to plugin 1.50 (see
https://issues.jenkins-ci.org/browse/JENKINS-62043 for details).