### PR TITLE
FIX: Bad filter passed to DescribeSpotInstanceRequests API

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -413,7 +413,7 @@ public abstract class EC2Cloud extends Cloud {
             }
         } while(result.getNextToken() != null);
 
-        n += countCurrentEC2SpotSlaves(template, jenkinsServerUrl, filters, instanceIds);
+        n += countCurrentEC2SpotSlaves(template, jenkinsServerUrl, instanceIds);
         
         return n;
     }
@@ -424,10 +424,11 @@ public abstract class EC2Cloud extends Cloud {
      *
      * @param template If left null, then all spot instances are counted.
      */
-    private int countCurrentEC2SpotSlaves(SlaveTemplate template, String jenkinsServerUrl, List<Filter> filters, Set<String> instanceIds) throws AmazonClientException {
+    private int countCurrentEC2SpotSlaves(SlaveTemplate template, String jenkinsServerUrl, Set<String> instanceIds) throws AmazonClientException {
         int n = 0;
         String description = template != null ? template.description : null;
         List<SpotInstanceRequest> sirs = null;
+        List<Filter> filters = getGenericFilters(jenkinsServerUrl, template);
         if (template != null) {
             filters.add(new Filter("launch.image-id").withValues(template.getAmi()));
         }

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudUnitTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudUnitTest.java
@@ -110,7 +110,7 @@ public class AmazonEC2CloudUnitTest {
         
         Mockito.doReturn(AmazonEC2FactoryMockImpl.createAmazonEC2Mock(null)).when(cloud).connect();
 
-        Object[] params = {null, "jenkinsurl", new ArrayList<Filter>(), new HashSet<String>()};
+        Object[] params = {null, "jenkinsurl", new HashSet<String>()};
         int n = Whitebox.invokeMethod(cloud, "countCurrentEC2SpotSlaves", params);
         
         // Should equal number of spot instance requests + 1 for spot nodes not having a spot instance request


### PR DESCRIPTION
https://github.com/jenkinsci/ec2-plugin/pull/449 contained a bug where a DescribeInstances filter "instance-state-name" was propagated to the DescribeSpotInstanceRequests API call and is unsupported within that call.  I was able to reproduce the bug on the 1.50 release and tested that it is working properly with this patch. 