### PR TITLE
StrictHostKeyChecking=off should be StrictHostKeyChecking=no

### DIFF
--- a/src/main/java/hudson/plugins/ec2/HostKeyVerificationStrategyEnum.java
+++ b/src/main/java/hudson/plugins/ec2/HostKeyVerificationStrategyEnum.java
@@ -34,7 +34,7 @@ public enum HostKeyVerificationStrategyEnum {
     CHECK_NEW_HARD("check-new-hard", "yes", new CheckNewHardStrategy()),
     CHECK_NEW_SOFT("check-new-soft", "accept-new", new CheckNewSoftStrategy()),
     ACCEPT_NEW("accept-new", "accept-new", new AcceptNewStrategy()),
-    OFF("off", "off", new NonVerifyingKeyVerificationStrategy());
+    OFF("off", "no", new NonVerifyingKeyVerificationStrategy());
     
     private final String displayText;
     private final SshHostKeyVerificationStrategy strategy;

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-hostKeyVerificationStrategy.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-hostKeyVerificationStrategy.html
@@ -35,7 +35,7 @@ THE SOFTWARE.
         <li><b><i>check-new-hard = yes</i></b></li>
         <li><b><i>check-new-soft = accept-new</i></b></li>
         <li><b><i>accept-new = accept-new</i></b></li>
-        <li><b><i>off = off</i></b></li>
+        <li><b><i>off = no</i></b></li>
     </ul>
     
     <i><strong>Note: </strong></i>With the <i>check-new-hard</i> and <i>check-new-soft</i> strategies you may need to increase the <i>Launch Timeout in seconds</i> because it will now


### PR DESCRIPTION
This plugin was upgraded on our Jenkins server, and we were unaware of the host key requirement changes (and our AMIs are incompatible without some extra effort).  We were unable to continue without downgrading, because the SSH syntax for the "off" option is incorrect, leading to the following error, even when the "Host Key Verification Strategy" was set to off:

```
$ ssh -o StrictHostKeyChecking=off -i /var/lib/jenkins/tmp/ec2_4085601235825214564.pem jenkins@172.33.200.99 -p 22  java -Dfile.encoding=UTF8 -jar /tmp/remoting.jar -workDir /jenkins
command-line line 0: unsupported option "off".
```

It should be `-o StrictHostKeyChecking=no`

(we have every intention of fixing the AMIs, and the new feature makes sense, but we like to keep our Jenkins plugins relatively up-to-date, and breaking changes with more restrictive defaults make this difficult)