### PR TITLE
JENKINS-62212 Add filter to periodic EC2 connection polling

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -1051,7 +1051,10 @@ public abstract class EC2Cloud extends Cloud {
                         LOGGER.finer(() -> "Checking EC2 Connection on: " + ec2_cloud.getDisplayName());
                         try {
                             if(ec2_cloud.connection != null) {
-                                ec2_cloud.connection.describeInstances();
+                                List<Filter> filters = new ArrayList<>();
+                                filters.add(new Filter("tag-key").withValues("bogus-EC2ConnectionKeepalive"));
+                                DescribeInstancesRequest dir = new DescribeInstancesRequest().withFilters(filters);
+                                ec2_cloud.connection.describeInstances(dir);
                             }
                         } catch (AmazonClientException e) {
                             LOGGER.finer(() -> "Reconnecting to EC2 on: " + ec2_cloud.getDisplayName());


### PR DESCRIPTION
It appears the response from this request is discarded, and the request
is made only to validate we still have a good connection to AWS.

This prevents the connection polling from returning _all_ ec2 instances
in the AWS account, using up AWS API quotas (which take result size into
account for API quota tracking purposes).

We are running a semi-degenerate setup with ~50 instances in a single AWS account, all of which make this unfiltered request every minute, and have been getting API throttled.  My rough understanding is that this is just a health check and we don't actually need the whole query result, and we've been running one master with this patch with no ill effects so far, but it's entirely possible I'm misinterpreting the purpose of this request.