### PR TITLE
[JENKINS-62195] Replace off by no to guarantee compatibility with old ssh clients

### DIFF
--- a/src/main/java/hudson/plugins/ec2/HostKeyVerificationStrategyEnum.java
+++ b/src/main/java/hudson/plugins/ec2/HostKeyVerificationStrategyEnum.java
@@ -34,7 +34,7 @@ public enum HostKeyVerificationStrategyEnum {
     CHECK_NEW_HARD("check-new-hard", "yes", new CheckNewHardStrategy()),
     CHECK_NEW_SOFT("check-new-soft", "accept-new", new CheckNewSoftStrategy()),
     ACCEPT_NEW("accept-new", "accept-new", new AcceptNewStrategy()),
-    OFF("off", "off", new NonVerifyingKeyVerificationStrategy());
+    OFF("off", "no", new NonVerifyingKeyVerificationStrategy());
     
     private final String displayText;
     private final SshHostKeyVerificationStrategy strategy;


### PR DESCRIPTION
See [JENKINS-62195](https://issues.jenkins-ci.org/browse/JENKINS-62195)

Versions of ssh client previous to OpenSSH_7.6 didn't have the new options used by the plugin:
* accept-new
* off

The option **_off_** seems to be synonym of the **_no_** option even on recent versions of the plugin. See help of OpenSSH_8.0p1 version:

```
     StrictHostKeyChecking
...
 If this flag is set to “no” or “off”, ssh will automatically add new host keys to the user known hosts files and allow connections to hosts with changed hostkeys to proceed, subject to some restrictions.
...
```

So we change to use this option instead of _off_.

It was expected (on 7.6 version) that the **_off_** option differs from the **_no_** one in the future, but this future doesn't yet come, so we will use the **_no_** option. Attending the documentation of the 7.6 version:

```
The second setting "off", is a synonym for the current behaviour of StrictHostKeyChecking=no: accept new host keys, and continue connection for hosts with incorrect hostkeys. A future release will change the meaning of  StrictHostKeyChecking=no to the behaviour of "accept-new"
```

That's why we didn't use the **_no_** option since the beginning.

Desired reviewers: @res0nance @fcojfernandez @jvz @varyvol @alecharp @rsandell @oleg-nenashev @MarkEWaite @daniel-beck