### PR TITLE
[JENKINS-62227] Replace slf4j by java logging in CloudHelper

### DIFF
--- a/src/main/java/hudson/plugins/ec2/CloudHelper.java
+++ b/src/main/java/hudson/plugins/ec2/CloudHelper.java
@@ -12,16 +12,15 @@ import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.Reservation;
 import java.util.ArrayList;
 import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckForNull;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.logging.Logger;
 
 final class CloudHelper {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CloudHelper.class);
+    private static final Logger LOGGER = Logger.getLogger(CloudHelper.class.getName());
 
     static Instance getInstanceWithRetry(String instanceId, EC2Cloud cloud) throws AmazonClientException, InterruptedException {
         // Sometimes even after a successful RunInstances, DescribeInstances


### PR DESCRIPTION
See [JENKINS-62227](https://issues.jenkins-ci.org/browse/JENKINS-62227)

Sometimes Jenkins fails to start, it gets hung with:

```
2020-05-09 12:19:27.321+0000 [id=46]    SEVERE  hudson.triggers.SafeTimerTask#run: Timer task hudson.slaves.ComputerRetentionWork@5988e277 failed
java.lang.NoClassDefFoundError: Could not initialize class hudson.plugins.ec2.CloudHelper
        at hudson.plugins.ec2.EC2Computer.getState(EC2Computer.java:139)
        at hudson.plugins.ec2.EC2RetentionStrategy.internalCheck(EC2RetentionStrategy.java:146)
        at hudson.plugins.ec2.EC2RetentionStrategy.check(EC2RetentionStrategy.java:107)
        at hudson.plugins.ec2.EC2RetentionStrategy.check(EC2RetentionStrategy.java:52)
        at hudson.slaves.ComputerRetentionWork$1.run(ComputerRetentionWork.java:70)
        at hudson.model.Queue._withLock(Queue.java:1398)
        at hudson.model.Queue.withLock(Queue.java:1275)
        at hudson.slaves.ComputerRetentionWork.doRun(ComputerRetentionWork.java:61)
        at hudson.triggers.SafeTimerTask.run(SafeTimerTask.java:91)
        at jenkins.security.ImpersonatingScheduledExecutorService$1.run(ImpersonatingScheduledExecutorService.java:58)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

The root cause is:
```
2020-05-09 12:19:26.516+0000 [id=38]    WARNING jenkins.model.Jenkins$5#runTask: Loading global config failed perhaps due to plugin dependency issues
java.lang.LinkageError: loader constraint violation: when resolving method "org.slf4j.impl.StaticLoggerBinder.getLoggerFactory()Lorg/slf4j/ILoggerFactory;" the class loader (instance of hudson/PluginFirstClassLoader) of the current class, org/slf4j/LoggerFactory, and the class loader (instance of org/eclipse/jetty/webapp/WebAppClassLoader) for the method's defining class, org/slf4j/impl/StaticLoggerBinder, have different Class objects for the type org/slf4j/ILoggerFactory used in the signature
        at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:418)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:357)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:383)
        at hudson.plugins.ec2.CloudHelper.<clinit>(CloudHelper.java:24)
```

@res0nance @fcojfernandez @thoulen @julienduchesne