### PR TITLE
[JENKINS-62231] Move start logic to postInitialize to avoid OldDataMo…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,15 @@
-buildPlugin(useAci: true, configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(useAci: true, configurations: configurations)
+
+def recentLTS = "2.222.3"
+def configurations = [
+        // Intentionally test configurations which have detected the most problems
+        // Linux - Java 8 with plugin specified minimum Jenkins version
+        // Windows - Java 8 with recent LTS
+        // Linux - Java 11 with recent LTS
+        [ platform: "linux", jdk: "8", jenkins: null ],
+        // [ platform: "windows", jdk: "8", jenkins: null ],
+        // [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
+        [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
+        [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
+        // [ platform: "windows", jdk: "11", jenkins: recentLTS, javaLevel: "8" ]
+    ]

--- a/src/main/java/hudson/plugins/ec2/PluginImpl.java
+++ b/src/main/java/hudson/plugins/ec2/PluginImpl.java
@@ -33,6 +33,8 @@ import jenkins.model.Jenkins;
 import java.io.IOException;
 import java.util.logging.Logger;
 
+import java.io.IOException;
+
 /**
  * Added to handle backwards compatibility of xstream class name mapping.
  */
@@ -85,7 +87,15 @@ public class PluginImpl extends Plugin implements Describable<PluginImpl> {
     }
 
     @Override
-    public void postInitialize() {
+    public void postInitialize() throws IOException {
+        // backward compatibility with the legacy class name
+        Jenkins.XSTREAM.alias("hudson.plugins.ec2.EC2Cloud", AmazonEC2Cloud.class);
+        Jenkins.XSTREAM.alias("hudson.plugins.ec2.EC2Slave", EC2OndemandSlave.class);
+        // backward compatibility with the legacy instance type
+        Jenkins.XSTREAM.registerConverter(new InstanceTypeConverter());
+
+        load();
+        
         MinimumInstanceChecker.checkForMinimumInstances();
     }
 }

--- a/src/main/java/hudson/plugins/ec2/PluginImpl.java
+++ b/src/main/java/hudson/plugins/ec2/PluginImpl.java
@@ -58,17 +58,6 @@ public class PluginImpl extends Plugin implements Describable<PluginImpl> {
     public long getDismissInsecureMessages() {
         return dismissInsecureMessages;
     }
-    
-    @Override
-    public void start() throws Exception {
-        // backward compatibility with the legacy class name
-        Jenkins.XSTREAM.alias("hudson.plugins.ec2.EC2Cloud", AmazonEC2Cloud.class);
-        Jenkins.XSTREAM.alias("hudson.plugins.ec2.EC2Slave", EC2OndemandSlave.class);
-        // backward compatibility with the legacy instance type
-        Jenkins.XSTREAM.registerConverter(new InstanceTypeConverter());
-
-        load();
-    }
 
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) Jenkins.get().getDescriptorOrDie(getClass());


### PR DESCRIPTION
See [JENKINS-62231](https://issues.jenkins-ci.org/browse/JENKINS-62231) for full story

To avoid the plugin to fail when loading its configuration if any modification has been done we move the logic from `start` to `postInitialize` method. It may help for future versions upgrade/downgrade ability.

@res0nance @fcojfernandez @alecharp @varyvol @rsandell ARggghhhh I cannot even request reviewers