### PR TITLE
Fixed altEC2Endpoint Persistence

### DIFF
--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -77,7 +77,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
         this.altEC2Endpoint = "";
     }
 
-    public AmazonEC2Cloud(String cloudName, boolean useInstanceProfileForCredentials, String credentialsId, String region, String, altEC2Endpoint, String privateKey, String instanceCapStr, List<? extends SlaveTemplate> templates, String roleArn, String roleSessionName) {
+    public AmazonEC2Cloud(String cloudName, boolean useInstanceProfileForCredentials, String credentialsId, String region, String altEC2Endpoint, String privateKey, String instanceCapStr, List<? extends SlaveTemplate> templates, String roleArn, String roleSessionName) {
         super(createCloudId(cloudName), useInstanceProfileForCredentials, credentialsId, privateKey, instanceCapStr, templates, roleArn, roleSessionName);
         this.region = region;
         this.altEC2Endpoint = altEC2Endpoint;

--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -64,6 +64,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
      * Represents the region. Can be null for backward compatibility reasons.
      */
     private String region;
+    private String altEC2Endpoint;
 
     public static final String CLOUD_ID_PREFIX = "ec2-";
 
@@ -73,6 +74,13 @@ public class AmazonEC2Cloud extends EC2Cloud {
     public AmazonEC2Cloud(String cloudName, boolean useInstanceProfileForCredentials, String credentialsId, String region, String privateKey, String instanceCapStr, List<? extends SlaveTemplate> templates, String roleArn, String roleSessionName) {
         super(createCloudId(cloudName), useInstanceProfileForCredentials, credentialsId, privateKey, instanceCapStr, templates, roleArn, roleSessionName);
         this.region = region;
+        this.altEC2Endpoint = "";
+    }
+
+    public AmazonEC2Cloud(String cloudName, boolean useInstanceProfileForCredentials, String credentialsId, String region, String, altEC2Endpoint, String privateKey, String instanceCapStr, List<? extends SlaveTemplate> templates, String roleArn, String roleSessionName) {
+        super(createCloudId(cloudName), useInstanceProfileForCredentials, credentialsId, privateKey, instanceCapStr, templates, roleArn, roleSessionName);
+        this.region = region;
+        this.altEC2Endpoint = altEC2Endpoint;
     }
 
     public String getCloudName() {
@@ -96,6 +104,17 @@ public class AmazonEC2Cloud extends EC2Cloud {
         if (region.indexOf('_') > 0)
             return region.replace('_', '-').toLowerCase(Locale.ENGLISH);
         return region;
+    }
+
+    @DataBoundSetter
+    public void setAltEC2Endpoint(String altEC2Endpoint) {
+
+        this.altEC2Endpoint = altEC2Endpoint;
+    }
+
+    public String getAltEC2Endpoint() {
+
+        return this.altEC2Endpoint;
     }
 
     public static URL getEc2EndpointUrl(String region) {


### PR DESCRIPTION
altEC2Endpoint was not being persisted in config.xml.  Consequently, if you are working in govcloud, and you make any changes to your config file, your region would be broken.   So, I added, altEC2Endpoint data member, constructor overload, and getter to the AmazonEC2Cloud class. (as well as a Setter for good measure).

Test Results:
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running InjectedTest
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.872 s - in InjectedTest
[INFO] Running hudson.plugins.ec2.AmazonEC2CloudTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 88.707 s - in hudson.plugins.ec2.AmazonEC2CloudTest
[INFO] Running hudson.plugins.ec2.AmazonEC2CloudUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.887 s - in hudson.plugins.ec2.AmazonEC2CloudUnitTest
[INFO] Running hudson.plugins.ec2.ConfigurationAsCodeTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.618 s - in hudson.plugins.ec2.ConfigurationAsCodeTest
[INFO] Running hudson.plugins.ec2.ConnectionStrategyTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in hudson.plugins.ec2.ConnectionStrategyTest
[INFO] Running hudson.plugins.ec2.EC2AbstractSlaveTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.293 s - in hudson.plugins.ec2.EC2AbstractSlaveTest
[INFO] Running hudson.plugins.ec2.EC2HostAddressProviderTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.121 s - in hudson.plugins.ec2.EC2HostAddressProviderTest
[INFO] Running hudson.plugins.ec2.EC2InstanceTypesTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in hudson.plugins.ec2.EC2InstanceTypesTest
[INFO] Running hudson.plugins.ec2.EC2OndemandSlaveTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.41 s - in hudson.plugins.ec2.EC2OndemandSlaveTest
[INFO] Running hudson.plugins.ec2.EC2PrivateKeyTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.775 s - in hudson.plugins.ec2.EC2PrivateKeyTest
[INFO] Running hudson.plugins.ec2.EC2RetentionStrategyTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 183.743 s - in hudson.plugins.ec2.EC2RetentionStrategyTest
[INFO] Running hudson.plugins.ec2.EC2SlaveMonitorTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 85.627 s - in hudson.plugins.ec2.EC2SlaveMonitorTest
[INFO] Running hudson.plugins.ec2.EC2StepTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 45.49 s - in hudson.plugins.ec2.EC2StepTest
[INFO] Running hudson.plugins.ec2.SlaveTemplateTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 351.712 s - in hudson.plugins.ec2.SlaveTemplateTest
[INFO] Running hudson.plugins.ec2.SlaveTemplateUnitTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.03 s - in hudson.plugins.ec2.SlaveTemplateUnitTest
[INFO] Running hudson.plugins.ec2.TemplateLabelsTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.76 s - in hudson.plugins.ec2.TemplateLabelsTest
[INFO] Running hudson.plugins.ec2.WinRMMessageTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in hudson.plugins.ec2.WinRMMessageTest
[INFO] Running hudson.plugins.ec2.ssh.HostKeyVerifierImplTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in hudson.plugins.ec2.ssh.HostKeyVerifierImplTest
[INFO] Running hudson.plugins.ec2.ssh.verifiers.SshHostKeyVerificationStrategyTest
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 11.99 s - in hudson.plugins.ec2.ssh.verifiers.SshHostKeyVerificationStrategyTest
[INFO] Running hudson.plugins.ec2.win.WinConnectionTest
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.01 s - in hudson.plugins.ec2.win.WinConnectionTest
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 120, Failures: 0, Errors: 0, Skipped: 2
[INFO]
[INFO]
[INFO] --- animal-sniffer-maven-plugin:1.18:check (check) @ ec2 ---
[INFO] Resolved signature org.codehaus.mojo.signature:java18 version as 1.0 from dependencyManagement
[INFO] Checking unresolved references to org.codehaus.mojo.signature:java18:1.0
[INFO]
[INFO] --- maven-license-plugin:1.8:process (default) @ ec2 ---
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass$3$1 (file:/root/.m2/repository/org/codehaus/groovy/groovy/1.6.5/groovy-1.6.5.jar) to method java.lang.Object.finalize()
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass$3$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[INFO] Generated /home/<user_redacted>/ec2plugin/ec2-plugin/target/ec2/WEB-INF/licenses.xml
[INFO]
[INFO] --- maven-hpi-plugin:3.13:hpi (default-hpi) @ ec2 ---
[INFO] Generating /home/<user_redacted>/ec2plugin/ec2-plugin/target/ec2/META-INF/MANIFEST.MF
May 18, 2020 3:15:27 PM org.jenkinsci.maven.plugins.hpi.AbstractJenkinsManifestMojo setAttributes
INFO: Minimum Java version for the plugin: 8
[INFO] Checking for attached .jar artifact ...
[INFO] Generating jar /home/<user_redacted>/ec2plugin/ec2-plugin/target/ec2.jar
[INFO] Building jar: /home/<user_redacted>/ec2plugin/ec2-plugin/target/ec2.jar
[INFO] Exploding webapp...
[INFO] Copy webapp webResources to /home/<user_redacted>/ec2plugin/ec2-plugin/target/ec2
[INFO] Assembling webapp ec2 in /home/<user_redacted>/ec2plugin/ec2-plugin/target/ec2
[WARNING] Bundling transitive dependency asn-one-0.4.0.jar (via smbj)
[INFO] Bundling direct dependency smbj-0.10.0.jar
[INFO] Bundling direct dependency multiline-secrets-ui-1.0.jar
[WARNING] Bundling transitive dependency mbassador-1.3.0.jar (via smbj)
[WARNING] Bundling transitive dependency slf4j-api-1.7.25.jar (via smbj)
[INFO] Generating hpi /home/<user_redacted>/ec2plugin/ec2-plugin/target/ec2.hpi
[INFO] Building jar: /home/<user_redacted>/ec2plugin/ec2-plugin/target/ec2.hpi
[INFO]
[INFO] --- maven-jar-plugin:3.2.0:test-jar (maybe-test-jar) @ ec2 ---
[INFO] Skipping packaging of the test-jar
[INFO]
[INFO] >>> spotbugs-maven-plugin:4.0.0:check (spotbugs) > :spotbugs @ ec2 >>>
[INFO]
[INFO] --- spotbugs-maven-plugin:4.0.0:spotbugs (spotbugs) @ ec2 ---
[INFO] Fork Value is true
[INFO] Done SpotBugs Analysis....
[INFO]
[INFO] <<< spotbugs-maven-plugin:4.0.0:check (spotbugs) < :spotbugs @ ec2 <<<
[INFO]
[INFO]
[INFO] --- spotbugs-maven-plugin:4.0.0:check (spotbugs) @ ec2 ---
[INFO] BugInstance size is 0
[INFO] Error size is 0
[INFO] No errors/warnings found
[INFO]
[INFO] --- maven-install-plugin:3.0.0-M1:install (default-install) @ ec2 ---
[INFO] Installing /home/<user_redacted>/ec2plugin/ec2-plugin/target/ec2.hpi to /root/.m2/repository/org/jenkins-ci/plugins/ec2/1.51-SNAPSHOT/ec2-1.51-SNAPSHOT.hpi
[INFO] Installing /home/<user_redacted>/ec2plugin/ec2-plugin/target/ec2-1.51-SNAPSHOT.pom to /root/.m2/repository/org/jenkins-ci/plugins/ec2/1.51-SNAPSHOT/ec2-1.51-SNAPSHOT.pom
[INFO] Installing /home/<user_redacted>/ec2plugin/ec2-plugin/target/ec2.jar to /root/.m2/repository/org/jenkins-ci/plugins/ec2/1.51-SNAPSHOT/ec2-1.51-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  16:01 min
[INFO] Finished at: 2020-05-18T15:15:56-07:00
[INFO] ------------------------------------------------------------------------