### PR TITLE
get root device fix

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -961,7 +961,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 LOGGER.warning("AMI missing block devices");
                 return;
             }
-            BlockDeviceMapping rootMapping = rootDeviceMappings.get(0);
+            BlockDeviceMapping rootMapping = getRootDeviceMapping(rootDeviceMappings);
+            if (rootMapping==null) {
+                LOGGER.warning("AMI missing root device");
+                return;
+            }
             LOGGER.info("AMI had " + rootMapping.getDeviceName());
             LOGGER.info(rootMapping.getEbs().toString());
 
@@ -982,6 +986,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             newMapping.getEbs().setEncrypted(null);
             deviceMappings.add(0, newMapping);
         }
+    }
+
+    private BlockDeviceMapping getRootDeviceMapping(List<BlockDeviceMapping> deviceMappings) {
+        return deviceMappings.stream().filter(mapping -> mapping.getDeviceName().equals(getImage().getRootDeviceName()))
+                .findFirst()
+                .orElse(null);
     }
 
     private List<BlockDeviceMapping> getNewEphemeralDeviceMapping() {


### PR DESCRIPTION
Ran into a situation where rootMapping wasn't the first item in the list causing some errors.

This PR attempts to fix:
- Getting the root device mapping through the actual root device name.