### PR TITLE
reduce number of getPasswordData calls

### DIFF
--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import hudson.slaves.OfflineCause;
@@ -37,7 +38,19 @@ import javax.net.ssl.SSLException;
 public class EC2WindowsLauncher extends EC2ComputerLauncher {
     private static final String AGENT_JAR = "remoting.jar";
 
-    final long sleepBetweenAttempts = TimeUnit.SECONDS.toMillis(10);
+    private static final String DEFAULT_MAX_SLEEP = Long.toString(TimeUnit.MINUTES.toMillis(30));
+
+    private static long maxGetPassThreadSleep = Long.parseLong(System.getProperty(EC2WindowsLauncher.class.getName() + ".maxGetPassThreadSleep", DEFAULT_MAX_SLEEP));
+
+    private static long maxWinRMThreadSleep = Long.parseLong(System.getProperty(EC2WindowsLauncher.class.getName() + ".maxWinRMThreadSleep", DEFAULT_MAX_SLEEP));
+
+    private long sleepBetweenGetPassRange = TimeUnit.SECONDS.toMillis(1);
+
+    private long sleepBetweenGetPassAttempts = TimeUnit.SECONDS.toMillis(1);
+
+    private long sleepBetweenWinRMRange = TimeUnit.SECONDS.toMillis(1);
+
+    private long sleepBetweenWinRMAttempts = TimeUnit.SECONDS.toMillis(1);
 
     @Override
     protected void launchScript(EC2Computer computer, TaskListener listener) throws IOException,
@@ -54,7 +67,7 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
         }
 
         final WinConnection connection = connectToWinRM(computer, node, template, logger);
-        
+
         try {
             String initScript = node.initScript;
             String tmpDir = (node.tmpDir != null && !node.tmpDir.equals("") ? WindowsUtil.quoteArgument(Util.ensureEndsWith(node.tmpDir,"\\"))
@@ -131,6 +144,7 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
         if (timeout < minTimeout) {
             timeout = minTimeout;
         }
+        logger.println(String.format("Launch Timeout set to %ds", TimeUnit.MILLISECONDS.toSeconds(timeout)));
         final long startTime = System.currentTimeMillis();
 
         logger.println(node.getDisplayName() + " booted at " + node.getCreatedTime());
@@ -158,35 +172,46 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
 
                     if (!node.isSpecifyPassword()) {
                         GetPasswordDataResult result;
+                        logger.print(String.format("GetPass sleep range: %ds. ", TimeUnit.MILLISECONDS.toSeconds(sleepBetweenGetPassRange)));
+                        logger.print(String.format("GetPass max sleep: %ds. ", TimeUnit.MILLISECONDS.toSeconds(maxGetPassThreadSleep)));
                         try {
                             result = node.getCloud().connect().getPasswordData(new GetPasswordDataRequest(instance.getInstanceId()));
                         } catch (Exception e) {
-                            logger.println("Unexpected Exception: " + e.toString());
-                            Thread.sleep(sleepBetweenAttempts);
+                            logger.println(String.format("Unexpected Exception: %s. Sleeping %ds.", e.toString(), TimeUnit.MILLISECONDS.toSeconds(sleepBetweenGetPassAttempts)));
+                            Thread.sleep(sleepBetweenGetPassAttempts);
+                            getPassBackoff();
                             continue;
                         }
                         String passwordData = result.getPasswordData();
                         if (passwordData == null || passwordData.isEmpty()) {
-                            logger.println("Waiting for password to be available. Sleeping 10s.");
-                            Thread.sleep(sleepBetweenAttempts);
+                            logger.println(String.format("Waiting for password to be available. Sleeping %ds.", TimeUnit.MILLISECONDS.toSeconds(sleepBetweenGetPassAttempts)));
+                            Thread.sleep(sleepBetweenGetPassAttempts);
+                            getPassBackoff();
                             continue;
                         }
                         String password = node.getCloud().getPrivateKey().decryptWindowsPassword(passwordData);
-                        if (!node.getRemoteAdmin().equals("Administrator")) {
-                            logger.println("WARNING: For password retrieval remote admin must be Administrator, ignoring user provided value");
+                        String username = System.getProperty(EC2WindowsLauncher.class.getName() + ".amiTemplateUsername", "david_webb6");
+
+                        if (!node.getRemoteAdmin().equals(username)) {
+                            logger.println("WARNING: For password retrieval remote admin must be " + username + ", ignoring user provided value");
                         }
-                        logger.println("Connecting to " + "(" + host + ") with WinRM as Administrator");
-                        connection = new WinConnection(host, "Administrator", password, allowSelfSignedCertificate);
+                        logger.println("Connecting to " + "(" + host + ") with WinRM as " + username);
+                        connection = new WinConnection(host, username, password, allowSelfSignedCertificate);
+
                     } else { //password Specified
                         logger.println("Connecting to " + "(" + host + ") with WinRM as " + node.getRemoteAdmin());
                         connection = new WinConnection(host, node.getRemoteAdmin(), node.getAdminPassword().getPlainText(), allowSelfSignedCertificate);
                     }
+                    resetGetPassBackoff();
                     connection.setUseHTTPS(node.isUseHTTPS());
                 }
-
+                logger.print(String.format("WinRM sleep range: %ds. ", TimeUnit.MILLISECONDS.toSeconds(sleepBetweenWinRMRange)));
+                logger.print(String.format("WinRM max sleep: %ds. ", TimeUnit.MILLISECONDS.toSeconds(maxWinRMThreadSleep)));
                 if (!connection.pingFailingIfSSHHandShakeError()) {
-                    logger.println("Waiting for WinRM to come up. Sleeping 10s.");
-                    Thread.sleep(sleepBetweenAttempts);
+                    logger.println(String.format("Waiting for WinRM to come up. Sleeping %ds.", TimeUnit.MILLISECONDS.toSeconds(sleepBetweenWinRMAttempts)));
+                    Thread.sleep(sleepBetweenWinRMAttempts);
+                    winRMBackoff();
+
                     continue;
                 }
 
@@ -197,13 +222,15 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
                     alreadyBooted = true;
                     logger.println("WinRM should now be ok on " + node.getDisplayName());
                     if (!connection.pingFailingIfSSHHandShakeError()) {
-                        logger.println("WinRM not yet up. Sleeping 10s.");
-                        Thread.sleep(sleepBetweenAttempts);
+                        logger.println(String.format("WinRM not yet up. Sleeping %ds.", TimeUnit.MILLISECONDS.toSeconds(sleepBetweenWinRMAttempts)));
+                        Thread.sleep(sleepBetweenWinRMAttempts);
+                        winRMBackoff();
                         continue;
                     }
                 }
 
                 logger.println("Connected with WinRM.");
+                resetWinRMBackoff();
                 return connection; // successfully connected
             } catch (IOException e) {
                 if (e instanceof SSLException) {
@@ -212,8 +239,9 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
                     // avoid waiting and trying again, this connection needs human intervention to change the certificate
                     throw new AmazonClientException("The SSL connection failed while negotiating SSL", e);
                 }
-                logger.println("Waiting for WinRM to come up. Sleeping 10s.");
-                Thread.sleep(sleepBetweenAttempts);
+                logger.println(String.format("Waiting for WinRM to come up. Sleeping %ds.", TimeUnit.MILLISECONDS.toSeconds(sleepBetweenWinRMAttempts)));
+                Thread.sleep(sleepBetweenWinRMAttempts);
+                winRMBackoff();
             }
         }
     }
@@ -222,4 +250,29 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
     public Descriptor<ComputerLauncher> getDescriptor() {
         throw new UnsupportedOperationException();
     }
+
+    private void getPassBackoff() {
+        long previousSleepBetweenGetPassRange = sleepBetweenGetPassRange;
+        sleepBetweenGetPassRange = sleepBetweenGetPassRange * 2;
+        sleepBetweenGetPassAttempts = ThreadLocalRandom.current().nextLong(previousSleepBetweenGetPassRange + 1,
+                Math.min(maxGetPassThreadSleep, sleepBetweenGetPassRange));
+    }
+
+    private void winRMBackoff() {
+        long previousSleepBetweenWinRMRange = sleepBetweenWinRMRange;
+        sleepBetweenWinRMRange = sleepBetweenWinRMRange * 2;
+        sleepBetweenWinRMAttempts = ThreadLocalRandom.current().nextLong(previousSleepBetweenWinRMRange + 1,
+                Math.min(maxWinRMThreadSleep, sleepBetweenWinRMRange));
+    }
+
+    private void resetGetPassBackoff() {
+        sleepBetweenGetPassRange = TimeUnit.SECONDS.toMillis(1);
+        sleepBetweenGetPassAttempts = TimeUnit.SECONDS.toMillis(1);
+    }
+
+    private void resetWinRMBackoff() {
+        sleepBetweenWinRMRange = TimeUnit.SECONDS.toMillis(1);
+        sleepBetweenWinRMAttempts = TimeUnit.SECONDS.toMillis(1);
+    }
+
 }


### PR DESCRIPTION
If the AMI was not setup to generate passwords, AWS does not generate passwords. In such cases, ec2 plugin keeps making EC2 api attempting to get the password. This exhausts the allowed EC2 api calls from aws side and AWS starts throttling the api calls, especially if multiple nodes are spun up at the same time.

This PR attempts to address this issue by reducing the frequency of GetPasswordData calls using exponential back off with full jitter.

Here is an example of the log messages printed out:
![image](https://user-images.githubusercontent.com/9890146/82705908-63337700-9c2d-11ea-8a82-3e1017e7b77d.png)
