### PR TITLE
[JENKINS-62221] Bug fix parsing the line with the host key in the console

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/verifiers/SshHostKeyVerificationStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/verifiers/SshHostKeyVerificationStrategy.java
@@ -137,7 +137,7 @@ public abstract class SshHostKeyVerificationStrategy implements Describable<SshH
     @CheckForNull
     HostKey getKeyFromLine(@NonNull final Logger logger, @NonNull final String line, @Nullable final TaskListener listener) {
         String[] parts = line.split(" ");
-        if (parts.length > 2) {
+        if (parts.length >= 2) {
             // The public SSH key in the console is Base64 encoded
             return new HostKey(parts[0], Base64.getDecoder().decode(parts[1]));
         } else {


### PR DESCRIPTION
Fix an issue retrieving the host key from the instance console.

See [JENKINS-62221](https://issues.jenkins-ci.org/browse/JENKINS-62221)