### PR TITLE
Exclude SLF4J from smbj since it causes class loading errors.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,10 @@ THE SOFTWARE.
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
When I upgraded to 1.50.3 (from an ancient version which was no longer compatible with modern Jenkins), connections to Windows nodes started failing with no errors in any logs, which I traced to a NoClassDefFoundError caused by loading SLF4J classes from both the plugin and Jenkins itself. The lack of logging remains, but excluding SLF4J from the SMBJ dependency fixes the problem for me. I have no idea if this is the right solution, though.

This may be what's causing https://issues.jenkins-ci.org/browse/JENKINS-62641.