### PR TITLE
Sts consideration

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java
@@ -14,6 +14,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static java.util.logging.Level.INFO;
+
 /**
  * @author Bruno Meneguello
  */
@@ -66,8 +68,14 @@ public class EC2SlaveMonitor extends AsyncPeriodicWork {
     private boolean isCheckable(Node node) {
         boolean result = false;
         Computer computer = node.toComputer();
-        if (computer == null || computer.isIdle()) {
+        if (computer == null) {
             result = true;
+            LOGGER.log(INFO, "Unable to determine executor status for node {0}", node.getNodeName());
+        } else if (computer.isIdle()) {
+            result = true;
+            LOGGER.log(INFO, "All executors for node {0} are idle", node.getNodeName());
+        } else {
+            LOGGER.log(INFO, "Node {0} is currently busy", node.getNodeName());
         }
         return result;
     }


### PR DESCRIPTION
[JENKINS-63537](https://issues.jenkins-ci.org/browse/JENKINS-63537) - EC2SlaveMonitor terminates agent with a running job when STS session expires
* Adding a isCheckable(Node) method to determine if connectivity should be checked to the node. A node with a running job will not get checked. If the computer associated with the node can not be established or if the node is idle, then normal processing is performed.