### PR TITLE
Bugfix: Removed @RequirePost and changed ssh key migration behavior

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -171,12 +171,6 @@ public abstract class EC2Cloud extends Cloud {
         this.credentialsId = credentialsId;
         this.sshKeysCredentialsId = sshKeysCredentialsId;
 
-        if (this.sshKeysCredentialsId == null && ( this.privateKey != null || privateKey != null)){
-            migratePrivateSshKeyToCredential(this.privateKey != null ? this.privateKey.getPrivateKey() : privateKey);
-        }
-        this.privateKey = null; // This enforces it not to be persisted and that CasC will never output privateKey on export
-
-
         if (templates == null) {
             this.templates = Collections.emptyList();
         } else {
@@ -249,6 +243,11 @@ public abstract class EC2Cloud extends Cloud {
 
         for (SlaveTemplate t : templates)
             t.parent = this;
+
+        if (this.sshKeysCredentialsId == null && this.privateKey != null ){
+            migratePrivateSshKeyToCredential(this.privateKey.getPrivateKey());
+        }
+        this.privateKey = null; // This enforces it not to be persisted and that CasC will never output privateKey on export
 
         if (this.accessId != null && this.secretKey != null && credentialsId == null) {
             String secretKeyEncryptedValue = this.secretKey.getEncryptedValue();
@@ -1066,7 +1065,6 @@ public abstract class EC2Cloud extends Cloud {
                     .includeCurrentValue(sshKeysCredentialsId);
         }
 
-        @RequirePOST
         public FormValidation doCheckSshKeysCredentialsId(@QueryParameter String value) throws IOException, ServletException {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -1065,6 +1065,7 @@ public abstract class EC2Cloud extends Cloud {
                     .includeCurrentValue(sshKeysCredentialsId);
         }
 
+        @RequirePOST
         public FormValidation doCheckSshKeysCredentialsId(@QueryParameter String value) throws IOException, ServletException {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 

--- a/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
     <f:select/>
   </f:entry>
   <f:entry field="sshKeysCredentialsId" title="${%EC2 Key Pair's Private Key}">
-    <c:select includeUser="false"/>
+    <c:select includeUser="false" checkMethod="post"/>
   </f:entry>
   <f:advanced>
     <f:entry title="${%Instance Cap}" field="instanceCapStr">

--- a/src/main/resources/hudson/plugins/ec2/Eucalyptus/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/Eucalyptus/config-entries.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
     <f:checkbox />
   </f:entry>
   <f:entry field="sshKeysCredentialsId" title="${%EC2 Key Pair's Private Key}">
-    <c:select includeUser="false"/>
+    <c:select includeUser="false" checkMethod="post"/>
   </f:entry>
   <f:advanced>
     <f:entry title="${%Instance Cap}" field="instanceCapStr">

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -7,6 +7,7 @@ import hudson.plugins.ec2.util.AmazonEC2FactoryMockImpl;
 import hudson.plugins.ec2.util.MinimumInstanceChecker;
 import hudson.plugins.ec2.util.MinimumNumberOfInstancesTimeRangeConfig;
 import hudson.plugins.ec2.util.PrivateKeyHelper;
+import hudson.plugins.ec2.util.SSHCredentialHelper;
 import hudson.slaves.NodeProperty;
 import hudson.model.Executor;
 import hudson.model.Node;
@@ -15,7 +16,9 @@ import net.sf.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.testcontainers.shaded.org.bouncycastle.jce.provider.BouncyCastleProvider;
 
+import java.security.Security;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -210,7 +213,8 @@ public class EC2RetentionStrategyTest {
           InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null,
           "-Xmx1g", false, "subnet 456", null, null, 2, 0, "10", null, true, true, false, "", false, "", false, false,
           true, ConnectionStrategy.PRIVATE_IP, 0, Collections.emptyList());
-        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3",
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", null, "ghi", "3",
           Collections
             .singletonList(template), "roleArn", "roleSessionName");
         r.jenkins.clouds.add(cloud);
@@ -288,8 +292,8 @@ public class EC2RetentionStrategyTest {
 
         //Set fixed clock to be able to test properly
         MinimumInstanceChecker.clock = Clock.fixed(localDateTime.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
-
-        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3",
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", null, "ghi", "3",
             Collections
                 .singletonList(template), "roleArn", "roleSessionName");
         r.jenkins.clouds.add(cloud);
@@ -385,8 +389,8 @@ public class EC2RetentionStrategyTest {
 
         //Set fixed clock to be able to test properly
         MinimumInstanceChecker.clock = Clock.fixed(localDateTime.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
-
-        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3",
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", null, "ghi", "3",
             Collections
                 .singletonList(template), "roleArn", "roleSessionName");
         r.jenkins.clouds.add(cloud);
@@ -440,7 +444,8 @@ public class EC2RetentionStrategyTest {
         LocalDateTime localDateTime = LocalDateTime.of(2019, Month.SEPTEMBER, 24, 14, 0); //Tuesday
         MinimumInstanceChecker.clock = Clock.fixed(localDateTime.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
 
-        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3",
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", null, "ghi", "3",
             Collections
                 .singletonList(template), "roleArn", "roleSessionName");
         r.jenkins.clouds.add(cloud);

--- a/src/test/java/hudson/plugins/ec2/EC2SlaveMonitorTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2SlaveMonitorTest.java
@@ -13,7 +13,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import com.amazonaws.services.ec2.model.InstanceType;
 
 import hudson.model.Node;
-import hudson.plugins.ec2.util.PrivateKeyHelper;
+import hudson.plugins.ec2.util.SSHCredentialHelper;
 import jenkins.model.Jenkins;
 
 public class EC2SlaveMonitorTest {
@@ -30,7 +30,8 @@ public class EC2SlaveMonitorTest {
     @Test
     public void testMinimumNumberOfInstances() throws Exception {
         SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 2, null, null, true, true, false, "", false, "", false, false, true, ConnectionStrategy.PRIVATE_IP, 0);
-        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3", Collections.singletonList(template), "roleArn", "roleSessionName");
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", null, "ghi", "3", Collections.singletonList(template), "roleArn", "roleSessionName");
         r.jenkins.clouds.add(cloud);
         r.configRoundtrip();
 
@@ -49,7 +50,8 @@ public class EC2SlaveMonitorTest {
                                                    "", false, false,
                                                    true, ConnectionStrategy.PRIVATE_IP, 0,
                                                    null);
-        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", PrivateKeyHelper.generate(), "3", Collections.singletonList(template), "roleArn", "roleSessionName");
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", null, "ghi", "3", Collections.singletonList(template), "roleArn", "roleSessionName");
         r.jenkins.clouds.add(cloud);
         r.configRoundtrip();
         Assert.assertEquals(2, Arrays.stream(Jenkins.get().getComputers()).filter(computer -> computer instanceof EC2Computer).count());

--- a/src/test/java/hudson/plugins/ec2/util/SSHCredentialHelper.java
+++ b/src/test/java/hudson/plugins/ec2/util/SSHCredentialHelper.java
@@ -1,0 +1,48 @@
+package hudson.plugins.ec2.util;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.model.Jenkins;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+
+public class SSHCredentialHelper {
+
+    public static void assureSshCredentialAvailableThroughCredentialProviders(String id){
+        BasicSSHUserPrivateKey sshKeyCredentials = new BasicSSHUserPrivateKey(CredentialsScope.SYSTEM, id, "key",
+                new BasicSSHUserPrivateKey.PrivateKeySource() {
+                    @NonNull
+                    @Override
+                    public List<String> getPrivateKeys() {
+                        return Collections.singletonList(PrivateKeyHelper.generate());
+                    }
+                }, "", "EC2 Testing Cloud Private Key");
+
+        addNewGlobalCredential(sshKeyCredentials);
+    }
+
+    private static void addNewGlobalCredential(Credentials credentials){
+        for (CredentialsStore credentialsStore: CredentialsProvider.lookupStores(Jenkins.get())) {
+
+            if (credentialsStore instanceof  SystemCredentialsProvider.StoreImpl) {
+
+                try {
+                    credentialsStore.addCredentials(Domain.global(), credentials);
+                } catch (IOException e) {
+                    throw new IllegalStateException("Failed to add testing credential");
+                }
+            }
+
+        }
+    }
+
+}


### PR DESCRIPTION
I changed the behavior from my feature added in #445 as suggested by @daniel-beck by moving the migration code to EC2Cloud.readResolve(). I also tested again the migration from 1.51 to 1.52. I could confirm that it wasn't working before and that it works now for me with that change.
Not sure why the @RequirePost lead to issues as it was requested as an addition but maybe someone can clarify if there is a better way than just removing it for now.

Thanks to @varyvol for the bugnotice and @daniel-beck for the hint how to fix it quickly.
