### PR TITLE
inclusive language tags: jenkins_slave_type renamed to jenkins_node_type

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Tag.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Tag.java
@@ -42,7 +42,7 @@ public class EC2Tag extends AbstractDescribableImpl<EC2Tag> {
     /**
      * Tag name for the specific jenkins slave type tag, used to identify the EC2 instances provisioned by this plugin.
      */
-    public static final String TAG_NAME_JENKINS_SLAVE_TYPE = "jenkins_slave_type";
+    public static final String TAG_NAME_JENKINS_SLAVE_TYPE = "jenkins_node_type";
     public static final String TAG_NAME_JENKINS_SERVER_URL = "jenkins_server_url";
 
     @DataBoundConstructor

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudUnitTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudUnitTest.java
@@ -104,7 +104,7 @@ public class AmazonEC2CloudUnitTest {
 
         List<Instance> instances = new ArrayList<Instance>();
         for(int i=0; i<=numberOfSpotInstanceRequests; i++) {
-            instances.add(new Instance().withInstanceId("id"+i).withTags(new Tag().withKey("jenkins_slave_type").withValue("spot")));
+            instances.add(new Instance().withInstanceId("id"+i).withTags(new Tag().withKey("jenkins_node_type").withValue("spot")));
         }
         
         AmazonEC2FactoryMockImpl.instances = instances;


### PR DESCRIPTION
I know there are many other master/slave references. This one will only correct the issue with jenkins ec2 worker tags.

This is also consistent with Jenkins using the word `node` for their workers.

Ref: https://tools.ietf.org/id/draft-knodel-terminology-02.html