### PR TITLE
Add re-submission of tasks during spot interruption disconnects

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -50,7 +50,7 @@ public class EC2SpotSlave extends EC2AbstractSlave implements EC2Readiness {
     @Deprecated
     public EC2SpotSlave(String name, String spotInstanceRequestId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
             throws FormException, IOException {
-        this(name, spotInstanceRequestId, templateDescription, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, nodeProperties, remoteAdmin, jvmopts, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses)
+        this(name, spotInstanceRequestId, templateDescription, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, nodeProperties, remoteAdmin, jvmopts, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, false);
     }
 
     @DataBoundConstructor

--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -47,6 +47,12 @@ public class EC2SpotSlave extends EC2AbstractSlave implements EC2Readiness {
         this(templateDescription + " (" + name + ")", spotInstanceRequestId, templateDescription, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, Collections.emptyList(), remoteAdmin, jvmopts, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, ConnectionStrategy.backwardsCompatible(usePrivateDnsName, false, false), -1, false);
     }
 
+    @Deprecated
+    public EC2SpotSlave(String name, String spotInstanceRequestId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
+            throws FormException, IOException {
+        this(name, spotInstanceRequestId, templateDescription, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, nodeProperties, remoteAdmin, jvmopts, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses)
+    }
+
     @DataBoundConstructor
     public EC2SpotSlave(String name, String spotInstanceRequestId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, boolean restartSpotInterruption)
             throws FormException, IOException {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -1276,6 +1276,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             .withAmiType(amiType)
             .withConnectionStrategy(connectionStrategy)
             .withMaxTotalUses(maxTotalUses)
+            .withRestartSpotInterruption(spotConfig.getRestartSpotInterruption())
             .build();
         return EC2AgentFactory.getInstance().createSpotAgent(config);
     }

--- a/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
+++ b/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -31,6 +32,7 @@ public final class SpotConfiguration extends AbstractDescribableImpl<SpotConfigu
     private String spotMaxBidPrice;
     private boolean fallbackToOndemand;
     private int spotBlockReservationDuration;
+    private boolean restartSpotInterruption;
 
     @Deprecated
     public SpotConfiguration(boolean useBidPrice, String spotMaxBidPrice, boolean fallbackToOndemand, String spotBlockReservationDurationStr) {
@@ -122,8 +124,18 @@ public final class SpotConfiguration extends AbstractDescribableImpl<SpotConfigu
 
     }
 
+    public boolean getRestartSpotInterruption() {
+        return restartSpotInterruption;
+    }
+
+    @DataBoundSetter
+    public void setRestartSpotInterruption(boolean restartSpotInterruption) {
+        this.restartSpotInterruption = restartSpotInterruption;
+    }
+
     @Extension
     public static class DescriptorImpl extends Descriptor<SpotConfiguration> {
+        @Nonnull
         @Override
         public String getDisplayName() {
             return "spotConfig";

--- a/src/main/java/hudson/plugins/ec2/util/EC2AgentConfig.java
+++ b/src/main/java/hudson/plugins/ec2/util/EC2AgentConfig.java
@@ -71,10 +71,12 @@ public abstract class EC2AgentConfig {
     public static class Spot extends EC2AgentConfig {
 
         final String spotInstanceRequestId;
+        boolean restartSpotInterruption;
 
         private Spot(SpotBuilder builder) {
             super(builder);
             this.spotInstanceRequestId = builder.spotInstanceRequestId;
+            this.restartSpotInterruption = builder.restartSpotInterruption;
         }
     }
 
@@ -265,9 +267,15 @@ public abstract class EC2AgentConfig {
     public static class SpotBuilder extends Builder<SpotBuilder, Spot> {
 
         private String spotInstanceRequestId;
+        private boolean restartSpotInterruption;
 
         public SpotBuilder withSpotInstanceRequestId(String spotInstanceRequestId) {
             this.spotInstanceRequestId = spotInstanceRequestId;
+            return this;
+        }
+
+        public SpotBuilder withRestartSpotInterruption(boolean restartSpotInterruption) {
+            this.restartSpotInterruption = restartSpotInterruption;
             return this;
         }
 

--- a/src/main/java/hudson/plugins/ec2/util/EC2AgentFactoryImpl.java
+++ b/src/main/java/hudson/plugins/ec2/util/EC2AgentFactoryImpl.java
@@ -17,6 +17,6 @@ public class EC2AgentFactoryImpl implements EC2AgentFactory {
 
     @Override
     public EC2SpotSlave createSpotAgent(EC2AgentConfig.Spot config) throws Descriptor.FormException, IOException {
-        return new EC2SpotSlave(config.name, config.spotInstanceRequestId, config.description, config.remoteFS, config.numExecutors, config.mode, config.initScript, config.tmpDir, config.labelString, config.nodeProperties, config.remoteAdmin, config.jvmopts, config.idleTerminationMinutes, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses);
+        return new EC2SpotSlave(config.name, config.spotInstanceRequestId, config.description, config.remoteFS, config.numExecutors, config.mode, config.initScript, config.tmpDir, config.labelString, config.nodeProperties, config.remoteAdmin, config.jvmopts, config.idleTerminationMinutes, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses, config.restartSpotInterruption);
     }
 }

--- a/src/main/resources/hudson/plugins/ec2/SpotConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SpotConfiguration/config.jelly
@@ -35,4 +35,8 @@ THE SOFTWARE.
   <f:entry title="${%Spot Block Reservation Duration}" field="spotBlockReservationDuration">
     <f:number />
   </f:entry>
+
+  <f:entry title="Restart tasks if spot interruted" field="restartSpotInterruption">
+    <f:checkbox />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/ec2/SpotConfiguration/help-restartSpotInterruption.html
+++ b/src/main/resources/hudson/plugins/ec2/SpotConfiguration/help-restartSpotInterruption.html
@@ -1,0 +1,4 @@
+<div>
+    If set to true, the tasks that a node was running will be restarted if a spot interruption event has happened.
+    Find out more information on Spot Interruption <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html">here</a>
+</div>

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -311,35 +311,9 @@ public class SlaveTemplateTest {
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
-        // TODO - find out how to mock the spot interruption event
-        // https://help.spot.io/spotinst-api/elastigroup/amazon-web-services/simulate-instance-interruption/
+
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(slaveTemplate, received, "ami,zone,spotConfig,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,connectionStrategy,hostKeyVerificationStrategy");
-    }
-
-    @Test
-    public void ensureTaskRestartedSpotInterruption() throws Exception {
-
-        String ami = "ami1";
-        String description = "foo ami";
-
-        EC2Tag tag1 = new EC2Tag("name1", "value1");
-        EC2Tag tag2 = new EC2Tag("name2", "value2");
-        List<EC2Tag> tags = new ArrayList<EC2Tag>();
-        tags.add(tag1);
-        tags.add(tag2);
-
-        SpotConfiguration spotConfig = new SpotConfiguration(true);
-        spotConfig.setSpotMaxBidPrice("0.1");
-        spotConfig.setFallbackToOndemand(true);
-        spotConfig.setSpotBlockReservationDuration(0);
-        spotConfig.setRestartSpotInterruption(true);
-
-        SlaveTemplate slaveTemplate = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, true, null, "", false, false, "", false, "");
-        AmazonEC2 mockedEC2 = setupTestForProvisioning(slaveTemplate);
-        // TODO - mock a disconnection
-        RequestSpotInstancesRequest request = mock(RequestSpotInstancesRequest.class);
-        mockedEC2.requestSpotInstances(request);
     }
 
     /**

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -39,6 +39,7 @@ import com.amazonaws.services.ec2.model.InstanceNetworkInterfaceSpecification;
 import com.amazonaws.services.ec2.model.InstanceState;
 import com.amazonaws.services.ec2.model.InstanceType;
 import com.amazonaws.services.ec2.model.KeyPair;
+import com.amazonaws.services.ec2.model.RequestSpotInstancesRequest;
 import com.amazonaws.services.ec2.model.RunInstancesRequest;
 import com.amazonaws.services.ec2.model.RunInstancesResult;
 import com.amazonaws.services.ec2.model.SecurityGroup;
@@ -60,6 +61,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import org.mockito.ArgumentCaptor;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -282,6 +284,65 @@ public class SlaveTemplateTest {
     }
 
     /**
+     * Test to make sure the slave created has been configured properly with the restart spot interruption configuration
+     * correctly set
+     * @throws Exception - Exception that can be thrown by the Jenkins test harness
+     */
+    @Test
+    public void testRestartSpotInterruption() throws Exception {
+        String ami = "ami1";
+        String description = "foo ami";
+
+        EC2Tag tag1 = new EC2Tag("name1", "value1");
+        EC2Tag tag2 = new EC2Tag("name2", "value2");
+        List<EC2Tag> tags = new ArrayList<EC2Tag>();
+        tags.add(tag1);
+        tags.add(tag2);
+
+        SpotConfiguration spotConfig = new SpotConfiguration(true);
+        spotConfig.setSpotMaxBidPrice("0.1");
+        spotConfig.setFallbackToOndemand(true);
+        spotConfig.setSpotBlockReservationDuration(0);
+        spotConfig.setRestartSpotInterruption(true);
+
+        SlaveTemplate slaveTemplate = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, true, null, "", false, false, "", false, "");
+        List<SlaveTemplate> templates = new ArrayList<>();
+        templates.add(slaveTemplate);
+
+        AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+        r.jenkins.clouds.add(ac);
+        // TODO - find out how to mock the spot interruption event
+        // https://help.spot.io/spotinst-api/elastigroup/amazon-web-services/simulate-instance-interruption/
+        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        r.assertEqualBeans(slaveTemplate, received, "ami,zone,spotConfig,description,remoteFS,type,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,connectionStrategy,hostKeyVerificationStrategy");
+    }
+
+    @Test
+    public void ensureTaskRestartedSpotInterruption() throws Exception {
+
+        String ami = "ami1";
+        String description = "foo ami";
+
+        EC2Tag tag1 = new EC2Tag("name1", "value1");
+        EC2Tag tag2 = new EC2Tag("name2", "value2");
+        List<EC2Tag> tags = new ArrayList<EC2Tag>();
+        tags.add(tag1);
+        tags.add(tag2);
+
+        SpotConfiguration spotConfig = new SpotConfiguration(true);
+        spotConfig.setSpotMaxBidPrice("0.1");
+        spotConfig.setFallbackToOndemand(true);
+        spotConfig.setSpotBlockReservationDuration(0);
+        spotConfig.setRestartSpotInterruption(true);
+
+        SlaveTemplate slaveTemplate = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, true, null, "", false, false, "", false, "");
+        AmazonEC2 mockedEC2 = setupTestForProvisioning(slaveTemplate);
+        // TODO - mock a disconnection
+        RequestSpotInstancesRequest request = mock(RequestSpotInstancesRequest.class);
+        mockedEC2.requestSpotInstances(request);
+    }
+
+    /**
      * Test to make sure the IAM Role is set properly.
      *
      * @throws Exception
@@ -480,8 +541,8 @@ public class SlaveTemplateTest {
         Assert.assertEquals(true, stored.getMinimumNoInstancesActiveTimeRangeDays().get("tuesday"));
     }
 
-  @Test
-  public void provisionOndemandSetsAwsNetworkingOnEc2Request() throws Exception {
+    @Test
+    public void provisionOndemandSetsAwsNetworkingOnEc2Request() throws Exception {
         boolean associatePublicIp = false;
         String ami = "ami1";
         String description = "foo ami";
@@ -521,10 +582,10 @@ public class SlaveTemplateTest {
                 assertEquals(actualRequest.getSecurityGroups(), Stream.of(securityGroups).collect(Collectors.toList()));
             }
         }
-  }
+    }
 
-  @Test
-  public void provisionOndemandSetsAwsNetworkingOnNetworkInterface() throws Exception {
+    @Test
+    public void provisionOndemandSetsAwsNetworkingOnNetworkInterface() throws Exception {
         boolean associatePublicIp = true;
         String ami = "ami1";
         String description = "foo ami";
@@ -561,9 +622,9 @@ public class SlaveTemplateTest {
             assertEquals(actualRequest.getSecurityGroupIds(), Collections.emptyList());
             assertEquals(actualRequest.getSecurityGroups(), Collections.emptyList());
         }
-  }
+    }
 
-  private AmazonEC2 setupTestForProvisioning(SlaveTemplate template) throws Exception {
+    private AmazonEC2 setupTestForProvisioning(SlaveTemplate template) throws Exception {
         AmazonEC2Cloud mockedCloud = mock(AmazonEC2Cloud.class);
         AmazonEC2 mockedEC2 = mock(AmazonEC2.class);
         EC2PrivateKey mockedPrivateKey = mock(EC2PrivateKey.class);
@@ -614,5 +675,6 @@ public class SlaveTemplateTest {
         when(mockedEC2.runInstances(any(RunInstancesRequest.class))).thenReturn(mockedResult);
 
         return mockedEC2;
-  }
+    }
+
 }

--- a/src/test/java/hudson/plugins/ec2/SpotResubmitTest.java
+++ b/src/test/java/hudson/plugins/ec2/SpotResubmitTest.java
@@ -1,0 +1,146 @@
+package hudson.plugins.ec2;
+
+import com.amazonaws.services.ec2.model.SpotInstanceRequest;
+import com.amazonaws.services.ec2.model.SpotInstanceStatus;
+import hudson.model.Action;
+import hudson.model.Actionable;
+import hudson.model.Descriptor;
+import hudson.model.Executor;
+import hudson.model.Queue;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.plugins.ec2.ssh.EC2UnixLauncher;
+import hudson.slaves.OfflineCause;
+import hudson.slaves.SlaveComputer;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import hudson.model.queue.SubTask;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Logger;
+
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Jenkins.class, Queue.class})
+public class SpotResubmitTest {
+
+//    EC2SpotSlave computer = mock(EC2SpotSlave.class, withSettings().extraInterfaces(SlaveComputer.class));
+    @Mock
+    private SlaveComputer computer;
+    @Mock
+    private EC2SpotSlave ec2SpotSlave;
+    @Mock
+    private TaskListener taskListener;
+    @Mock
+    private Jenkins jenkins;
+    @Mock
+    private Queue queue;
+    @Mock
+    private Queue.Task task;
+    @Mock
+    private Action action;
+    @Mock
+    private Executor executor;
+
+    /**
+     * Setups the queue and task
+     */
+    @Before
+    public void setup() {
+
+        // attaching console handler for debugging
+        Logger LOGGER = Logger.getLogger(EC2ComputerLauncher.class.getName());
+        LOGGER.addHandler(new ConsoleHandler());
+
+        // Mocking the static classes
+        mockStatic(Jenkins.class);
+        when(Jenkins.get()).thenReturn(jenkins);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.getInstanceOrNull()).thenReturn(jenkins);
+        when(Queue.getInstance()).thenReturn(queue);
+        // Setting computer offline due to channel termination - disconnection
+        when(computer.isOffline()).thenReturn(true);
+        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
+        // Mocking executor
+        List<Executor> executors = Arrays.asList(executor);
+        when(computer.getExecutors()).thenReturn(executors);
+        // Mocking executable
+        Actionable executable = mock(Actionable.class, withSettings().extraInterfaces(Queue.Executable.class));
+
+        when(executor.getCurrentExecutable()).thenReturn((Queue.Executable) executable);
+        // Mocking task list
+        SubTask subTask = mock(SubTask.class);
+        when(((Queue.Executable) executable).getParent()).thenReturn(subTask);
+        when(subTask.getOwnerTask()).thenReturn(task);
+        List<Action> actions = Arrays.asList(action);
+        when(executable.getActions(Action.class)).thenReturn(actions);
+    }
+
+    @Test
+    public void testNonSpotInstanceDisconnect() {
+        EC2OndemandSlave ec2OndemandSlave = mock(EC2OndemandSlave.class);
+        when(computer.getNode()).thenReturn(ec2OndemandSlave);  // set node as ec2ondemandslave
+        when(ec2SpotSlave.getRestartSpotInterruption()).thenReturn(true);  // setting restart spot instances to true
+        new EC2UnixLauncher().afterDisconnect(computer, taskListener);
+        verify(computer).getNode();
+        verifyNoMoreInteractions(computer);
+    }
+
+    @Test
+    public void testSpotInterruptionNoResubmit() {
+
+        EC2SpotSlave ec2SpotSlave = mock(EC2SpotSlave.class);
+        when(ec2SpotSlave.getRestartSpotInterruption()).thenReturn(false);  // setting is turned off
+        new EC2UnixLauncher().afterDisconnect(computer, taskListener);
+        PowerMockito.verifyZeroInteractions(queue);  // verify that the queue has no tasks resubmitted
+    }
+
+    @Test
+    public void testInterruptExecutors() {
+
+
+        EC2SpotSlave ec2SpotSlave = mock(EC2SpotSlave.class);
+        when(computer.getNode()).thenReturn(ec2SpotSlave);
+        when(ec2SpotSlave.getNodeName()).thenReturn("mocked_node");
+        when(ec2SpotSlave.getRestartSpotInterruption()).thenReturn(true);
+        SpotInstanceRequest spotInstanceRequest = mock(SpotInstanceRequest.class);
+        when(ec2SpotSlave.getSpotRequest()).thenReturn(spotInstanceRequest);
+        SpotInstanceStatus spotInstanceStatus = mock(SpotInstanceStatus.class);
+        when(spotInstanceRequest.getStatus()).thenReturn(spotInstanceStatus);
+        when(spotInstanceStatus.getCode()).thenReturn("instance-terminated-by-price");
+        new EC2UnixLauncher().afterDisconnect(computer, taskListener);
+        verify(executor).interrupt(Result.ABORTED, new EC2ComputerLauncher.EC2SpotInterruptedCause(ec2SpotSlave.getNodeName()));
+    }
+
+    @Test
+    public void testSpotInterruptionResubmitQueue() throws IOException, Descriptor.FormException {
+
+//        EC2SpotSlave ec2SpotSlave = mock(EC2SpotSlave.class);
+        when(computer.getNode()).thenReturn(ec2SpotSlave);
+        when(ec2SpotSlave.getNodeName()).thenReturn("mocked_node");
+        // Mocking the spot interruption settings and events
+        when(ec2SpotSlave.getRestartSpotInterruption()).thenReturn(true);
+        SpotInstanceRequest spotInstanceRequest = mock(SpotInstanceRequest.class);
+        when(ec2SpotSlave.getSpotRequest()).thenReturn(spotInstanceRequest);
+        SpotInstanceStatus spotInstanceStatus = mock(SpotInstanceStatus.class);
+        when(spotInstanceRequest.getStatus()).thenReturn(spotInstanceStatus);
+        when(spotInstanceStatus.getCode()).thenReturn("instance-terminated-by-price");
+
+        // Verifying that the queue task was rescheduled
+        new EC2UnixLauncher().afterDisconnect(computer, taskListener);
+        verify(queue).schedule2(eq(task), anyInt(), eq(Arrays.asList(action)));
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/SpotResubmitTest.java
+++ b/src/test/java/hudson/plugins/ec2/SpotResubmitTest.java
@@ -36,7 +36,6 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 @PrepareForTest({Jenkins.class, Queue.class})
 public class SpotResubmitTest {
 
-//    EC2SpotSlave computer = mock(EC2SpotSlave.class, withSettings().extraInterfaces(SlaveComputer.class));
     @Mock
     private SlaveComputer computer;
     @Mock
@@ -126,7 +125,6 @@ public class SpotResubmitTest {
     @Test
     public void testSpotInterruptionResubmitQueue() throws IOException, Descriptor.FormException {
 
-//        EC2SpotSlave ec2SpotSlave = mock(EC2SpotSlave.class);
         when(computer.getNode()).thenReturn(ec2SpotSlave);
         when(ec2SpotSlave.getNodeName()).thenReturn("mocked_node");
         // Mocking the spot interruption settings and events

--- a/src/test/java/hudson/plugins/ec2/SpotResubmitTest.java
+++ b/src/test/java/hudson/plugins/ec2/SpotResubmitTest.java
@@ -23,7 +23,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import hudson.model.queue.SubTask;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.ConsoleHandler;
@@ -31,8 +30,8 @@ import java.util.logging.Logger;
 
 import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
+@PowerMockIgnore({"javax.crypto.*", "org.hamcrest.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Jenkins.class, Queue.class})
 public class SpotResubmitTest {
@@ -110,7 +109,6 @@ public class SpotResubmitTest {
 
     @Test
     public void testInterruptExecutors() {
-
 
         EC2SpotSlave ec2SpotSlave = mock(EC2SpotSlave.class);
         when(computer.getNode()).thenReturn(ec2SpotSlave);

--- a/src/test/java/hudson/plugins/ec2/SpotResubmitTest.java
+++ b/src/test/java/hudson/plugins/ec2/SpotResubmitTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import hudson.model.queue.SubTask;

--- a/src/test/java/hudson/plugins/ec2/util/EC2AgentFactoryMockImpl.java
+++ b/src/test/java/hudson/plugins/ec2/util/EC2AgentFactoryMockImpl.java
@@ -23,7 +23,7 @@ public class EC2AgentFactoryMockImpl implements EC2AgentFactory {
     @Override
     public EC2SpotSlave createSpotAgent(EC2AgentConfig.Spot config)
             throws Descriptor.FormException, IOException {
-        return new MockEC2SpotSlave(config.name, config.spotInstanceRequestId, config.description, config.remoteFS, config.numExecutors, config.mode, config.initScript, config.tmpDir, config.labelString, config.nodeProperties, config.remoteAdmin, config.jvmopts, config.idleTerminationMinutes, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses);
+        return new MockEC2SpotSlave(config.name, config.spotInstanceRequestId, config.description, config.remoteFS, config.numExecutors, config.mode, config.initScript, config.tmpDir, config.labelString, config.nodeProperties, config.remoteAdmin, config.jvmopts, config.idleTerminationMinutes, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses, config.restartSpotInterruption);
     }
 
     private static class MockEC2OndemandSlave extends EC2OndemandSlave {
@@ -49,9 +49,9 @@ public class EC2AgentFactoryMockImpl implements EC2AgentFactory {
     private static class MockEC2SpotSlave extends EC2SpotSlave {
         private static final long serialVersionUID = 1L;
 
-        private MockEC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
+        private MockEC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, boolean restartSpotInterruption)
                 throws Descriptor.FormException, IOException {
-            super(name, spotInstanceRequestId, description, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, nodeProperties, remoteAdmin, jvmopts, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses);
+            super(name, spotInstanceRequestId, description, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, nodeProperties, remoteAdmin, jvmopts, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, restartSpotInterruption);
         }
 
         @Override


### PR DESCRIPTION
This PR adds a new feature - re-submission of tasks for agents that are disconnected due to spot interruption event in AWS.
Whenever an agent is disconnected, there are checks to determine if it is an unexpected disconnect and if the disconnection is a spot interruption event. If the answer is yes to both, the tasks that were running on the agent will be re-submitted to the queue.

### Motivation

Builds may fail due to spot instances being terminated. This PR can help to reduce the number of build failures for spot interruption events.

### Notes
This may or may not prevent build failures. There doesn't seem to be any documentation on how tasks can be resubmitted. This PR is inspired by another Jenkins plugin that has the suggested behaviour implemented - https://github.com/jenkinsci/ec2-fleet-plugin/blob/master/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java