### PR TITLE
Use SSHUserPrivateKey instead of BasicSSHUserPrivateKey

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -34,6 +34,7 @@ import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
@@ -195,7 +196,7 @@ public abstract class EC2Cloud extends Cloud {
     @CheckForNull
     public EC2PrivateKey resolvePrivateKey(){
         if (sshKeysCredentialsId != null) {
-            BasicSSHUserPrivateKey privateKeyCredential = getSshCredential(sshKeysCredentialsId);
+            SSHUserPrivateKey privateKeyCredential = getSshCredential(sshKeysCredentialsId);
             if (privateKeyCredential != null) {
                 return new EC2PrivateKey(privateKeyCredential.getPrivateKey());
             }
@@ -209,11 +210,11 @@ public abstract class EC2Cloud extends Cloud {
 
     private void migratePrivateSshKeyToCredential(String privateKey){
         // GET matching private key credential from Credential API if exists
-        Optional<BasicSSHUserPrivateKey> keyCredential = SystemCredentialsProvider.getInstance().getCredentials()
+        Optional<SSHUserPrivateKey> keyCredential = SystemCredentialsProvider.getInstance().getCredentials()
                 .stream()
-                .filter((cred) -> cred instanceof BasicSSHUserPrivateKey)
-                .filter((cred) -> ((BasicSSHUserPrivateKey)cred).getPrivateKey().trim().equals(privateKey.trim()))
-                .map(cred -> (BasicSSHUserPrivateKey)cred)
+                .filter((cred) -> cred instanceof SSHUserPrivateKey)
+                .filter((cred) -> ((SSHUserPrivateKey)cred).getPrivateKey().trim().equals(privateKey.trim()))
+                .map(cred -> (SSHUserPrivateKey)cred)
                 .findFirst();
 
         if (keyCredential.isPresent()){
@@ -223,7 +224,7 @@ public abstract class EC2Cloud extends Cloud {
             // CREATE new credential
             String credsId = UUID.randomUUID().toString();
 
-            BasicSSHUserPrivateKey sshKeyCredentials = new BasicSSHUserPrivateKey(CredentialsScope.SYSTEM, credsId, "key",
+            SSHUserPrivateKey sshKeyCredentials = new BasicSSHUserPrivateKey(CredentialsScope.SYSTEM, credsId, "key",
                     new BasicSSHUserPrivateKey.PrivateKeySource() {
                         @NonNull
                         @Override
@@ -1019,11 +1020,11 @@ public abstract class EC2Cloud extends Cloud {
     }
 
     @CheckForNull
-    private static BasicSSHUserPrivateKey getSshCredential(String id){
+    private static SSHUserPrivateKey getSshCredential(String id){
 
-        BasicSSHUserPrivateKey credential = CredentialsMatchers.firstOrNull(
+        SSHUserPrivateKey credential = CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(
-                        BasicSSHUserPrivateKey.class, // (1)
+                        SSHUserPrivateKey.class, // (1)
                         (ItemGroup) null,
                         null,
                         Collections.emptyList()),
@@ -1060,8 +1061,8 @@ public abstract class EC2Cloud extends Cloud {
             StandardListBoxModel result = new StandardListBoxModel();
 
             return result
-                    .includeMatchingAs(Jenkins.getAuthentication(), Jenkins.get(), BasicSSHUserPrivateKey.class, Collections.<DomainRequirement>emptyList(), CredentialsMatchers.always())
-                    .includeMatchingAs(ACL.SYSTEM, Jenkins.get(), BasicSSHUserPrivateKey.class, Collections.<DomainRequirement>emptyList(), CredentialsMatchers.always())
+                    .includeMatchingAs(Jenkins.getAuthentication(), Jenkins.get(), SSHUserPrivateKey.class, Collections.<DomainRequirement>emptyList(), CredentialsMatchers.always())
+                    .includeMatchingAs(ACL.SYSTEM, Jenkins.get(), SSHUserPrivateKey.class, Collections.<DomainRequirement>emptyList(), CredentialsMatchers.always())
                     .includeCurrentValue(sshKeysCredentialsId);
         }
 
@@ -1073,7 +1074,7 @@ public abstract class EC2Cloud extends Cloud {
                 return FormValidation.error("No ssh credentials selected");
             }
 
-            BasicSSHUserPrivateKey sshCredential = getSshCredential(value);
+            SSHUserPrivateKey sshCredential = getSshCredential(value);
             String privateKey = "";
             if (sshCredential != null) {
                 privateKey = sshCredential.getPrivateKey();
@@ -1118,7 +1119,7 @@ public abstract class EC2Cloud extends Cloud {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             try {
 
-                BasicSSHUserPrivateKey sshCredential = getSshCredential(sshKeysCredentialsId);
+                SSHUserPrivateKey sshCredential = getSshCredential(sshKeysCredentialsId);
                 String privateKey = "";
                 if (sshCredential != null) {
                     privateKey = sshCredential.getPrivateKey();

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
@@ -39,6 +39,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Mockito;
 import org.xml.sax.SAXException;
@@ -120,10 +121,9 @@ public class AmazonEC2CloudTest {
 
     /**
      * Ensure that EC2 plugin can use any implementation of SSHUserPrivateKey (not just the default implementation, BasicSSHUserPrivateKey).
-     *
-     * See <a href="https://issues.jenkins-ci.org/browse/JENKINS-63986">JENKINS-63986</a>.
      */
     @Test
+    @Issue("JENKINS-63986")
     public void testCustomSshCredentialTypes() throws IOException {
         AmazonEC2Cloud actual = r.jenkins.clouds.get(AmazonEC2Cloud.class);
         AmazonEC2Cloud.DescriptorImpl descriptor = (AmazonEC2Cloud.DescriptorImpl) actual.getDescriptor();

--- a/src/test/java/hudson/plugins/ec2/util/TestSSHUserPrivateKey.java
+++ b/src/test/java/hudson/plugins/ec2/util/TestSSHUserPrivateKey.java
@@ -1,0 +1,57 @@
+package hudson.plugins.ec2.util;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import hudson.util.Secret;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Use an instance of this class alongside an instance of {@see BasicSSHUserPrivateKey} to ensure that the plugin can
+ * use ANY {@see SSHUserPrivateKey} subtype, not just a particular subtype.
+ */
+public class TestSSHUserPrivateKey extends BaseStandardCredentials implements SSHUserPrivateKey {
+
+    private final String username;
+    private final Secret passphrase;
+    BasicSSHUserPrivateKey.PrivateKeySource privateKeySource;
+
+    public TestSSHUserPrivateKey(CredentialsScope scope,
+                                 String id,
+                                 String username,
+                                 BasicSSHUserPrivateKey.PrivateKeySource privateKeySource,
+                                 String passphrase,
+                                 String description) {
+        super(scope, id, description);
+        this.username = username;
+        this.privateKeySource = privateKeySource;
+        this.passphrase = Secret.fromString(passphrase);
+    }
+
+    @NotNull
+    @Override
+    public String getPrivateKey() {
+        List<String> privateKeys = getPrivateKeys();
+        return privateKeys.isEmpty() ? "" : privateKeys.get(0);
+    }
+
+    @Override
+    public Secret getPassphrase() {
+        return passphrase;
+    }
+
+    @NotNull
+    @Override
+    public List<String> getPrivateKeys() {
+        return privateKeySource.getPrivateKeys();
+    }
+
+    @NotNull
+    @Override
+    public String getUsername() {
+        return username;
+    }
+}


### PR DESCRIPTION
Use the general `SSHUserPrivateKey` type when looking up SSH credentials instead of the `BasicSSHUserPrivateKey` concrete subtype. This will allow the plugin to use any compatible SSH key, not just `BasicSSHUserPrivateKey` instances.

Fixes [JENKINS-63986](https://issues.jenkins-ci.org/browse/JENKINS-63986)