### PR TITLE
Change parameter for MaxMemoryPerShellMB to 10GB 

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-amiType.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-amiType.html
@@ -21,7 +21,7 @@ to the slave afterward.
 	      <li>winrm quickconfig</li>
 	      <li>winrm set winrm/config/service/Auth '@{Basic="true"}'</li>
 	      <li>winrm set winrm/config/service '@{AllowUnencrypted="true"}'</li>
-	      <li>winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="1024"}'</li>
+	      <li>winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="10240"}'</li>
 		  <li>For https:
 		     <ul>
 		         <li><a href="http://www.hansolav.net/blog/SelfsignedSSLCertificatesOnIIS7AndCommonNames.aspx">Generate a windows certificate</a></li>


### PR DESCRIPTION
Referring to the documentation from the Cloudbees side: https://support.cloudbees.com/hc/en-us/articles/216091837-EC2-Plugin-Out-of-Memory-issue-when-launching-agents-in-AWS?mobile_site=false 
In our case we had a similar problem, MSBuild could not build large projects, change this parameter resolved the problem on our side.