### PR TITLE
[JENKINS-59180] Allow AMI filtering instead of AMI ID

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Filter.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Filter.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License
+ *
+ * Copyright © 2020 Endless OS Foundation LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.ec2;
+
+import hudson.model.Descriptor;
+import hudson.model.AbstractDescribableImpl;
+import hudson.Extension;
+import hudson.Util;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import com.amazonaws.services.ec2.model.Filter;
+
+public class EC2Filter extends AbstractDescribableImpl<EC2Filter> {
+    @Nonnull
+    private final String name;
+
+    /* FIXME: Ideally this would be List<String>, but Jenkins currently
+     * doesn't offer a usable way to represent those in forms. Instead
+     * the values are interpreted as a comma separated list.
+     *
+     * https://issues.jenkins.io/browse/JENKINS-27901
+     */
+    @Nonnull
+    private final String values;
+
+    @DataBoundConstructor
+    public EC2Filter(@Nonnull String name, @Nonnull String values) {
+        this.name = Objects.requireNonNull(name);
+        this.values = Objects.requireNonNull(values);
+    }
+
+    @Override
+    public String toString() {
+        return "EC2Filter{name=\"" + name + "\", values=\"" + values + "\"}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null)
+            return false;
+        if (this.getClass() != o.getClass())
+            return false;
+
+        EC2Filter other = (EC2Filter) o;
+        return name.equals(other.name) && getValuesList().equals(other.getValuesList());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, values);
+    }
+
+    @Nonnull
+    public String getName() {
+        return name;
+    }
+
+    @Nonnull
+    public String getValues() {
+        return values;
+    }
+
+    @Nonnull
+    private List<String> getValuesList() {
+        return Stream.of(Util.tokenize(values))
+            .collect(Collectors.toList());
+    }
+
+    /* Helper method to convert EC2Filter to Filter */
+    @Nonnull
+    public Filter toFilter() {
+        return new Filter(name, getValuesList());
+    }
+
+    /* Helper method to convert list of EC2Filter to list of Filter */
+    @Nonnull
+    public static List<Filter> toFilterList(@CheckForNull List<EC2Filter> filters) {
+        return Util.fixNull(filters).stream()
+            .map(EC2Filter::toFilter)
+            .collect(Collectors.toList());
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<EC2Filter> {
+        @Override
+        public String getDisplayName() {
+            return "";
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -812,12 +812,13 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @return always non-null. This needs to be then added to {@link Hudson#addNode(Node)}.
      */
     public List<EC2AbstractSlave> provision(int number, EnumSet<ProvisionOptions> provisionOptions) throws AmazonClientException, IOException {
+        final Image image = getImage();
         if (this.spotConfig != null) {
             if (provisionOptions.contains(ProvisionOptions.ALLOW_CREATE) || provisionOptions.contains(ProvisionOptions.FORCE_CREATE))
-                return provisionSpot(number, provisionOptions);
+                return provisionSpot(image, number, provisionOptions);
             return null;
         }
-        return provisionOndemand(number, provisionOptions);
+        return provisionOndemand(image, number, provisionOptions);
     }
 
     /**
@@ -857,12 +858,18 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         LOGGER.info(this + ". " + message);
     }
 
-    HashMap<RunInstancesRequest, List<Filter>> makeRunInstancesRequestAndFilters(int number, AmazonEC2 ec2) throws IOException {
-        return makeRunInstancesRequestAndFilters(number, ec2, true);
+    HashMap<RunInstancesRequest, List<Filter>> makeRunInstancesRequestAndFilters(Image image, int number, AmazonEC2 ec2) throws IOException {
+        return makeRunInstancesRequestAndFilters(image, number, ec2, true);
     }
 
-    HashMap<RunInstancesRequest, List<Filter>> makeRunInstancesRequestAndFilters(int number, AmazonEC2 ec2, boolean rotateSubnet) throws IOException {
-        RunInstancesRequest riRequest = new RunInstancesRequest(ami, 1, number).withInstanceType(type);
+    @Deprecated
+    HashMap<RunInstancesRequest, List<Filter>> makeRunInstancesRequestAndFilters(int number, AmazonEC2 ec2) throws IOException {
+        return makeRunInstancesRequestAndFilters(getImage(), number, ec2);
+    }
+
+    HashMap<RunInstancesRequest, List<Filter>> makeRunInstancesRequestAndFilters(Image image, int number, AmazonEC2 ec2, boolean rotateSubnet) throws IOException {
+        String imageId = image.getImageId();
+        RunInstancesRequest riRequest = new RunInstancesRequest(imageId, 1, number).withInstanceType(type);
         riRequest.setEbsOptimized(ebsOptimized);
         riRequest.setMonitoring(monitoring);
 
@@ -872,7 +879,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             riRequest.setCreditSpecification(creditRequest);
         }
 
-        setupBlockDeviceMappings(riRequest.getBlockDeviceMappings());
+        setupBlockDeviceMappings(image, riRequest.getBlockDeviceMappings());
 
         if(stopOnTerminate){
             riRequest.setInstanceInitiatedShutdownBehavior(ShutdownBehavior.Stop);
@@ -883,7 +890,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
 
         List<Filter> diFilters = new ArrayList<>();
-        diFilters.add(new Filter("image-id").withValues(ami));
+        diFilters.add(new Filter("image-id").withValues(imageId));
         diFilters.add(new Filter("instance-type").withValues(type.toString()));
 
         KeyPair keyPair = getKeyPair(ec2);
@@ -976,24 +983,29 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return ret;
     }
 
-    /**
-     * Provisions an On-demand EC2 slave by launching a new instance or starting a previously-stopped instance.
-     */
-    private List<EC2AbstractSlave> provisionOndemand(int number, EnumSet<ProvisionOptions> provisionOptions)
-            throws IOException {
-        return provisionOndemand(number, provisionOptions, false, false);
+    @Deprecated
+    HashMap<RunInstancesRequest, List<Filter>> makeRunInstancesRequestAndFilters(int number, AmazonEC2 ec2, boolean rotateSubnet) throws IOException {
+        return makeRunInstancesRequestAndFilters(getImage(), number, ec2, rotateSubnet);
     }
 
     /**
      * Provisions an On-demand EC2 slave by launching a new instance or starting a previously-stopped instance.
      */
-    private List<EC2AbstractSlave> provisionOndemand(int number, EnumSet<ProvisionOptions> provisionOptions, boolean spotWithoutBidPrice, boolean fallbackSpotToOndemand)
+    private List<EC2AbstractSlave> provisionOndemand(Image image, int number, EnumSet<ProvisionOptions> provisionOptions)
+            throws IOException {
+        return provisionOndemand(image, number, provisionOptions, false, false);
+    }
+
+    /**
+     * Provisions an On-demand EC2 slave by launching a new instance or starting a previously-stopped instance.
+     */
+    private List<EC2AbstractSlave> provisionOndemand(Image image, int number, EnumSet<ProvisionOptions> provisionOptions, boolean spotWithoutBidPrice, boolean fallbackSpotToOndemand)
             throws IOException {
         AmazonEC2 ec2 = getParent().connect();
 
         logProvisionInfo("Considering launching");
 
-        HashMap<RunInstancesRequest, List<Filter>> runInstancesRequestFilterMap = makeRunInstancesRequestAndFilters(number, ec2);
+        HashMap<RunInstancesRequest, List<Filter>> runInstancesRequestFilterMap = makeRunInstancesRequestAndFilters(image, number, ec2);
         Map.Entry<RunInstancesRequest, List<Filter>> entry = runInstancesRequestFilterMap.entrySet().iterator().next();
         RunInstancesRequest riRequest = entry.getKey();
         List<Filter> diFilters = entry.getValue();
@@ -1116,10 +1128,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return orphansOrStopped;
     }
 
-    private void setupRootDevice(List<BlockDeviceMapping> deviceMappings) {
-        if (deleteRootOnTermination && getImage().getRootDeviceType().equals("ebs")) {
+    private void setupRootDevice(Image image, List<BlockDeviceMapping> deviceMappings) {
+        if (deleteRootOnTermination && image.getRootDeviceType().equals("ebs")) {
             // get the root device (only one expected in the blockmappings)
-            final List<BlockDeviceMapping> rootDeviceMappings = getAmiBlockDeviceMappings();
+            final List<BlockDeviceMapping> rootDeviceMappings = image.getBlockDeviceMappings();
             if (rootDeviceMappings.size() == 0) {
                 LOGGER.warning("AMI missing block devices");
                 return;
@@ -1147,9 +1159,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
     }
 
-    private List<BlockDeviceMapping> getNewEphemeralDeviceMapping() {
+    private List<BlockDeviceMapping> getNewEphemeralDeviceMapping(Image image) {
 
-        final List<BlockDeviceMapping> oldDeviceMapping = getAmiBlockDeviceMappings();
+        final List<BlockDeviceMapping> oldDeviceMapping = image.getBlockDeviceMappings();
 
         final Set<String> occupiedDevices = new HashSet<>();
         for (final BlockDeviceMapping mapping : oldDeviceMapping) {
@@ -1178,18 +1190,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return newDeviceMapping;
     }
 
-    private void setupEphemeralDeviceMapping(List<BlockDeviceMapping> deviceMappings) {
+    private void setupEphemeralDeviceMapping(Image image, List<BlockDeviceMapping> deviceMappings) {
         // Don't wipe out pre-existing mappings
-        deviceMappings.addAll(getNewEphemeralDeviceMapping());
-    }
-
-    private List<BlockDeviceMapping> getAmiBlockDeviceMappings() {
-
-        /*
-         * AmazonEC2#describeImageAttribute does not work due to a bug
-         * https://forums.aws.amazon.com/message.jspa?messageID=231972
-         */
-        return getImage().getBlockDeviceMappings();
+        deviceMappings.addAll(getNewEphemeralDeviceMapping(image));
     }
 
     private Image getImage() {
@@ -1215,16 +1218,17 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     /**
      * Provision a new slave for an EC2 spot instance to call back to Jenkins
      */
-    private List<EC2AbstractSlave> provisionSpot(int number, EnumSet<ProvisionOptions> provisionOptions)
+    private List<EC2AbstractSlave> provisionSpot(Image image, int number, EnumSet<ProvisionOptions> provisionOptions)
             throws IOException {
         if (!spotConfig.useBidPrice) {
-            return provisionOndemand(1, provisionOptions, true, spotConfig.getFallbackToOndemand());
+            return provisionOndemand(image, 1, provisionOptions, true, spotConfig.getFallbackToOndemand());
         }
 
         AmazonEC2 ec2 = getParent().connect();
+        String imageId = image.getImageId();
 
         try {
-            LOGGER.info("Launching " + ami + " for template " + description);
+            LOGGER.info("Launching " + imageId + " for template " + description);
 
             KeyPair keyPair = getKeyPair(ec2);
 
@@ -1240,7 +1244,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             LaunchSpecification launchSpecification = new LaunchSpecification();
 
-            launchSpecification.setImageId(ami);
+            launchSpecification.setImageId(imageId);
             launchSpecification.setInstanceType(type);
             launchSpecification.setEbsOptimized(ebsOptimized);
             launchSpecification.setMonitoringEnabled(monitoring);
@@ -1290,7 +1294,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 launchSpecification.setIamInstanceProfile(new IamInstanceProfileSpecification().withArn(getIamInstanceProfile()));
             }
 
-            setupBlockDeviceMappings(launchSpecification.getBlockDeviceMappings());
+            setupBlockDeviceMappings(image, launchSpecification.getBlockDeviceMappings());
 
             spotRequest.setLaunchSpecification(launchSpecification);
 
@@ -1328,7 +1332,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                         List<String> requestsToCancel = reqInstances.stream().map(SpotInstanceRequest::getSpotInstanceRequestId).collect(Collectors.toList());
                         CancelSpotInstanceRequestsRequest cancelRequest = new CancelSpotInstanceRequestsRequest(requestsToCancel);
                         ec2.cancelSpotInstanceRequests(cancelRequest);
-                        return provisionOndemand(number, provisionOptions);
+                        return provisionOndemand(image, number, provisionOptions);
                     }
                 }
 
@@ -1354,10 +1358,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
     }
 
-    private void setupBlockDeviceMappings(List<BlockDeviceMapping> blockDeviceMappings) {
-        setupRootDevice(blockDeviceMappings);
+    private void setupBlockDeviceMappings(Image image, List<BlockDeviceMapping> blockDeviceMappings) {
+        setupRootDevice(image, blockDeviceMappings);
         if (useEphemeralDevices) {
-            setupEphemeralDeviceMapping(blockDeviceMappings);
+            setupEphemeralDeviceMapping(image, blockDeviceMappings);
         } else {
             setupCustomDeviceMapping(blockDeviceMappings);
         }
@@ -1629,7 +1633,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @return DescribeInstancesResult of DescribeInstanceRequst constructed from this SlaveTemplate's configs
      */
     DescribeInstancesResult getDescribeInstanceResult(AmazonEC2 ec2, boolean allSubnets) throws IOException {
-        HashMap<RunInstancesRequest, List<Filter>> runInstancesRequestFilterMap = makeRunInstancesRequestAndFilters(1, ec2, false);
+        HashMap<RunInstancesRequest, List<Filter>> runInstancesRequestFilterMap = makeRunInstancesRequestAndFilters(getImage(), 1, ec2, false);
         Map.Entry<RunInstancesRequest, List<Filter>> entry = runInstancesRequestFilterMap.entrySet().iterator().next();
         List<Filter> diFilters = entry.getValue();
 

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -791,7 +791,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     @Override
     public String toString() {
         return "SlaveTemplate{" +
-                "ami='" + ami + '\'' +
+                "description='" + description + '\'' +
                 ", labels='" + labels + '\'' +
                 '}';
     }

--- a/src/main/resources/hudson/plugins/ec2/EC2Filter/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Filter/config.jelly
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright © 2020 Endless OS Foundation LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Name}" field="name">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Values}" field="values">
+    <f:textbox />
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -33,7 +33,29 @@ THE SOFTWARE.
     <f:textbox />
   </f:entry>
 
+  <!-- FIXME: Ideally this would include owners and filters, but
+       validateButton only marshals simple types and can't handle the
+       filters repeatableProperty.
+  -->
   <f:validateButton title="${%Check AMI}" progress="${%Checking...}" method="validateAmi" with="useInstanceProfileForCredentials,credentialsId,region,ec2endpoint,ami,roleArn,roleSessionName" />
+
+  <f:entry title="${%AMI Owners}" field="amiOwners">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%AMI Users}" field="amiUsers">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%AMI Filters}" help="/descriptor/hudson.plugins.ec2.SlaveTemplate/help/amiFilters">
+    <f:repeatableProperty field="amiFilters">
+      <f:block>
+        <div align="right">
+          <f:repeatableDeleteButton />
+        </div>
+      </f:block>
+    </f:repeatableProperty>
+  </f:entry>
 
   <f:entry title="${%Instance Type}" field="type">
     <f:enum>${it.name()}</f:enum>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-ami.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-ami.html
@@ -1,0 +1,12 @@
+<div>
+  A specific image ID to use for instances. Alternatively, the image can
+  be queried by criteria using the AMI Owners, Users and Filters options.
+
+  <br/>
+
+  See the <code>ImageId</code> parameter in the AWS
+  <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html">
+    describeImages API documentation
+  </a>
+  for details.
+</div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-amiFilters.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-amiFilters.html
@@ -1,0 +1,16 @@
+<div>
+  Limits the AMI to be used by attributes of the image. Each filter is a
+  name and values pair. The filter values are a whitespace separated
+  list allowing the attribute to match against multiple values. Values
+  can be quoted to preserve embedded whitespace. Any quote characters
+  must be escaped with <code>\</code>. The latest image by creation date
+  will be used when multiple images are matched.
+
+  <br/>
+
+  See the <code>Filter</code> parameter in the AWS
+  <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html">
+    describeImages API documentation
+  </a>
+  for details.
+</div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-amiOwners.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-amiOwners.html
@@ -1,0 +1,14 @@
+<div>
+  Limits the AMI to images owned by the specified AWS accounts. The
+  value is a whitespace separated list allowing images to match against
+  multiple accounts. The latest image by creation date will be used when
+  multiple images are matched.
+
+  <br/>
+
+  See the <code>Owner</code> parameter in the AWS
+  <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html">
+    describeImages API documentation
+  </a>
+  for details.
+</div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-amiUsers.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-amiUsers.html
@@ -1,0 +1,14 @@
+<div>
+  Limits the AMI to images executable by the specified AWS accounts. The
+  value is a whitespace separated list allowing images to match against
+  multiple accounts. The latest image by creation date will be used when
+  multiple images are matched.
+
+  <br/>
+
+  See the <code>ExecutableBy</code> parameter in the AWS
+  <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html">
+    describeImages API documentation
+  </a>
+  for details.
+</div>

--- a/src/test/java/hudson/plugins/ec2/ConfigurationAsCodeTest.java
+++ b/src/test/java/hudson/plugins/ec2/ConfigurationAsCodeTest.java
@@ -1,5 +1,7 @@
 package hudson.plugins.ec2;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import jenkins.model.Jenkins;
@@ -20,6 +22,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class ConfigurationAsCodeTest {
@@ -144,5 +147,39 @@ public class ConfigurationAsCodeTest {
         String exported = toYamlString(clouds);
         String expected = toStringFromYamlFile(this, "UnixDataExport.yml");
         assertEquals(expected, exported);
+    }
+
+    @Test
+    @ConfiguredWithCode("Ami.yml")
+    public void testAmi() throws Exception {
+        final AmazonEC2Cloud ec2Cloud = (AmazonEC2Cloud) Jenkins.get().getCloud("ec2-test");
+        assertNotNull(ec2Cloud);
+
+        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        assertEquals(3, templates.size());
+
+        SlaveTemplate slaveTemplate;
+        List<EC2Filter> expectedFilters;
+
+        slaveTemplate = templates.get(0);
+        assertEquals("ami-0123456789abcdefg", slaveTemplate.ami);
+        assertNull(slaveTemplate.getAmiOwners());
+        assertNull(slaveTemplate.getAmiUsers());
+        assertNull(slaveTemplate.getAmiFilters());
+
+        slaveTemplate = templates.get(1);
+        assertNull(slaveTemplate.ami);
+        assertEquals("self", slaveTemplate.getAmiOwners());
+        assertEquals("self", slaveTemplate.getAmiUsers());
+        expectedFilters = Arrays.asList(new EC2Filter("name", "foo-*"),
+                                        new EC2Filter("architecture", "x86_64"));
+        assertEquals(expectedFilters, slaveTemplate.getAmiFilters());
+
+        slaveTemplate = templates.get(2);
+        assertNull(slaveTemplate.ami);
+        assertNull(slaveTemplate.getAmiOwners());
+        assertNull(slaveTemplate.getAmiUsers());
+        expectedFilters = Collections.emptyList();
+        assertEquals(expectedFilters, slaveTemplate.getAmiFilters());
     }
 }

--- a/src/test/java/hudson/plugins/ec2/EC2FilterTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2FilterTest.java
@@ -1,0 +1,137 @@
+/*
+ * The MIT License
+ *
+ * Copyright © 2020 Endless OS Foundation LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.ec2;
+
+import com.amazonaws.services.ec2.model.Filter;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+public class EC2FilterTest {
+    @Test
+    public void testSingleValue() throws Exception {
+        EC2Filter ec2Filter = new EC2Filter("name", "value");
+        assertEquals("name", ec2Filter.getName());
+        assertEquals("value", ec2Filter.getValues());
+        assertEquals("EC2Filter{name=\"name\", values=\"value\"}", ec2Filter.toString());
+        Filter filter = ec2Filter.toFilter();
+        assertNotNull(filter);
+        assertEquals("name", filter.getName());
+        assertEquals(Arrays.asList("value"), filter.getValues());
+    }
+
+    @Test
+    public void testMultiValue() throws Exception {
+        EC2Filter ec2Filter = new EC2Filter("name", "value1 'value 2'");
+        assertEquals("name", ec2Filter.getName());
+        assertEquals("value1 'value 2'", ec2Filter.getValues());
+        assertEquals("EC2Filter{name=\"name\", values=\"value1 'value 2'\"}", ec2Filter.toString());
+        Filter filter = ec2Filter.toFilter();
+        assertNotNull(filter);
+        assertEquals("name", filter.getName());
+        assertEquals(Arrays.asList("value1", "value 2"), filter.getValues());
+    }
+
+    @Test
+    public void testEmptyValue() throws Exception {
+        EC2Filter ec2Filter = new EC2Filter("", "");
+        assertEquals("", ec2Filter.getName());
+        assertEquals("", ec2Filter.getValues());
+        assertEquals("EC2Filter{name=\"\", values=\"\"}", ec2Filter.toString());
+        Filter filter = ec2Filter.toFilter();
+        assertNotNull(filter);
+        assertEquals("", filter.getName());
+        assertEquals(Collections.emptyList(), filter.getValues());
+    }
+
+    @Test
+    public void testNullValue() throws Exception {
+        assertThrows(NullPointerException.class, () -> new EC2Filter(null, "value"));
+        assertThrows(NullPointerException.class, () -> new EC2Filter("name", null));
+        assertThrows(NullPointerException.class, () -> new EC2Filter(null, null));
+    }
+
+    @Test
+    public void testEquals() throws Exception {
+        EC2Filter a;
+        EC2Filter b;
+
+        a = new EC2Filter("", "");
+        assertNotEquals(a, null);
+
+        a = new EC2Filter("", "");
+        assertNotEquals(a, new Object());
+
+        a = new EC2Filter("", "");
+        b = new EC2Filter("", "");
+        assertEquals(a, b);
+
+        a = new EC2Filter("", "");
+        b = new EC2Filter("", "  ");
+        assertEquals(a, b);
+
+        a = new EC2Filter("foo", "value");
+        b = new EC2Filter("bar", "value");
+        assertNotEquals(a, b);
+
+        a = new EC2Filter("name", "value");
+        b = new EC2Filter("name", "value");
+        assertEquals(a, b);
+
+        a = new EC2Filter("name", "value");
+        b = new EC2Filter(" name ", "value");
+        assertNotEquals(a, b);
+
+        a = new EC2Filter("name", "value1");
+        b = new EC2Filter("name", "value2");
+        assertNotEquals(a, b);
+
+        a = new EC2Filter("name", " value ");
+        b = new EC2Filter("name", "'value'");
+        assertEquals(a, b);
+
+        a = new EC2Filter("name", "value1 value2");
+        b = new EC2Filter("name", " value1  'value2' ");
+        assertEquals(a, b);
+
+        a = new EC2Filter("name", "s p a c e s");
+        b = new EC2Filter("name", "'s p a c e s'");
+        assertNotEquals(a, b);
+
+        a = new EC2Filter("name", "s\\ p\\ a\\ c\\ e\\ s");
+        b = new EC2Filter("name", "'s p a c e s'");
+        assertEquals(a, b);
+
+        a = new EC2Filter("name", "a\\'quote");
+        b = new EC2Filter("name", "\"a'quote\"");
+        assertEquals(a, b);
+    }
+}

--- a/src/test/resources/hudson/plugins/ec2/Ami.yml
+++ b/src/test/resources/hudson/plugins/ec2/Ami.yml
@@ -1,0 +1,18 @@
+---
+configuration-as-code:
+  deprecated: warn
+jenkins:
+  clouds:
+    - amazonEC2:
+        cloudName: "test"
+        privateKey: "${PRIVATE_KEY}"
+        templates:
+          - ami: ami-0123456789abcdefg
+          - amiOwners: self
+            amiUsers: self
+            amiFilters:
+              - name: name
+                values: "foo-*"
+              - name: architecture
+                values: x86_64
+          - amiFilters: []


### PR DESCRIPTION
Allow finding the image to launch by the various `describeImages` criteria instead of just a specific image ID. Currently you're required to reconfigure the plugin whenever the image is updated, which is inconvenient.

Fixes: https://issues.jenkins.io/browse/JENKINS-59180