### PR TITLE
[JENKINS-60482] Persist the alternate ec2 endpoint

### DIFF
--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -64,6 +64,8 @@ public class AmazonEC2Cloud extends EC2Cloud {
      */
     private String region;
 
+    private String altEC2Endpoint;
+
     public static final String CLOUD_ID_PREFIX = "ec2-";
 
     private boolean noDelayProvisioning;
@@ -132,6 +134,15 @@ public class AmazonEC2Cloud extends EC2Cloud {
     @DataBoundSetter
     public void setNoDelayProvisioning(boolean noDelayProvisioning) {
         this.noDelayProvisioning = noDelayProvisioning;
+    }
+
+    public String getAltEC2Endpoint() {
+        return altEC2Endpoint;
+    }
+
+    @DataBoundSetter
+    public void setAltEC2Endpoint(String altEC2Endpoint) {
+        this.altEC2Endpoint = altEC2Endpoint;
     }
 
     @Override

--- a/src/test/java/hudson/plugins/ec2/ConfigurationAsCodeTest.java
+++ b/src/test/java/hudson/plugins/ec2/ConfigurationAsCodeTest.java
@@ -150,6 +150,17 @@ public class ConfigurationAsCodeTest {
     }
 
     @Test
+    @ConfiguredWithCode("UnixData-withAltEndpoint.yml")
+    public void testConfigAsCodeWithAltEncpointExport() throws Exception {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        CNode clouds = getJenkinsRoot(context).get("clouds");
+        String exported = toYamlString(clouds);
+        String expected = toStringFromYamlFile(this, "UnixDataExport-withAltEndpoint.yml");
+        assertEquals(expected, exported);
+    }
+
+    @Test
     @ConfiguredWithCode("Ami.yml")
     public void testAmi() throws Exception {
         final AmazonEC2Cloud ec2Cloud = (AmazonEC2Cloud) Jenkins.get().getCloud("ec2-test");

--- a/src/test/resources/hudson/plugins/ec2/UnixData-withAltEndpoint.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixData-withAltEndpoint.yml
@@ -1,0 +1,27 @@
+---
+jenkins:
+  clouds:
+    - amazonEC2:
+        altEC2Endpoint: "https.//ec2.us-east-1.amazonaws.com"
+        cloudName: "production"
+        region: "eu-central-1"
+        useInstanceProfileForCredentials: true
+        sshKeysCredentialsId: "random credentials id"
+        templates:
+          - description:
+            ami: "ami-12345"
+            labelString: "linux ubuntu"
+            type: "T2Micro"
+            remoteFS: "/home/ec2-user"
+            mode: "NORMAL"
+            spotConfig:
+              fallbackToOndemand: true
+              spotBlockReservationDuration: 3
+              spotMaxBidPrice: "0.15"
+              useBidPrice: true
+            amiType:
+              unixData:
+                rootCommandPrefix: "sudo"
+                slaveCommandPrefix: "sudo -u jenkins"
+                slaveCommandSuffix: "-fakeFlag"
+                sshPort: "22"

--- a/src/test/resources/hudson/plugins/ec2/UnixDataExport-withAltEndpoint.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixDataExport-withAltEndpoint.yml
@@ -1,0 +1,38 @@
+- amazonEC2:
+    altEC2Endpoint: "https.//ec2.us-east-1.amazonaws.com"
+    cloudName: "production"
+    region: "eu-central-1"
+    sshKeysCredentialsId: "random credentials id"
+    templates:
+    - ami: "ami-12345"
+      amiType:
+        unixData:
+          rootCommandPrefix: "sudo"
+          slaveCommandPrefix: "sudo -u jenkins"
+          slaveCommandSuffix: "-fakeFlag"
+          sshPort: "22"
+      associatePublicIp: false
+      connectBySSHProcess: false
+      connectionStrategy: PRIVATE_IP
+      deleteRootOnTermination: false
+      ebsOptimized: false
+      hostKeyVerificationStrategy: CHECK_NEW_SOFT
+      labelString: "linux ubuntu"
+      maxTotalUses: -1
+      minimumNumberOfInstances: 0
+      minimumNumberOfSpareInstances: 0
+      mode: NORMAL
+      monitoring: false
+      numExecutors: 1
+      remoteFS: "/home/ec2-user"
+      spotConfig:
+        fallbackToOndemand: true
+        spotBlockReservationDuration: 3
+        spotMaxBidPrice: "0.15"
+        useBidPrice: true
+      stopOnTerminate: false
+      t2Unlimited: false
+      type: T2Micro
+      useDedicatedTenancy: false
+      useEphemeralDevices: false
+    useInstanceProfileForCredentials: true


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/JENKINS-60482

Simplified version of https://github.com/jenkinsci/ec2-plugin/pull/439

Reasoning:

The field `Alternate EC2 endpoint` has only one purpose, to fill up the `Region` field. If you're in an environment where the default endpoint is not reachable, you can specify here the full url to use instead. Like: `https://ec2.us-west-1.amazonaws.com`. Once the field is populated, the connection and all other operations are performed using this region, so they should go fine.

It's true that every time you enter the configuration page, the `Alternate EC2 endpoint` is empty, so the `Region` field never gets populated until you set the endpoint properly. So it causes a lot of frustration and misunderstanding, IMO.

This PR tries to resolve the problem by persisting this field, so every time you reach the configuration page, the field is established, so the region field is populated correctly. This PR is simpler than https://github.com/jenkinsci/ec2-plugin/pull/439 where we use the `Alternate EC2 endpoint` as the full new AWS endpoint (IIUC), which I think it's not necessary.

I've recorded a video to show the behavior: https://photos.app.goo.gl/aADg5roUcKbMqLKj8

CC: @jkfernan @GaToRAiD @troymohl