### PR TITLE
[JENKINS-61161] Avoid infamous UI connection strategy warning

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -2040,7 +2040,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         public FormValidation doCheckConnectionStrategy(@QueryParameter String connectionStrategy) {
             return Stream.of(ConnectionStrategy.values())
-                    .filter(v -> v.equalsName(connectionStrategy))
+                    .filter(v -> v.name().equals(connectionStrategy))
                     .findFirst()
                     .map(s -> FormValidation.ok())
                     .orElse(FormValidation.error("Could not find selected connection strategy"));


### PR DESCRIPTION
See https://issues.jenkins.io/browse/JENKINS-61161

Avoid the ugly and erroneous _Could not find selected connection strategy_ every time one changes the connection strategy.

See:
![Screenshot from 2020-11-24 14-16-51](https://user-images.githubusercontent.com/22069922/100100350-f8bff580-2e60-11eb-95f0-35eda27bfc73.png)
