### PR TITLE
[JENKINS-60482] Improve alternate ec2 point checks

### DIFF
--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -183,10 +183,12 @@ public class AmazonEC2Cloud extends EC2Cloud {
         }
 
         public FormValidation doCheckAltEC2Endpoint(@QueryParameter String value) {
-            try {
-                new URL(value);
-            } catch (MalformedURLException ignored) {
-                return FormValidation.error(Messages.AmazonEC2Cloud_MalformedUrl());
+            if (Util.fixEmpty(value) != null) {
+                try {
+                    new URL(value);
+                } catch (MalformedURLException ignored) {
+                    return FormValidation.error(Messages.AmazonEC2Cloud_MalformedUrl());
+                }
             }
             return FormValidation.ok();
         }
@@ -222,6 +224,9 @@ public class AmazonEC2Cloud extends EC2Cloud {
         // value if not specified.
         @VisibleForTesting
         URL determineEC2EndpointURL(@Nullable String altEC2Endpoint) throws MalformedURLException {
+            if (Util.fixEmpty(altEC2Endpoint) == null) {
+                return new URL(DEFAULT_EC2_ENDPOINT);
+            }
             try {
                 return new URL(altEC2Endpoint);    
             } catch (MalformedURLException e) {

--- a/src/main/resources/hudson/plugins/ec2/Messages.properties
+++ b/src/main/resources/hudson/plugins/ec2/Messages.properties
@@ -9,5 +9,5 @@ EC2SpotSlave.Spot1=Spot $
 EC2SpotSlave.Spot2= max bid price
 
 AmazonEC2Cloud.NonUniqName=Cloud name must be unique across EC2 clouds
-
+AmazonEC2Cloud.MalformedUrl=The URL is malformed. The default endpoint will be used
 General.MissingPermission=You do not have the Overall/Administer right to modify this field


### PR DESCRIPTION
Follow up on #537 (JENKINS-60482) to better manage errors when setting the **_Alternate EC2 endpoint_**.

If the URL is wrong, you get an angry Jenkins on the field row:

![Screenshot from 2020-11-24 16-50-08](https://user-images.githubusercontent.com/22069922/100117509-29118f00-2e75-11eb-8273-cb8e61eeac1b.png)


With this PR it's not displayed and you get an error message behind the field:
![image](https://user-images.githubusercontent.com/22069922/100115976-7a208380-2e73-11eb-806f-8c91b8b1829b.png)

Log:
```
2020-11-24 15:38:10.712+0000 [id=81]    WARNING h.p.e.AmazonEC2Cloud$DescriptorImpl#determineEC2EndpointURL: The alternate EC2 endpoint is malformed (https.//ec2.us-east-1.amazonaws.com). Using the default endpoint (https://ec2.amazonaws.com)
```

Once you fix the wrong URL (In the image by removing the `https.` by `https:`), it works:
![image](https://user-images.githubusercontent.com/22069922/100116093-a0deba00-2e73-11eb-8cc0-5bffa312a2f0.png)
