### PR TITLE
Add null check for minimum instance time of day

### DIFF
--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -119,7 +119,7 @@ public class MinimumInstanceChecker {
 
     public static boolean minimumInstancesActive(
         MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig) {
-        if (minimumNumberOfInstancesTimeRangeConfig == null || inimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeDays() == null) {
+        if (minimumNumberOfInstancesTimeRangeConfig == null || minimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeDays() == null) {
             return true;
         }
         LocalTime fromTime = minimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeFromAsTime();

--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -119,7 +119,7 @@ public class MinimumInstanceChecker {
 
     public static boolean minimumInstancesActive(
         MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig) {
-        if (minimumNumberOfInstancesTimeRangeConfig == null) {
+        if (minimumNumberOfInstancesTimeRangeConfig == null || inimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeDays() == null) {
             return true;
         }
         LocalTime fromTime = minimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeFromAsTime();

--- a/src/main/java/hudson/plugins/ec2/util/MinimumNumberOfInstancesTimeRangeConfig.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumNumberOfInstancesTimeRangeConfig.java
@@ -4,6 +4,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import javax.annotation.CheckForNull;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -79,6 +80,7 @@ public class MinimumNumberOfInstancesTimeRangeConfig {
         return getLocalTime(minimumNoInstancesActiveTimeRangeTo);
     }
 
+    @CheckForNull
     public Map<String, Boolean> getMinimumNoInstancesActiveTimeRangeDays() {
         return minimumNoInstancesActiveTimeRangeDays;
     }


### PR DESCRIPTION
When using the ec2 plugin and JCasC I see this error message frequently in the logs

```
2020-11-25 01:32:15.623+0000 [id=236]	SEVERE	h.i.i.InstallUncaughtExceptionHandler$DefaultUncaughtExceptionHandler#uncaughtException: A thread (EC2 alive slaves monitor thread/236) died unexpectedly due to an uncaught exception, this may leave your Jenkins in a bad way and is usually indicative of a bug in the code.
java.lang.NullPointerException
	at hudson.plugins.ec2.util.MinimumInstanceChecker.minimumInstancesActive(MinimumInstanceChecker.java:143)
	at hudson.plugins.ec2.util.MinimumInstanceChecker.lambda$null$11(MinimumInstanceChecker.java:80)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1082)
	at hudson.plugins.ec2.util.MinimumInstanceChecker.lambda$checkForMinimumInstances$12(MinimumInstanceChecker.java:77)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.Iterator.forEachRemaining(Iterator.java:116)
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
	at hudson.plugins.ec2.util.MinimumInstanceChecker.checkForMinimumInstances(MinimumInstanceChecker.java:76)
	at hudson.plugins.ec2.EC2SlaveMonitor.execute(EC2SlaveMonitor.java:41)
	at hudson.model.AsyncPeriodicWork.lambda$doRun$0(AsyncPeriodicWork.java:100)
	at java.lang.Thread.run(Thread.java:748)
```

This patch adds a check to avoid the NPE and return `true` when the minimumTimeRangeConfig is missing a configuration.