### PR TITLE
[JENKINS-62908] Remove table row for embedded descriptor class

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly
@@ -121,11 +121,10 @@ THE SOFTWARE.
     	</f:entry>
 
         <f:dropdownList name="amiType" title="${%AMI Type}">
-            <f:dropdownListBlock value="0" title="${instance.amiType.descriptor.displayName}" selected="true">
-		        <j:set var="instance" value="${instance.amiType}" />
-                <tr><td><input type="hidden" name="stapler-class" value="${instance.descriptor.clazz.name}"/></td></tr>
-                <st:include from="${instance.descriptor}" page="${instance.descriptor.configPage}" />
-            </f:dropdownListBlock>
+          <f:dropdownListBlock value="0" title="${instance.amiType.descriptor.displayName}" staperClass="${instance.descriptor.clazz.name}" selected="true">
+            <j:set var="instance" value="${instance.amiType}" />
+            <st:include from="${instance.descriptor}" page="${instance.descriptor.configPage}" />
+          </f:dropdownListBlock>
         </f:dropdownList>
 
       <f:entry title="${%Maximum Total Uses}" field="maxTotalUses">


### PR DESCRIPTION
The inspiration came from https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/lib/form/dropdownListBlock.jelly#L38.

The problem was the row just to have a hidden input to specify the `stapler-class`, when in fact the `dropdownListBlock` has an attribute to store this value.