### PR TITLE
[JENKINS-60482] Update bom to fix PCT failures because of JCasC outdated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ THE SOFTWARE.
     <properties>
         <revision>1.57</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.204.6</jenkins.version>
+        <jenkins.version>2.222.4</jenkins.version>
         <java.level>8</java.level>
         <aws-java-sdk.version>1.11.821</aws-java-sdk.version>
     </properties>
@@ -230,6 +230,17 @@ THE SOFTWARE.
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
             <scope>test</scope>
+            <!--
+            PCT fails on maven-enforcer-plugin:enforce
+            test-harness:1.46 puts joda-time:2.10.2
+            aws-java-sdk:1.11.821 puts 2.8.1
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
@@ -276,8 +287,8 @@ THE SOFTWARE.
             </dependency>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.204.x</artifactId>
-                <version>18</version>
+                <artifactId>bom-2.222.x</artifactId>
+                <version>19</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
PCT is failing on ConfigurationAsCodeTest#testConfigAsCodeExport and ConfigurationAsCodeTest#testConfigAsCodeWithAltEncpointExport because it needs an updated JCasC.

This PR bump the bom to catch the CasC needed.