### PR TITLE
Detect an expired request exception

### DIFF
--- a/src/main/java/hudson/plugins/ec2/CloudHelper.java
+++ b/src/main/java/hudson/plugins/ec2/CloudHelper.java
@@ -15,9 +15,10 @@ import org.apache.commons.lang.StringUtils;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Logger;
+
+import static hudson.plugins.ec2.EC2Cloud.EC2_REQUEST_EXPIRED_ERROR_CODE;
 
 final class CloudHelper {
     private static final Logger LOGGER = Logger.getLogger(CloudHelper.class.getName());
@@ -30,7 +31,7 @@ final class CloudHelper {
             try {
                 return getInstance(instanceId, cloud);
             } catch (AmazonServiceException e) {
-                if (e.getErrorCode().equals("InvalidInstanceID.NotFound") || e.getErrorCode().equals("RequestExpired")) {
+                if (e.getErrorCode().equals("InvalidInstanceID.NotFound") || EC2_REQUEST_EXPIRED_ERROR_CODE.equals(e.getErrorCode())) {
                     // retry in 5 seconds.
                     Thread.sleep(5000);
                     continue;


### PR DESCRIPTION
[JENKINS-63537](https://issues.jenkins-ci.org/browse/JENKINS-63537) - EC2SlaveMonitor terminates agent with a running job when STS session expires

* Add conditional logic to skip removal of nodes when RequestExpiredPredicate.test(AmazonClientException) returns true

This pull request is an alternative implementation to #493 as proposed @MRamonLeon. I am working on including tests for the new functionality.