### PR TITLE
Option to launch encrypted EBS root volume from unencrypted AMI

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EbsEncryptRootVolume.java
+++ b/src/main/java/hudson/plugins/ec2/EbsEncryptRootVolume.java
@@ -1,0 +1,27 @@
+package hudson.plugins.ec2;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public enum EbsEncryptRootVolume {
+    DEFAULT("Based on AMI", null),
+    ENCRYPTED("Encrypted", true),
+    UNENCRYPTED("Not Encrypted", false);
+
+    private final String displayText;
+    private final Boolean value;
+
+    EbsEncryptRootVolume(String displayText, Boolean value) {
+        this.displayText = displayText;
+        this.value = value;
+    }
+
+    @NonNull
+    public String getDisplayText() {
+        return displayText;
+    }
+
+    public Boolean getValue() {
+        return value;
+    }
+
+}

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -194,6 +194,10 @@ THE SOFTWARE.
       <f:checkbox />
     </f:entry>
 
+    <f:entry title="${%Encrypt EBS root volume}" field="ebsEncryptRootVolume">
+      <f:select default="${descriptor.getDefaultEbsEncryptRootVolume()}"/>
+    </f:entry>
+
     <f:entry title="${%Block device mapping}" field="customDeviceMapping">
       <f:textbox />
     </f:entry>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-ebsEncryptRootVolume.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-ebsEncryptRootVolume.html
@@ -1,0 +1,9 @@
+<div>
+    Option to launch encrypted EBS backed EC2 instances from unencrypted AMIs in a single step.
+    <ul>
+        <li><b><i>Based on AMI</i></b>: EBS will be either encrypted or not encrypted based on what is defined in AMI</li>
+        <li><b><i>Not Encrypted</i></b>: Launches not encrypted EBS</i></b></li>
+        <li><b><i>Encrypted</i></b>: Launches encrypted EBS</li>
+    </ul>
+</div>
+

--- a/src/test/resources/hudson/plugins/ec2/UnixDataExport-withAltEndpoint.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixDataExport-withAltEndpoint.yml
@@ -15,6 +15,7 @@
       connectBySSHProcess: false
       connectionStrategy: PRIVATE_IP
       deleteRootOnTermination: false
+      ebsEncryptRootVolume: DEFAULT
       ebsOptimized: false
       hostKeyVerificationStrategy: CHECK_NEW_SOFT
       labelString: "linux ubuntu"

--- a/src/test/resources/hudson/plugins/ec2/UnixDataExport.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixDataExport.yml
@@ -14,6 +14,7 @@
       connectBySSHProcess: false
       connectionStrategy: PRIVATE_IP
       deleteRootOnTermination: false
+      ebsEncryptRootVolume: DEFAULT
       ebsOptimized: false
       hostKeyVerificationStrategy: CHECK_NEW_SOFT
       labelString: "linux ubuntu"


### PR DESCRIPTION
**What does PR do:**
This PR implements option to encrypt root EBS volume from unencrypted AMI

**Why:**
Our security policy requires EBS volumes to be encrypted, and since all public AMIs need to be unencrypted, in order for us to use them we would require this implementation.

Since 2019 it is possible to encrypt EBS backed EC2 instances from unencrypted AMIs; more about  it [here](https://aws.amazon.com/about-aws/whats-new/2019/05/launch-encrypted-ebs-backed-ec2-instances-from-unencrypted-amis-in-a-single-step/).

