### PR TITLE
Don't fetch instance data on node creation

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -166,7 +166,6 @@ public abstract class EC2AbstractSlave extends Slave {
         this.amiType = amiType;
         this.maxTotalUses = maxTotalUses;
         readResolve();
-        fetchLiveInstanceData(true);
     }
 
     @Deprecated


### PR DESCRIPTION
When a new node is provisioned from EC2, the instance data should be
lazily fetched in order to avoid generating network traffic in the
NodeProvisioner thread. All the getters for the attributes updated by
fetchLiveInstanceData call it first to update if need be, so there's no
need to be eager here.