### PR TITLE
[JENKINS-64520][JENKINS-62340] Pass ssh host key to ssh process when using the strategy CHECK_NEW_HARD

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -30,6 +30,7 @@ import hudson.model.Descriptor;
 import hudson.model.TaskListener;
 import hudson.plugins.ec2.*;
 import hudson.plugins.ec2.ssh.verifiers.HostKey;
+import hudson.plugins.ec2.ssh.verifiers.HostKeyHelper;
 import hudson.plugins.ec2.ssh.verifiers.Messages;
 import hudson.remoting.Channel;
 import hudson.remoting.Channel.Listener;
@@ -44,6 +45,7 @@ import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -245,11 +247,17 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
 
             if (slaveTemplate != null && slaveTemplate.isConnectBySSHProcess()) {
                 File identityKeyFile = createIdentityKeyFile(computer);
+                String ec2HostAddress = getEC2HostAddress(computer, template);
+                File hostKeyFile = createHostKeyFile(computer, ec2HostAddress, listener);
+                String userKnownHostsFileFlag = "";
+                if (hostKeyFile != null) {
+                    userKnownHostsFileFlag = String.format(" -o \"UserKnownHostsFile=%s\"", hostKeyFile.getAbsolutePath());
+                }
 
                 try {
                     // Obviously the master must have an installed ssh client.
                     // Depending on the strategy selected on the UI, we set the StrictHostKeyChecking flag
-                    String sshClientLaunchString = String.format("ssh -o StrictHostKeyChecking=%s -i %s %s@%s -p %d %s", slaveTemplate.getHostKeyVerificationStrategy().getSshCommandEquivalentFlag(), identityKeyFile.getAbsolutePath(), node.remoteAdmin, getEC2HostAddress(computer, template), node.getSshPort(), launchString);
+                    String sshClientLaunchString = String.format("ssh -o StrictHostKeyChecking=%s%s%s -i %s %s@%s -p %d %s", slaveTemplate.getHostKeyVerificationStrategy().getSshCommandEquivalentFlag(), userKnownHostsFileFlag, getEC2HostKeyAlgorithmFlag(computer), identityKeyFile.getAbsolutePath(), node.remoteAdmin, ec2HostAddress, node.getSshPort(), launchString);
 
                     logInfo(computer, listener, "Launching remoting agent (via SSH client process): " + sshClientLaunchString);
                     CommandLauncher commandLauncher = new CommandLauncher(sshClientLaunchString, null);
@@ -257,6 +265,9 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 } finally {
                     if(!identityKeyFile.delete()) {
                         LOGGER.log(Level.WARNING, "Failed to delete identity key file");
+                    }
+                    if(hostKeyFile != null && !hostKeyFile.delete()) {
+                        LOGGER.log(Level.WARNING, "Failed to delete host key file");
                     }
                 }
             } else {
@@ -319,6 +330,36 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 LOGGER.log(Level.WARNING, "Failed to delete identity key file");
             }
             throw new IOException("Error creating temporary identity key file for connecting to EC2 agent.", e);
+        }
+    }
+
+    private File createHostKeyFile(EC2Computer computer, String ec2HostAddress, TaskListener listener) throws IOException {
+        HostKey ec2HostKey = HostKeyHelper.getInstance().getHostKey(computer);
+        if (ec2HostKey == null){
+            return null;
+        }
+        File tempFile = File.createTempFile("ec2_", "_known_hosts");
+        String knownHost = "";
+        knownHost = String.format("%s %s %s", ec2HostAddress, ec2HostKey.getAlgorithm(), Base64.getEncoder().encodeToString(ec2HostKey.getKey()));
+
+        try {
+            FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
+            OutputStreamWriter writer = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8);
+            try {
+                writer.write(knownHost);
+                writer.flush();
+            } finally {
+                writer.close();
+                fileOutputStream.close();
+            }
+            FilePath filePath = new FilePath(tempFile);
+            filePath.chmod(0400); // octal file mask - readonly by owner
+            return tempFile;
+        } catch (Exception e) {
+            if (!tempFile.delete()) {
+                LOGGER.log(Level.WARNING, "Failed to delete known hosts key file");
+            }
+            throw new IOException("Error creating temporary known hosts file for connecting to EC2 agent.", e);
         }
     }
 
@@ -453,6 +494,14 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
         Instance instance = computer.updateInstanceDescription();
         ConnectionStrategy strategy = template.connectionStrategy;
         return EC2HostAddressProvider.unix(instance, strategy);
+    }
+
+    private static String getEC2HostKeyAlgorithmFlag(EC2Computer computer) throws IOException {
+        HostKey ec2HostKey = HostKeyHelper.getInstance().getHostKey(computer);
+        if (ec2HostKey != null){
+            return String.format(" -o \"HostKeyAlgorithms=%s\"", ec2HostKey.getAlgorithm());
+        }
+        return "";
     }
 
     private int waitCompletion(Session session) throws InterruptedException {

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -342,16 +342,10 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
         String knownHost = "";
         knownHost = String.format("%s %s %s", ec2HostAddress, ec2HostKey.getAlgorithm(), Base64.getEncoder().encodeToString(ec2HostKey.getKey()));
 
-        try {
-            FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
-            OutputStreamWriter writer = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8);
-            try {
-                writer.write(knownHost);
-                writer.flush();
-            } finally {
-                writer.close();
-                fileOutputStream.close();
-            }
+        try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
+             OutputStreamWriter writer = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8)) {
+            writer.write(knownHost);
+            writer.flush();
             FilePath filePath = new FilePath(tempFile);
             filePath.chmod(0400); // octal file mask - readonly by owner
             return tempFile;


### PR DESCRIPTION
Pass ssh host key to ssh process when using the strategy CHECK_NEW_HARD. Without this when connecting via ssh process, the ssh process might not have the ssh host key. Take the ssh host key that jenkins already verified and pass that to the ssh process. 

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

