### PR TITLE
[JENKINS-60647] Fix JCasC for minimumNumberOfInstancesTimeRangeConfig

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -416,9 +416,9 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
             } catch (IOException e) {
                 // keep retrying until SSH comes up
                 logInfo(computer, listener, "Failed to connect via ssh: " + e.getMessage());
-                
-                // If the computer was set offline because it's not trusted, we avoid persisting in connecting to it. 
-                // The computer is offline for a long period 
+
+                // If the computer was set offline because it's not trusted, we avoid persisting in connecting to it.
+                // The computer is offline for a long period
                 if (computer.isOffline() && StringUtils.isNotBlank(computer.getOfflineCauseReason()) && computer.getOfflineCauseReason().equals(Messages.OfflineCause_SSHKeyCheckFailed())) {
                     throw new AmazonClientException("The connection couldn't be established and the computer is now offline", e);
                 } else {
@@ -448,7 +448,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
             return template != null && template.getHostKeyVerificationStrategy().getStrategy().verify(computer, new HostKey(serverHostKeyAlgorithm, serverHostKey), listener);
         }
     }
-    
+
     private static String getEC2HostAddress(EC2Computer computer, SlaveTemplate template) throws InterruptedException {
         Instance instance = computer.updateInstanceDescription();
         ConnectionStrategy strategy = template.connectionStrategy;

--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -136,16 +136,16 @@ public class MinimumInstanceChecker {
         if (passingMidnight) {
             if (nowTime.isAfter(fromTime)) {
                 String today = now.getDayOfWeek().name().toLowerCase();
-                return minimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeDays().get(today);
+                return minimumNumberOfInstancesTimeRangeConfig.getDay(today);
             } else if (nowTime.isBefore(toTime)) {
                 //We've gone past midnight and want to check yesterday's setting.
                 String yesterday = now.minusDays(1).getDayOfWeek().name().toLowerCase();
-                return minimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeDays().get(yesterday);
+                return minimumNumberOfInstancesTimeRangeConfig.getDay(yesterday);
             }
         } else {
             if (nowTime.isAfter(fromTime) && nowTime.isBefore(toTime)) {
                 String today = now.getDayOfWeek().name().toLowerCase();
-                return minimumNumberOfInstancesTimeRangeConfig.getMinimumNoInstancesActiveTimeRangeDays().get(today);
+                return minimumNumberOfInstancesTimeRangeConfig.getDay(today);
             }
         }
         return false;

--- a/src/main/java/hudson/plugins/ec2/util/MinimumNumberOfInstancesTimeRangeConfig.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumNumberOfInstancesTimeRangeConfig.java
@@ -15,22 +15,35 @@ public class MinimumNumberOfInstancesTimeRangeConfig {
 
     private String minimumNoInstancesActiveTimeRangeFrom;
     private String minimumNoInstancesActiveTimeRangeTo;
-    private Map<String, Boolean> minimumNoInstancesActiveTimeRangeDays;
+
+    /* From old configs */
+    @Deprecated
+    private transient Map<String, Boolean> minimumNoInstancesActiveTimeRangeDays;
+
+    private Boolean monday;
+    private Boolean tuesday;
+    private Boolean wednesday;
+    private Boolean thursday;
+    private Boolean friday;
+    private Boolean saturday;
+    private Boolean sunday;
+
 
     @DataBoundConstructor
     public MinimumNumberOfInstancesTimeRangeConfig() {
     }
 
-    private static Map<String, Boolean> parseDays(JSONObject days) {
-        Map<String, Boolean> map = new HashMap<>();
-        map.put("monday", days.getBoolean("monday"));
-        map.put("tuesday", days.getBoolean("tuesday"));
-        map.put("wednesday", days.getBoolean("wednesday"));
-        map.put("thursday", days.getBoolean("thursday"));
-        map.put("friday", days.getBoolean("friday"));
-        map.put("saturday", days.getBoolean("saturday"));
-        map.put("sunday", days.getBoolean("sunday"));
-        return map;
+    protected Object readResolve() {
+        if (minimumNoInstancesActiveTimeRangeDays != null && !minimumNoInstancesActiveTimeRangeDays.isEmpty()) {
+            this.monday = minimumNoInstancesActiveTimeRangeDays.get("monday");
+            this.tuesday = minimumNoInstancesActiveTimeRangeDays.get("tuesday");
+            this.wednesday = minimumNoInstancesActiveTimeRangeDays.get("wednesday");
+            this.thursday = minimumNoInstancesActiveTimeRangeDays.get("thursday");
+            this.friday = minimumNoInstancesActiveTimeRangeDays.get("friday");
+            this.saturday = minimumNoInstancesActiveTimeRangeDays.get("saturday");
+            this.sunday = minimumNoInstancesActiveTimeRangeDays.get("sunday");
+        }
+        return this;
     }
 
     private static LocalTime getLocalTime(String value) {
@@ -47,7 +60,7 @@ public class MinimumNumberOfInstancesTimeRangeConfig {
 
     public static void validateLocalTimeString(String value) {
         if (getLocalTime(value) == null) {
-            throw new IllegalArgumentException("Value " + value + " is not valid time format, ([h:mm a] or [HH:mm])");
+            throw new IllegalArgumentException("Value " + value + " is not valid time format, ([12:34 AM] or [23:45])");
         }
     }
 
@@ -79,12 +92,79 @@ public class MinimumNumberOfInstancesTimeRangeConfig {
         return getLocalTime(minimumNoInstancesActiveTimeRangeTo);
     }
 
-    public Map<String, Boolean> getMinimumNoInstancesActiveTimeRangeDays() {
-        return minimumNoInstancesActiveTimeRangeDays;
+    public Boolean getMonday() {
+        return monday;
     }
 
     @DataBoundSetter
-    public void setMinimumNoInstancesActiveTimeRangeDays(JSONObject minimumNoInstancesActiveTimeRangeDays) {
-        this.minimumNoInstancesActiveTimeRangeDays = parseDays(minimumNoInstancesActiveTimeRangeDays);
+    public void setMonday(Boolean monday) {
+        this.monday = monday;
+    }
+
+    public Boolean getTuesday() {
+        return tuesday;
+    }
+
+    @DataBoundSetter
+    public void setTuesday(Boolean tuesday) {
+        this.tuesday = tuesday;
+    }
+
+    public Boolean getWednesday() {
+        return wednesday;
+    }
+
+    @DataBoundSetter
+    public void setWednesday(Boolean wednesday) {
+        this.wednesday = wednesday;
+    }
+
+    public Boolean getThursday() {
+        return thursday;
+    }
+
+    @DataBoundSetter
+    public void setThursday(Boolean thursday) {
+        this.thursday = thursday;
+    }
+
+    public Boolean getFriday() {
+        return friday;
+    }
+
+    @DataBoundSetter
+    public void setFriday(Boolean friday) {
+        this.friday = friday;
+    }
+
+    public Boolean getSaturday() {
+        return saturday;
+    }
+
+    @DataBoundSetter
+    public void setSaturday(Boolean saturday) {
+        this.saturday = saturday;
+    }
+
+    public Boolean getSunday() {
+        return sunday;
+    }
+
+    @DataBoundSetter
+    public void setSunday(Boolean sunday) {
+        this.sunday = sunday;
+    }
+
+    public boolean getDay(String day) {
+        switch (day.toLowerCase()) {
+        case "monday": return Boolean.TRUE.equals(this.monday);
+        case "tuesday": return Boolean.TRUE.equals(this.tuesday);
+        case "wednesday": return Boolean.TRUE.equals(this.wednesday);
+        case "thursday": return Boolean.TRUE.equals(this.thursday);
+        case "friday": return Boolean.TRUE.equals(this.friday);
+        case "saturday": return Boolean.TRUE.equals(this.saturday);
+        case "sunday": return Boolean.TRUE.equals(this.sunday);
+        default: throw new IllegalArgumentException("Can only get days");
+        }
     }
 }

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-sshKeysCredentialsId.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-sshKeysCredentialsId.html
@@ -22,12 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <div>
-    Paste the RSA private key of the EC2 key pair. You can use the AWS Console
-    or any other tool of your choice to generate the key pair.
+		A credential of the type "SSH Username with private key" with the RSA
+		private key of the EC2 key pair. You can use the AWS Console
+		or any other tool of your choice to generate the key pair.
+		The username is used, and the credential should not have a passphrase.
 
-    <p>
-    An RSA private key for EC2 is a text
-    that starts with "-----BEGIN RSA PRIVATE KEY-----". You normally
-    generate it via using either the AWS Management Console, the "ec2-add-keypair" tool or a GUI tool
-    like ElastiFox.
+		<p>
+		An RSA private key for EC2 is a text
+		that starts with "-----BEGIN RSA PRIVATE KEY-----". You normally
+		generate it via using either the AWS Management Console, the "ec2-add-keypair" tool or a GUI tool
+		like ElastiFox.
 </div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -94,7 +94,7 @@ THE SOFTWARE.
     <f:textbox />
   </f:entry>
 
- <f:dropdownDescriptorSelector title="${%AMI Type}" field="amiType" descriptors="${descriptor.getAMITypeDescriptors()}" />
+  <f:dropdownDescriptorSelector title="${%AMI Type}" field="amiType" descriptors="${descriptor.getAMITypeDescriptors()}" />
 
   <f:entry title="${%Labels}" field="labelString">
     <f:textbox />
@@ -161,24 +161,15 @@ THE SOFTWARE.
         From: <f:textbox style="width: 25%;" field="minimumNoInstancesActiveTimeRangeFrom" value="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeFrom}" />
         To: <f:textbox style="width: 25%;" field="minimumNoInstancesActiveTimeRangeTo" value="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeTo}" />
       </f:entry>
-      <f:rowSet name="minimumNoInstancesActiveTimeRangeDays">
-          <f:entry title="${%On days}" >
-              <f:checkbox field="monday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.monday}"/>
-              <label>${%Monday}</label>
-              <f:checkbox field="tuesday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.tuesday}"/>
-              <label>${%Tuesday}</label>
-              <f:checkbox field="wednesday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.wednesday}"/>
-              <label>${%Wednesday}</label>
-              <f:checkbox field="thursday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.thursday}"/>
-              <label>${%Thursday}</label>
-              <f:checkbox field="friday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.friday}"/>
-              <label>${%Friday}</label>
-              <f:checkbox field="saturday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.saturday}"/>
-              <label>${%Saturday}</label>
-              <f:checkbox field="sunday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeDays.sunday}"/>
-              <label>${%Sunday}</label>
-          </f:entry>
-      </f:rowSet>
+      <f:entry title="${%On days}">
+          <f:checkbox field="monday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.monday}" title="${%Monday}"/><st:nbsp/><st:nbsp/>
+          <f:checkbox field="tuesday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.tuesday}" title="${%Tuesday}"/><st:nbsp/><st:nbsp/>
+          <f:checkbox field="wednesday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.wednesday}" title="${%Wednesday}"/><st:nbsp/><st:nbsp/>
+          <f:checkbox field="thursday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.thursday}" title="${%Thursday}"/><st:nbsp/><st:nbsp/>
+          <f:checkbox field="friday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.friday}" title="${%Friday}"/><st:nbsp/><st:nbsp/>
+          <f:checkbox field="saturday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.saturday}" title="${%Saturday}"/><st:nbsp/><st:nbsp/>
+          <f:checkbox field="sunday" checked="${instance.minimumNumberOfInstancesTimeRangeConfig.sunday}" title="${%Sunday}"/><st:nbsp/><st:nbsp/>
+      </f:entry>
     </f:optionalBlock>
     <f:entry />
 
@@ -221,7 +212,7 @@ THE SOFTWARE.
       <f:entry title="${%Host Key Verification Strategy}" field="hostKeyVerificationStrategy">
           <f:select default="${descriptor.defaultHostKeyVerificationStrategy}"/>
       </f:entry>
-      
+
     <f:entry title="${%Maximum Total Uses}" field="maxTotalUses">
       <f:textbox default="-1"/>
     </f:entry>

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -46,10 +46,10 @@ public class EC2RetentionStrategyTest {
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
-    
+
     @Rule
     public LoggerRule logging = new LoggerRule();
-    
+
     final AtomicBoolean idleTimeoutCalled = new AtomicBoolean(false);
     final AtomicBoolean terminateCalled = new AtomicBoolean(false);
     private static ZoneId zoneId = ZoneId.systemDefault();
@@ -85,7 +85,7 @@ public class EC2RetentionStrategyTest {
     }
 
     /*
-     * Creates a computer with the params passed. If isOnline is null, the computer returns the real value, otherwise, 
+     * Creates a computer with the params passed. If isOnline is null, the computer returns the real value, otherwise,
      * the computer returns the value established.
      */
     private EC2Computer computerWithIdleTime(final int minutes, final int seconds, final Boolean isOffline, final Boolean isConnecting) throws Exception {
@@ -207,17 +207,17 @@ public class EC2RetentionStrategyTest {
         long nextCheckAfter = twoMinutesAgo.toEpochMilli();
         Clock clock = Clock.fixed(twoMinutesAgo.plusSeconds(1), zoneId);
         EC2RetentionStrategy rs = new EC2RetentionStrategy("1", clock, nextCheckAfter);
-        
+
         OfflineCause cause = OfflineCause.create(new NonLocalizable("Testing terminate on offline computer"));
-        
-        // A computer returning the real isOffline value and still connecting 
-        EC2Computer computer = computerWithIdleTime(0, 0, null, true); 
+
+        // A computer returning the real isOffline value and still connecting
+        EC2Computer computer = computerWithIdleTime(0, 0, null, true);
         computer.setTemporarilyOffline(true, cause);
         // We don't terminate this one
         rs.check(computer);
         assertThat("The computer is not terminated, it should still accept tasks", idleTimeoutCalled.get(), equalTo(false));
         assertThat(logging.getMessages(), hasItem(containsString("connecting and still offline, will check if the launch timeout has expired")));
-                
+
         // A computer returning the real isOffline value and not connecting
         rs = new EC2RetentionStrategy("1", clock, nextCheckAfter);
         EC2Computer computer2 = computerWithIdleTime(0, 0, null, false);
@@ -227,7 +227,7 @@ public class EC2RetentionStrategyTest {
         assertThat("The computer is terminated, it should not accept more tasks", idleTimeoutCalled.get(), equalTo(true));
         assertThat(logging.getMessages(), hasItem(containsString("offline but not connecting, will check if it should be terminated because of the idle time configured")));
     }
-    
+
     @Test
     public void testInternalCheckRespectsWait() throws Exception {
         List<Boolean> expected = new ArrayList<Boolean>();
@@ -335,15 +335,8 @@ public class EC2RetentionStrategyTest {
         MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig = new MinimumNumberOfInstancesTimeRangeConfig();
         minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeFrom("11:00");
         minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeTo("15:00");
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("monday", false);
-        jsonObject.put("tuesday", true);
-        jsonObject.put("wednesday", false);
-        jsonObject.put("thursday", false);
-        jsonObject.put("friday", false);
-        jsonObject.put("saturday", false);
-        jsonObject.put("sunday", false);
-        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeDays(jsonObject);
+        minimumNumberOfInstancesTimeRangeConfig.setMonday(false);
+        minimumNumberOfInstancesTimeRangeConfig.setTuesday(true);
         template.setMinimumNumberOfInstancesTimeRangeConfig(minimumNumberOfInstancesTimeRangeConfig);
 
         LocalDateTime localDateTime = LocalDateTime.of(2019, Month.SEPTEMBER, 24, 12, 0); //Tuesday
@@ -391,15 +384,8 @@ public class EC2RetentionStrategyTest {
         MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig = new MinimumNumberOfInstancesTimeRangeConfig();
         minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeFrom("11:00");
         minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeTo("15:00");
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("monday", false);
-        jsonObject.put("tuesday", true);
-        jsonObject.put("wednesday", false);
-        jsonObject.put("thursday", false);
-        jsonObject.put("friday", false);
-        jsonObject.put("saturday", false);
-        jsonObject.put("sunday", false);
-        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeDays(jsonObject);
+        minimumNumberOfInstancesTimeRangeConfig.setMonday(false);
+        minimumNumberOfInstancesTimeRangeConfig.setTuesday(true);
         template.setMinimumNumberOfInstancesTimeRangeConfig(minimumNumberOfInstancesTimeRangeConfig);
 
         LocalDateTime localDateTime = LocalDateTime.of(2019, Month.SEPTEMBER, 24, 10, 0); //Tuesday before range
@@ -432,15 +418,8 @@ public class EC2RetentionStrategyTest {
         MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig = new MinimumNumberOfInstancesTimeRangeConfig();
         minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeFrom("15:00");
         minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeTo("03:00");
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("monday", false);
-        jsonObject.put("tuesday", true);
-        jsonObject.put("wednesday", false);
-        jsonObject.put("thursday", false);
-        jsonObject.put("friday", false);
-        jsonObject.put("saturday", false);
-        jsonObject.put("sunday", false);
-        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeDays(jsonObject);
+        minimumNumberOfInstancesTimeRangeConfig.setMonday(false);
+        minimumNumberOfInstancesTimeRangeConfig.setTuesday(true);
         template.setMinimumNumberOfInstancesTimeRangeConfig(minimumNumberOfInstancesTimeRangeConfig);
 
         LocalDateTime localDateTime = LocalDateTime.of(2019, Month.SEPTEMBER, 25, 1, 0); //Wednesday
@@ -487,15 +466,8 @@ public class EC2RetentionStrategyTest {
         MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig = new MinimumNumberOfInstancesTimeRangeConfig();
         minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeFrom("11:00");
         minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeTo("15:00");
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("monday", false);
-        jsonObject.put("tuesday", true);
-        jsonObject.put("wednesday", false);
-        jsonObject.put("thursday", false);
-        jsonObject.put("friday", false);
-        jsonObject.put("saturday", false);
-        jsonObject.put("sunday", false);
-        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeDays(jsonObject);
+        minimumNumberOfInstancesTimeRangeConfig.setMonday(false);
+        minimumNumberOfInstancesTimeRangeConfig.setTuesday(true);
         template.setMinimumNumberOfInstancesTimeRangeConfig(minimumNumberOfInstancesTimeRangeConfig);
 
         //Set fixed clock to be able to test properly

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -170,7 +170,7 @@ public class SlaveTemplateTest {
 
         // We check this one is set
         final HostKeyVerificationStrategyEnum STRATEGY_TO_CHECK = HostKeyVerificationStrategyEnum.OFF;
-        
+
         SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, 0, 0, null, "", true, false, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, STRATEGY_TO_CHECK);
 
         List<SlaveTemplate> templates = new ArrayList<SlaveTemplate>();
@@ -452,15 +452,8 @@ public class SlaveTemplateTest {
         MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig = new MinimumNumberOfInstancesTimeRangeConfig();
         minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeFrom("11:00");
         minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeTo("15:00");
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("monday", false);
-        jsonObject.put("tuesday", true);
-        jsonObject.put("wednesday", false);
-        jsonObject.put("thursday", false);
-        jsonObject.put("friday", false);
-        jsonObject.put("saturday", false);
-        jsonObject.put("sunday", false);
-        minimumNumberOfInstancesTimeRangeConfig.setMinimumNoInstancesActiveTimeRangeDays(jsonObject);
+        minimumNumberOfInstancesTimeRangeConfig.setMonday(false);
+        minimumNumberOfInstancesTimeRangeConfig.setTuesday(true);
         SpotConfiguration spotConfig = new SpotConfiguration(true);
         spotConfig.setSpotMaxBidPrice("22");
         spotConfig.setFallbackToOndemand(true);
@@ -480,8 +473,8 @@ public class SlaveTemplateTest {
         Assert.assertNotNull(stored);
         Assert.assertEquals("11:00", stored.getMinimumNoInstancesActiveTimeRangeFrom());
         Assert.assertEquals("15:00", stored.getMinimumNoInstancesActiveTimeRangeTo());
-        Assert.assertEquals(false, stored.getMinimumNoInstancesActiveTimeRangeDays().get("monday"));
-        Assert.assertEquals(true, stored.getMinimumNoInstancesActiveTimeRangeDays().get("tuesday"));
+        Assert.assertEquals(false, stored.getDay("monday"));
+        Assert.assertEquals(true, stored.getDay("tuesday"));
     }
 
   @Test

--- a/src/test/resources/hudson/plugins/ec2/Unix-withMinimumInstancesTimeRange.yml
+++ b/src/test/resources/hudson/plugins/ec2/Unix-withMinimumInstancesTimeRange.yml
@@ -1,0 +1,19 @@
+---
+jenkins:
+  clouds:
+    - amazonEC2:
+        cloudName: "timed"
+        useInstanceProfileForCredentials: true
+        sshKeysCredentialsId: "random credentials id"
+        templates:
+          - description:
+            ami: "ami-123456"
+            labelString: "linux ubuntu"
+            type: "T2Micro"
+            remoteFS: "/home/ec2-user"
+            mode: "NORMAL"
+            minimumNumberOfInstancesTimeRangeConfig:
+              minimumNoInstancesActiveTimeRangeFrom: "01:00"
+              minimumNoInstancesActiveTimeRangeTo: "1:00 PM"
+              monday: false
+              tuesday: true


### PR DESCRIPTION
Instead of a map which is not supported by JCasC, use individual fields. This
requires a readResolve to convert the old objects to the new format.

This PR also fixes up some of the layout for these buttons, and adds back a missing help test for the sshKeys.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

