### PR TITLE
Fill credentials from current context instead of just Jenkins singleton

### DIFF
--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -28,6 +28,7 @@ import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Failure;
+import hudson.model.ItemGroup;
 import hudson.plugins.ec2.util.AmazonEC2Factory;
 import hudson.slaves.Cloud;
 import hudson.util.FormValidation;
@@ -45,6 +46,7 @@ import javax.servlet.ServletException;
 
 import jenkins.model.Jenkins;
 
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -237,6 +239,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
 
         @RequirePOST
         public FormValidation doTestConnection(
+                @AncestorInPath ItemGroup context,
                 @QueryParameter String region,
                 @QueryParameter boolean useInstanceProfileForCredentials,
                 @QueryParameter String credentialsId,
@@ -250,7 +253,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
                 region = DEFAULT_EC2_HOST;
             }
 
-            return super.doTestConnection(getEc2EndpointUrl(region), useInstanceProfileForCredentials, credentialsId, sshKeysCredentialsId, roleArn, roleSessionName, region);
+            return super.doTestConnection(context, getEc2EndpointUrl(region), useInstanceProfileForCredentials, credentialsId, sshKeysCredentialsId, roleArn, roleSessionName, region);
         }
     }
 }

--- a/src/main/java/hudson/plugins/ec2/Eucalyptus.java
+++ b/src/main/java/hudson/plugins/ec2/Eucalyptus.java
@@ -24,6 +24,7 @@
 package hudson.plugins.ec2;
 
 import hudson.Extension;
+import hudson.model.ItemGroup;
 import hudson.util.FormValidation;
 
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.util.List;
 
 import javax.servlet.ServletException;
 
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -80,9 +82,9 @@ public class Eucalyptus extends EC2Cloud {
 
         @Override
         @RequirePOST
-        public FormValidation doTestConnection(@QueryParameter URL ec2endpoint, @QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String credentialsId, @QueryParameter String sshKeysCredentialsId, @QueryParameter String roleArn, @QueryParameter String roleSessionName, @QueryParameter String region)
+        public FormValidation doTestConnection(@AncestorInPath ItemGroup context, @QueryParameter URL ec2endpoint, @QueryParameter boolean useInstanceProfileForCredentials, @QueryParameter String credentialsId, @QueryParameter String sshKeysCredentialsId, @QueryParameter String roleArn, @QueryParameter String roleSessionName, @QueryParameter String region)
                 throws IOException, ServletException {
-            return super.doTestConnection(ec2endpoint, useInstanceProfileForCredentials, credentialsId, sshKeysCredentialsId, roleArn, roleSessionName, region);
+            return super.doTestConnection(context, ec2endpoint, useInstanceProfileForCredentials, credentialsId, sshKeysCredentialsId, roleArn, roleSessionName, region);
         }
     }
 }

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
@@ -24,6 +24,7 @@
 package hudson.plugins.ec2;
 
 import com.amazonaws.services.ec2.AmazonEC2;
+import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl;
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -99,11 +100,29 @@ public class AmazonEC2CloudTest {
     }
 
     @Test
+    public void testAWSCredentials() throws IOException {
+        AmazonEC2Cloud actual = r.jenkins.clouds.get(AmazonEC2Cloud.class);
+        AmazonEC2Cloud.DescriptorImpl descriptor = (AmazonEC2Cloud.DescriptorImpl) actual.getDescriptor();
+        assertNotNull(descriptor);
+        ListBoxModel m = descriptor.doFillCredentialsIdItems(Jenkins.get());
+        assertThat(m.size(), is(1));
+        SystemCredentialsProvider.getInstance().getCredentials().add(
+            new AWSCredentialsImpl(CredentialsScope.SYSTEM, "system_id","system_ak", "system_sk", "system_desc"));
+        //Ensure added credential is displayed
+        m = descriptor.doFillCredentialsIdItems(Jenkins.get());
+        assertThat(m.size(), is(2));
+        SystemCredentialsProvider.getInstance().getCredentials().add(
+            new AWSCredentialsImpl(CredentialsScope.GLOBAL, "global_id","global_ak", "global_sk", "global_desc"));
+        m = descriptor.doFillCredentialsIdItems(Jenkins.get());
+        assertThat(m.size(), is(3));
+    }
+
+    @Test
     public void testSshCredentials() throws IOException {
         AmazonEC2Cloud actual = r.jenkins.clouds.get(AmazonEC2Cloud.class);
         AmazonEC2Cloud.DescriptorImpl descriptor = (AmazonEC2Cloud.DescriptorImpl) actual.getDescriptor();
         assertNotNull(descriptor);
-        ListBoxModel m = descriptor.doFillSshKeysCredentialsIdItems("");
+        ListBoxModel m = descriptor.doFillSshKeysCredentialsIdItems(Jenkins.get(), "");
         assertThat(m.size(), is(1));
         BasicSSHUserPrivateKey sshKeyCredentials = new BasicSSHUserPrivateKey(CredentialsScope.SYSTEM, "ghi", "key",
                 new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource("somekey"), "", "");
@@ -113,7 +132,7 @@ public class AmazonEC2CloudTest {
             }
         }
         //Ensure added credential is displayed
-        m = descriptor.doFillSshKeysCredentialsIdItems("");
+        m = descriptor.doFillSshKeysCredentialsIdItems(Jenkins.get(), "");
         assertThat(m.size(), is(2));
         //Ensure that the cloud can resolve the new key
         assertThat(actual.resolvePrivateKey(), notNullValue());
@@ -128,7 +147,7 @@ public class AmazonEC2CloudTest {
         AmazonEC2Cloud actual = r.jenkins.clouds.get(AmazonEC2Cloud.class);
         AmazonEC2Cloud.DescriptorImpl descriptor = (AmazonEC2Cloud.DescriptorImpl) actual.getDescriptor();
         assertNotNull(descriptor);
-        ListBoxModel m = descriptor.doFillSshKeysCredentialsIdItems("");
+        ListBoxModel m = descriptor.doFillSshKeysCredentialsIdItems(Jenkins.get(), "");
         assertThat(m.size(), is(1));
         SSHUserPrivateKey sshKeyCredentials = new TestSSHUserPrivateKey(CredentialsScope.SYSTEM, "ghi", "key",
                 new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource("somekey"), "", "");
@@ -138,7 +157,7 @@ public class AmazonEC2CloudTest {
             }
         }
         //Ensure added credential is displayed
-        m = descriptor.doFillSshKeysCredentialsIdItems("");
+        m = descriptor.doFillSshKeysCredentialsIdItems(Jenkins.get(), "");
         assertThat(m.size(), is(2));
         //Ensure that the cloud can resolve the new key
         assertThat(actual.resolvePrivateKey(), notNullValue());


### PR DESCRIPTION
Proposing this as this is useful in CloudBees products where Cloud implementation can be configured within Folders within folders, then pushed connected Jenkins instance. Similar feature were added to for example the kubernetes plugin: https://github.com/jenkinsci/kubernetes-plugin/commit/00ca6a819d951ebf481b21be6750493594a9b8ce

I have added a test to validate that this does not impact the current functionalities.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue