### PR TITLE
[JENKINS-64738] Fixed reference to get the amiType class name

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly
@@ -121,7 +121,7 @@ THE SOFTWARE.
         </f:entry>
 
         <f:dropdownList name="amiType" title="${%AMI Type}">
-          <f:dropdownListBlock value="0" title="${instance.amiType.descriptor.displayName}" staplerClass="${instance.descriptor.clazz.name}" selected="true">
+          <f:dropdownListBlock value="0" title="${instance.amiType.descriptor.displayName}" staplerClass="${instance.amiType.descriptor.clazz.name}" selected="true">
             <j:set var="instance" value="${instance.amiType}" />
             <st:include from="${instance.descriptor}" page="${instance.descriptor.configPage}" />
           </f:dropdownListBlock>


### PR DESCRIPTION
Turns out the typo fixed in [608](https://github.com/jenkinsci/ec2-plugin/pull/608) wasn't the only thing wrong. The `instance` var is only reassigned inside the `dropdownListBlock` element, so `instance.amiType` should be used in the `staplerClass` attribute instead.

The fix has been tested manually and now works as expected.
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
