### PR TITLE
Add required library to project configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
+            <!-- TODO: remove version once https://github.com/jenkinsci/bom/commit/0de33628090ece61378f6e8d97711b93af9b997a is released -->
             <version>1.77</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.12</version>
+        <version>4.18</version>
         <relativePath />
     </parent>
 
@@ -78,7 +78,7 @@ THE SOFTWARE.
     <properties>
         <revision>1.56</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.204.6</jenkins.version>
+        <jenkins.version>2.277.4</jenkins.version>
         <java.level>8</java.level>
         <aws-java-sdk.version>1.11.821</aws-java-sdk.version>
     </properties>
@@ -209,6 +209,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
+            <version>1.77</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -251,16 +252,14 @@ THE SOFTWARE.
             <version>1.7.30</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>libzfs</artifactId>
+            <version>0.8</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.jenkins-ci.main</groupId>
-                <artifactId>jenkins-bom</artifactId>
-                <version>${jenkins.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
@@ -276,10 +275,15 @@ THE SOFTWARE.
             </dependency>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.204.x</artifactId>
-                <version>18</version>
+                <artifactId>bom-2.277.x</artifactId>
+                <version>807.v6d348e44c987</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>2.10.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
+++ b/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
@@ -70,7 +70,7 @@ public class TemplateLabelsTest {
         assertEquals(true, ac.canProvision(new LabelAtom(LABEL1)));
         assertEquals(true, ac.canProvision(new LabelAtom(LABEL2)));
         assertEquals(false, ac.canProvision(new LabelAtom("aaa")));
-        assertEquals(true, ac.canProvision(null));
+        assertEquals(true, ac.canProvision((Label) null));
     }
 
     @Test
@@ -89,7 +89,7 @@ public class TemplateLabelsTest {
     public void testEmptyLabel() throws Exception {
         setUpCloud("");
 
-        assertEquals(true, ac.canProvision(null));
+        assertEquals(true, ac.canProvision((Label) null));
     }
 
     @Test
@@ -99,14 +99,14 @@ public class TemplateLabelsTest {
         assertEquals(true, ac.canProvision(new LabelAtom(LABEL1)));
         assertEquals(true, ac.canProvision(new LabelAtom(LABEL2)));
         assertEquals(false, ac.canProvision(new LabelAtom("aaa")));
-        assertEquals(false, ac.canProvision(null));
+        assertEquals(false, ac.canProvision((Label) null));
     }
 
     @Test
     public void testExclusiveModeEmptyLabel() throws Exception {
         setUpCloud("", Node.Mode.EXCLUSIVE);
 
-        assertEquals(false, ac.canProvision(null));
+        assertEquals(false, ac.canProvision((Label) null));
     }
 
 }


### PR DESCRIPTION
Update minimum core version and bom

Since https://github.com/jenkinsci/jenkins/pull/5047 was merged in Jenkins Core, the library `libzfs` was removed. This library is required in this plugin but was not properly described. 

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
