### PR TITLE
Script security version fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,8 +209,6 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <!-- TODO: remove version once https://github.com/jenkinsci/bom/commit/0de33628090ece61378f6e8d97711b93af9b997a is released -->
-            <version>1.77</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@ THE SOFTWARE.
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.277.x</artifactId>
-                <version>807.v6d348e44c987</version>
+                <version>831.v9814430e6383</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Removes the pinned version of script-security plugin now that the BOM has the correct minimum version required to have the caffeine-api plugin.

Replaces #618.

@MRamonLeon 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
