### PR TITLE
[JENKINS-64569] Add support for EBS Throughput parameter

### DIFF
--- a/src/main/java/hudson/plugins/ec2/util/DeviceMappingParser.java
+++ b/src/main/java/hudson/plugins/ec2/util/DeviceMappingParser.java
@@ -60,7 +60,7 @@ public class DeviceMappingParser {
         return deviceMappings;
     }
 
-    // [<snapshot-id>]:[<size>]:[<delete-on-termination>]:[<type>]:[<iops>]:[encrypted]
+    // [<snapshot-id>]:[<size>]:[<delete-on-termination>]:[<type>]:[<iops>]:[encrypted]:[throughput]
     private static EbsBlockDevice parseEbs(String blockDevice) {
 
         String[] parts = blockDevice.split(":");
@@ -83,6 +83,9 @@ public class DeviceMappingParser {
         }
         if (StringUtils.isNotBlank(getOrEmpty(parts, 5))) {
             ebs.setEncrypted(parts[5].equals("encrypted"));
+        }
+        if (StringUtils.isNotBlank(getOrEmpty(parts, 6))) {
+            ebs.setThroughput(Integer.valueOf(parts[6]));
         }
 
         return ebs;

--- a/src/test/java/hudson/plugins/ec2/util/DeviceMappingParserTest.java
+++ b/src/test/java/hudson/plugins/ec2/util/DeviceMappingParserTest.java
@@ -85,6 +85,16 @@ public class DeviceMappingParserTest {
     }
 
     @Test
+    public void testParserWithThroughput() {
+        List<BlockDeviceMapping> expected = new ArrayList<>();
+        expected.add(new BlockDeviceMapping().withDeviceName("/dev/sdd").withEbs(new EbsBlockDevice().withVolumeSize(120).withThroughput(1000)));
+
+        String customDeviceMappings = "/dev/sdd=:120:::::1000";
+        List<BlockDeviceMapping> actual = DeviceMappingParser.parse(customDeviceMappings);
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void testParserWithMultiple() {
         List<BlockDeviceMapping> expected = new ArrayList<>();
         expected.add(new BlockDeviceMapping().withDeviceName("/dev/sdd").withEbs(new EbsBlockDevice().withVolumeSize(120).withEncrypted(true)));


### PR DESCRIPTION
Closes https://issues.jenkins.io/browse/JENKINS-64569 by adding the `throughput` param to the end of the parser for the colon separated string. Based on other existing tests which have fewer separators than options, this should be entirely backwards compatible with existing block device config strings.

I've written a simple test, but I'm having issues getting the `util` tests to run both locally and in CI. It seems like maybe they aren't getting picked up by the Maven project?

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
