### PR TITLE
Adds new delimeters for subnet configuration: white spaces, comma, semicolon can be used

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -135,6 +135,8 @@ import java.util.stream.Stream;
 public class SlaveTemplate implements Describable<SlaveTemplate> {
     private static final Logger LOGGER = Logger.getLogger(SlaveTemplate.class.getName());
 
+    private static final String EC2_RESOURCE_ID_DELIMETERS = "[\\s,;]+";
+
     public String ami;
 
     public final String description;
@@ -619,7 +621,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         if (StringUtils.isBlank(subnetId)) {
             return null;
         } else {
-            String[] subnetIdList= getSubnetId().split(" ");
+            String[] subnetIdList= getSubnetId().split(EC2_RESOURCE_ID_DELIMETERS);
 
             // Round-robin subnet selection.
             currentSubnetId = subnetIdList[nextSubnet];
@@ -1752,7 +1754,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             /* Add filter using all subnets defined for this SlaveTemplate */
             Filter subnetFilter = new Filter("subnet-id");
-            subnetFilter.setValues(Arrays.asList(getSubnetId().split(" ")));
+            subnetFilter.setValues(Arrays.asList(getSubnetId().split(EC2_RESOURCE_ID_DELIMETERS)));
             diFilters.add(subnetFilter);
         }
 

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-subnetId.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-subnetId.html
@@ -1,3 +1,3 @@
 <div>
-  Space-separated list of subnet IDs to launch instances into.<br/><br/>Specify one or more subnet IDs if you're using a non-default VPC. If more than one subnet ID is provided, instances will be launched in each subnet in a round-robin fashion beginning with the first subnet in the list.
+  List of subnet IDs to launch instances into.<br/><br/>Specify one or more subnet IDs separated with space, comma, or semicolon if you're using a non-default VPC. If more than one subnet ID is provided, instances will be launched in each subnet in a round-robin fashion beginning with the first subnet in the list.
 </div>

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
@@ -413,8 +413,34 @@ public class SlaveTemplateUnitTest {
     }
 
     @Test
-    public void testChooseSubnetId() throws Exception {
+    public void testChooseSpaceDelimitedSubnetId() throws Exception {
         SlaveTemplate slaveTemplate = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123 subnet-456", null, null, true, null, "", false, false, "", false, "");
+
+        String subnet1 = slaveTemplate.chooseSubnetId();
+        String subnet2 = slaveTemplate.chooseSubnetId();
+        String subnet3 = slaveTemplate.chooseSubnetId();
+
+        assertEquals(subnet1, "subnet-123");
+        assertEquals(subnet2, "subnet-456");
+        assertEquals(subnet3, "subnet-123");
+    }
+
+    @Test
+    public void testChooseCommaDelimitedSubnetId() throws Exception {
+        SlaveTemplate slaveTemplate = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123,subnet-456", null, null, true, null, "", false, false, "", false, "");
+
+        String subnet1 = slaveTemplate.chooseSubnetId();
+        String subnet2 = slaveTemplate.chooseSubnetId();
+        String subnet3 = slaveTemplate.chooseSubnetId();
+
+        assertEquals(subnet1, "subnet-123");
+        assertEquals(subnet2, "subnet-456");
+        assertEquals(subnet3, "subnet-123");
+    }
+
+    @Test
+    public void testChooseSemicolonDelimitedSubnetId() throws Exception {
+        SlaveTemplate slaveTemplate = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123;subnet-456", null, null, true, null, "", false, false, "", false, "");
 
         String subnet1 = slaveTemplate.chooseSubnetId();
         String subnet2 = slaveTemplate.chooseSubnetId();
@@ -434,7 +460,6 @@ public class SlaveTemplateUnitTest {
         assertThat(exported, containsString("usePrivateDnsName"));
         assertThat(exported, containsString("connectUsingPublicIp"));
     }
-
 }
 
 class TestHandler extends Handler {


### PR DESCRIPTION
It looks reasonable to use more symbols to divide VPC subnets in Jenkins agent configuration. It can be used when you want to configure EC2 plugin through CASC (configuration-as-a-code) and perform evaluation some values from AWS SSM Parameter Store. In this case list of VPC subnets is provided as a comma separated values in a string.

I've added a regular expression that includes new symbols to split string of VPC subnet ids into array of its values. 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue