### PR TITLE
Fix connection strategy UI prompt

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ConnectionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/ConnectionStrategy.java
@@ -6,18 +6,14 @@ public enum ConnectionStrategy {
     PRIVATE_DNS("Private DNS"),
     PRIVATE_IP("Private IP");
 
-    private final String name;
+    private final String displayText;
 
-    ConnectionStrategy(String name) {
-        this.name = name;
+    ConnectionStrategy(String displayText) {
+        this.displayText = displayText;
     }
 
-    public boolean equalsName(String other) {
-        return this.name.equals(other);
-    }
-
-    public String toString() {
-        return this.name;
+    public String getDisplayText() {
+        return this.displayText;
     }
 
     /**

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -2062,9 +2062,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             return Stream.of(ConnectionStrategy.values())
                     .map(v -> {
                         if (v.name().equals(connectionStrategy)) {
-                            return new ListBoxModel.Option(v.toString(), v.name(), true);
+                            return new ListBoxModel.Option(v.getDisplayText(), v.name(), true);
                         } else {
-                            return new ListBoxModel.Option(v.toString(), v.name(), false);
+                            return new ListBoxModel.Option(v.getDisplayText(), v.name(), false);
                         }
                     })
                     .collect(Collectors.toCollection(ListBoxModel::new));


### PR DESCRIPTION
The issue seems stem from `ConnectionStrategy` having both a name field and function which seems to cause confusion so doFillConnectionStrategy can be called with either displayText or the enum NAME we only want the name but displayText was stored in the name field. Rename to prevent this issue

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
