### PR TITLE
[JENKINS-23792] Do not terminate stopped EC2 nodes that were just booted

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -106,7 +106,7 @@ public class EC2Computer extends SlaveComputer {
         GetConsoleOutputRequest request = new GetConsoleOutputRequest(getInstanceId());
         return ec2.getConsoleOutput(request).getDecodedOutput();
     }
-    
+
     /**
      * Obtains the instance state description in EC2.
      *
@@ -152,6 +152,15 @@ public class EC2Computer extends SlaveComputer {
      */
     public String getUptimeString() throws AmazonClientException, InterruptedException {
         return Util.getTimeSpanString(getUptime());
+    }
+
+    /**
+     * Return the time this instance was launched in ms since the epoch.
+     *
+     * @return Time this instance was launched, in ms since the epoch.
+     */
+    public long launchedAtMs() throws InterruptedException {
+        return this.describeInstance().getLaunchTime().getTime();
     }
 
     /**

--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -159,7 +159,7 @@ public class EC2Computer extends SlaveComputer {
      *
      * @return Time this instance was launched, in ms since the epoch.
      */
-    public long launchedAtMs() throws InterruptedException {
+    public long getLaunchTime() throws InterruptedException {
         return this.describeInstance().getLaunchTime().getTime();
     }
 

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -146,7 +146,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
             try {
                 state = computer.getState(); //Get State before Uptime because getState will refresh the cached EC2 info
                 uptime = computer.getUptime();
-                launchedAtMs = computer.launchedAtMs();
+                launchedAtMs = computer.getLaunchTime();
             } catch (AmazonClientException | InterruptedException e) {
                 // We'll just retry next time we test for idleness.
                 LOGGER.fine("Exception while checking host uptime for " + computer.getName()

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -140,11 +140,13 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
 
         if (computer.isIdle() && !DISABLED) {
             final long uptime;
+            final long launchedAtMs;
             InstanceState state;
 
             try {
                 state = computer.getState(); //Get State before Uptime because getState will refresh the cached EC2 info
                 uptime = computer.getUptime();
+                launchedAtMs = computer.launchedAtMs();
             } catch (AmazonClientException | InterruptedException e) {
                 // We'll just retry next time we test for idleness.
                 LOGGER.fine("Exception while checking host uptime for " + computer.getName()
@@ -190,7 +192,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                 }
             }
 
-            final long idleMilliseconds = this.clock.millis() - Math.max(computer.getIdleStartMilliseconds(), uptime);
+            final long idleMilliseconds = this.clock.millis() - Math.max(computer.getIdleStartMilliseconds(), launchedAtMs);
 
 
             if (idleTerminationMinutes > 0) {

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -190,7 +190,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                 }
             }
 
-            final long idleMilliseconds = this.clock.millis() - computer.getIdleStartMilliseconds();
+            final long idleMilliseconds = this.clock.millis() - Math.max(computer.getIdleStartMilliseconds(), uptime);
 
 
             if (idleTerminationMinutes > 0) {

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -11,12 +11,6 @@ import hudson.plugins.ec2.util.PrivateKeyHelper;
 import hudson.plugins.ec2.util.SSHCredentialHelper;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.OfflineCause;
-import jenkins.util.NonLocalizable;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LoggerRule;
-
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -26,18 +20,23 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
-
+import jenkins.util.NonLocalizable;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 
 public class EC2RetentionStrategyTest {
 
@@ -103,6 +102,7 @@ public class EC2RetentionStrategyTest {
             }
         };
         EC2Computer computer = new EC2Computer(slave) {
+            private final long launchedAtMs = new Date().getTime();
 
             @Override
             public EC2AbstractSlave getNode() {
@@ -112,6 +112,11 @@ public class EC2RetentionStrategyTest {
             @Override
             public long getUptime() throws AmazonClientException, InterruptedException {
                 return ((minutes * 60L) + seconds) * 1000L;
+            }
+
+            @Override
+            public long launchedAtMs() throws InterruptedException {
+                return this.launchedAtMs;
             }
 
             @Override

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -231,13 +231,13 @@ public class EC2RetentionStrategyTest {
 
     /**
      * Do not terminate an instance if a computer just launched, and the
-     * retention strategy timeout has not expired yet. The idle timeout
-     * is correctly accounted for nodes that have been stopped and started
+     * retention strategy timeout has not expired yet. The quirks with idle timeout
+     * are now correctly accounted for nodes that have been stopped and started
      * again (i.e termination policy is stop, rather than terminate).
      *
-     * How does the test below work: for our "mock" EC2Computer idle start time
+     * How does the test below work: for our "mock" EC2Computer, idle start time
      * is always the time when the object has been created, and we cannot
-     * easily control test in a test suite as the relevant method to override,
+     * easily control idle start time in a test suite as the relevant method to override
      * is declared final.
      *
      * We can achieve the same result where idle start time is < launch time

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -286,7 +286,7 @@ public class EC2RetentionStrategyTest {
             Clock.fixed(checkTime.plusSeconds(1), zoneId),
             checkTime.toEpochMilli()
         ).check(computerWithUpTime(-COMPUTER_UPTIME_MINUTES, 0, null, false));
-        assertThat("The computer is terminated, but should not be", idleTimeoutCalled.get(), equalTo(true));
+        assertThat("The computer is not terminated, but should be", idleTimeoutCalled.get(), equalTo(true));
         assertThat(logging.getMessages(), hasItem(containsString("offline but not connecting, will check if it should be terminated because of the idle time configured")));
     }
 

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -227,20 +227,6 @@ public class EC2RetentionStrategyTest {
         rs.check(computer2);
         assertThat("The computer is terminated, it should not accept more tasks", idleTimeoutCalled.get(), equalTo(true));
         assertThat(logging.getMessages(), hasItem(containsString("offline but not connecting, will check if it should be terminated because of the idle time configured")));
-
-        // A computer that just booted should not be terminated. Let's wait
-        // until up to termination minutes before terminating it
-        final Instant inOneMinute = Instant.now().plus(Duration.ofSeconds(60));
-        rs = new EC2RetentionStrategy(
-            "5",
-            Clock.fixed(inOneMinute.plusSeconds(1), zoneId),
-            inOneMinute.toEpochMilli()
-        );
-        final EC2Computer booting = computerWithIdleTime(0, 0, null, false);
-        // We terminate this one
-        rs.check(booting);
-        assertThat("The computer is terminated, but should not be", idleTimeoutCalled.get(), equalTo(false));
-        assertThat(logging.getMessages(), hasItem(containsString("offline but not connecting, will check if it should be terminated because of the idle time configured")));
     }
 
 

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -115,7 +115,7 @@ public class EC2RetentionStrategyTest {
             }
 
             @Override
-            public long launchedAtMs() throws InterruptedException {
+            public long getLaunchTime() throws InterruptedException {
                 return this.launchedAtMs;
             }
 


### PR DESCRIPTION
when a node just booted it is not connected, and simultaneously its idle start time could still be set to the previous time the node was booted. If the instance is checked by the plugin while in this phase, the plugin will erroneously decide to terminate it again. The change in this PR adds a safety check to ensure that idle time is calculated from the greatest of idle time as returned by jenkins or the node uptime, as returned by EC2.

Fixes: https://issues.jenkins.io/browse/JENKINS-23792

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

