### PR TITLE
Add Security Group and Subnet Filters to Counting

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -646,6 +646,18 @@ public abstract class EC2Cloud extends Cloud {
                     }
                 }
             }
+            // Add Security group filters
+            if (template.getSecurityGroupSet() != null && template.getSecurityGroupSet().size() > 0) {
+                for (String sg: template.getSecurityGroupSet()) {
+                    filters.add(new Filter("group-name").withValues(sg));
+                }
+            }
+            // Add Subnet filters
+            if (template.getSubnetId() != null && !template.getSubnetId().isEmpty()) {
+                for (String s: template.getSubnetId().split(SlaveTemplate.EC2_RESOURCE_ID_DELIMETERS)) {
+                    filters.add(new Filter("subnet-id").withValues(s));
+                }
+            }
         }
         return filters;
     }

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -17,10 +17,6 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package hudson.plugins.ec2;
-import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED;
-import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED;
-import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT;
-
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.AWSCredentialsProvider;
@@ -133,6 +129,10 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED;
+import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT;
+import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED;
+
 /**
  * Template of {@link EC2AbstractSlave} to launch.
  *
@@ -141,7 +141,7 @@ import java.util.stream.Stream;
 public class SlaveTemplate implements Describable<SlaveTemplate> {
     private static final Logger LOGGER = Logger.getLogger(SlaveTemplate.class.getName());
 
-    private static final String EC2_RESOURCE_ID_DELIMETERS = "[\\s,;]+";
+    static final String EC2_RESOURCE_ID_DELIMETERS = "[\\s,;]+";
 
     public String ami;
 
@@ -253,6 +253,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     @CheckForNull
     private List<EC2Filter> amiFilters;
+
 
     /*
      * Necessary to handle reading from old configurations. The UnixData object is created in readResolve()


### PR DESCRIPTION
When counting the number of existing instances to determine if there's capacity to create new instances for a specific slave template, there is a bug where the EC2 plugin would count EC2 instances regardless of different subnet and/or with a different security group than the ones configured for the slave template. These instances are incorrectly counted because having a existing instances with a different subnet and/or security group can have different connectivity and network permissions than desired by the slave template's configs. Adding the security group and subnet IDs filters gives us a more accurate number of existing instances that actually match all the desired configurations of the corresponding slave template.

Note that this doesn't solve incorrect counting of ALL instances (there's a separate count for all instances vs instances that match a given slave template).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
