### PR TITLE
[JENKINS-66736] win: moving exception catching to a proper place

### DIFF
--- a/src/main/java/hudson/plugins/ec2/win/WinConnection.java
+++ b/src/main/java/hudson/plugins/ec2/win/WinConnection.java
@@ -79,13 +79,7 @@ public class WinConnection {
 
     private DiskShare getSmbShare(String path) throws IOException {
         if(this.connection == null) {
-            try {
-                this.connection = smbclient.connect(host);
-            } catch (TransportException e) {
-                // JENKINS-66736: unregister and try again
-                smbclient.getServerList().unregister(host);
-                this.connection = smbclient.connect(host);
-            }
+            this.connection = smbclient.connect(host);
         }
         if(this.session == null) {
             this.session = connection.authenticate(this.authentication);
@@ -149,6 +143,9 @@ public class WinConnection {
             LOGGER.log(Level.WARNING, "Failed to verify connectivity to Windows agent", e);
             if (e instanceof SSLException) {
                 throw e;
+            } else if (e instanceof TransportException) {
+                // JENKINS-66736: unregister and try again
+                smbclient.getServerList().unregister(host);
             } else if (e.getCause() instanceof SSLException) {
                 throw (SSLException) e.getCause();
             }


### PR DESCRIPTION
The https://github.com/jenkinsci/ec2-plugin/pull/665 PR didn't fix the issue, b.c. an exception catching probably was inserted in a wrong place. 
This PR fixes the issue, windows agents spawn well now. 

- [ ] Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue