### PR TITLE
JENKINS-62939: Use latest for getting console output if Nitro

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ your user is not called ***jenkins***):
                 "ec2:CreateTags",
                 "ec2:DeleteTags",
                 "ec2:DescribeInstances",
+                "ec2:DescribeInstanceTypes",
                 "ec2:DescribeKeyPairs",
                 "ec2:DescribeRegions",
                 "ec2:DescribeImages",


### PR DESCRIPTION
Added check for if hypervisor is Nitro and if so add latest to getConsoleOutput so decrease the time for when 
console output can be parsed and ssh host key can be validated.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

