### PR TITLE
Update README to use proper constructor for UnixData

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ SlaveTemplate slaveTemplateUsEast1 = new SlaveTemplate(
   SlaveTemplateUsEast1Parameters.userData,
   SlaveTemplateUsEast1Parameters.numExecutors,
   SlaveTemplateUsEast1Parameters.remoteAdmin,
-  new UnixData(null, null, null, null),
+  new UnixData(null, null, null, null, null),
   SlaveTemplateUsEast1Parameters.jvmopts,
   SlaveTemplateUsEast1Parameters.stopOnTerminate,
   SlaveTemplateUsEast1Parameters.subnetId,


### PR DESCRIPTION
A new feature was added version 1.68 to allow for a boot delay for SSH
workers. This in turn created a breaking change in the UnixData
constructor. Updated README to follow new constructor.

New Feature PR: https://github.com/jenkinsci/ec2-plugin/pull/716

Commit change: https://github.com/jenkinsci/ec2-plugin/blob/a8abc59dd6b7c54f2c4e10ff754cf411d06bcdfc/src/main/java/hudson/plugins/ec2/UnixData.java#L24

Excerpt:
```
@DataBoundConstructor
public UnixData(String rootCommandPrefix, String slaveCommandPrefix, String slaveCommandSuffix, String sshPort, String bootDelay) {
    this.rootCommandPrefix = rootCommandPrefix;
    this.slaveCommandPrefix = slaveCommandPrefix;
    this.slaveCommandSuffix = slaveCommandSuffix;
    this.sshPort = sshPort;
    this.bootDelay = bootDelay;

    this.readResolve();
}
```
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
