### PR TITLE
chore: replace deprecated 'useAci' by 'useContainerAgent'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(useAci: true, configurations: [
+buildPlugin(useContainerAgent: true, configurations: [
     [platform: 'linux', jdk: '8'],
     //[platform: 'windows', jdk: '8'], Windows seems to be having infra issues re-add it later
     [platform: 'linux', jdk: '11'] 


### PR DESCRIPTION
Noticed the following warning in pipeline-lib checks:

> The parameter "useAci" is deprecated. Please use "useContainerAgent" instead as per https://issues.jenkins.io/browse/INFRA-2918.

<img width="909" alt="image" src="https://user-images.githubusercontent.com/91831478/185111132-2beb016e-6f34-46e8-9e21-d11d1056d1a4.png">
