### PR TITLE
Remove PowerMock

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.40</version>
+        <version>4.47</version>
         <relativePath />
     </parent>
 
@@ -69,7 +69,7 @@ THE SOFTWARE.
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
@@ -79,10 +79,7 @@ THE SOFTWARE.
         <revision>1.69</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.289.3</jenkins.version>
-        <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <mockito.version>3.12.4</mockito.version>
-        <powermock.version>2.0.9</powermock.version>
     </properties>
 
     <dependencies>
@@ -145,20 +142,8 @@ THE SOFTWARE.
             <artifactId>workflow-step-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -195,17 +180,6 @@ THE SOFTWARE.
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
             <scope>test</scope>
-            <!--
-            PCT fails on maven-enforcer-plugin:enforce
-            test-harness:1.46 puts joda-time:2.10.2
-            aws-java-sdk:1.11.821 puts 2.8.1
-            -->
-            <exclusions>
-                <exclusion>
-                    <groupId>joda-time</groupId>
-                    <artifactId>joda-time</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
@@ -239,17 +213,6 @@ THE SOFTWARE.
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>2.10.14</version>
-            </dependency>
-            <dependency>
-                <!-- fix upper bound -->
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>2.13.2</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -274,7 +237,6 @@ THE SOFTWARE.
                 <extensions>true</extensions>
                 <configuration>
                     <compatibleSinceVersion>1.45</compatibleSinceVersion>
-                    <minimumJavaVersion>8</minimumJavaVersion>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/hudson/plugins/ec2/CloudHelperTest.java
+++ b/src/test/java/hudson/plugins/ec2/CloudHelperTest.java
@@ -6,8 +6,6 @@ import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.Reservation;
-import jenkins.model.Jenkins;
-import jenkins.model.JenkinsLocationConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,11 +14,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 
 import java.util.Collections;
@@ -28,9 +23,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({JenkinsLocationConfiguration.class, CloudHelper.class, Jenkins.class, SlaveTemplate.class, DescribeInstancesResult.class, Instance.class, EC2AbstractSlave.class})
-@PowerMockIgnore({"javax.crypto.*", "org.hamcrest.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
+@RunWith(MockitoJUnitRunner.class)
 public class CloudHelperTest {
 
     @Mock
@@ -41,25 +34,23 @@ public class CloudHelperTest {
         cloud = new AmazonEC2Cloud("us-east-1", true,
                 "abc", "us-east-1", null, "ghi",
                 "3", Collections.emptyList(), "roleArn", "roleSessionName");
-
-        PowerMockito.mockStatic(Thread.class);
     }
 
     @Test
     public void testGetInstanceHappyPath() throws Exception {
         /* Mocked items */
-        EC2Cloud spyCloud = PowerMockito.spy(cloud);
-        AmazonEC2 mockEc2 = PowerMockito.mock(AmazonEC2.class);
-        DescribeInstancesResult mockedDIResult = PowerMockito.mock(DescribeInstancesResult.class);
-        Reservation mockedReservation = PowerMockito.mock(Reservation.class);
+        EC2Cloud spyCloud = Mockito.spy(cloud);
+        AmazonEC2 mockEc2 = Mockito.mock(AmazonEC2.class);
+        DescribeInstancesResult mockedDIResult = Mockito.mock(DescribeInstancesResult.class);
+        Reservation mockedReservation = Mockito.mock(Reservation.class);
         List<Reservation> reservationResults = Collections.singletonList(mockedReservation);
-        Instance mockedInstance = PowerMockito.mock(Instance.class);
+        Instance mockedInstance = Mockito.mock(Instance.class);
         List<Instance> instanceResults = Collections.singletonList(mockedInstance);
 
-        PowerMockito.doReturn(mockEc2).when(spyCloud).connect();
-        PowerMockito.doReturn(mockedDIResult).when(mockEc2).describeInstances(Mockito.any(DescribeInstancesRequest.class));
-        PowerMockito.doReturn(reservationResults).when(mockedDIResult).getReservations();
-        PowerMockito.doReturn(instanceResults).when(mockedReservation).getInstances();
+        Mockito.doReturn(mockEc2).when(spyCloud).connect();
+        Mockito.doReturn(mockedDIResult).when(mockEc2).describeInstances(Mockito.any(DescribeInstancesRequest.class));
+        Mockito.doReturn(reservationResults).when(mockedDIResult).getReservations();
+        Mockito.doReturn(instanceResults).when(mockedReservation).getInstances();
 
         /* Actual call to test*/
         Instance result = CloudHelper.getInstance("test-instance-id", spyCloud);
@@ -67,23 +58,14 @@ public class CloudHelperTest {
     }
 
     @Test
-    public void testGetInstanceWithRetryHappyPath() throws Exception {
-        Instance mockedInstance = PowerMockito.mock(Instance.class);
-        PowerMockito.stub(PowerMockito.method(CloudHelper.class, "getInstance")).toReturn(mockedInstance);
-
-        Instance result = CloudHelper.getInstanceWithRetry("test-instance-id", cloud);
-        assertEquals(mockedInstance, result);
-    }
-
-    @Test
     public void testGetInstanceWithRetryInstanceNotFound() throws Exception {
         /* Mocked items */
-        EC2Cloud spyCloud = PowerMockito.spy(cloud);
-        AmazonEC2 mockEc2 = PowerMockito.mock(AmazonEC2.class);
-        DescribeInstancesResult mockedDIResult = PowerMockito.mock(DescribeInstancesResult.class);
-        Reservation mockedReservation = PowerMockito.mock(Reservation.class);
+        EC2Cloud spyCloud = Mockito.spy(cloud);
+        AmazonEC2 mockEc2 = Mockito.mock(AmazonEC2.class);
+        DescribeInstancesResult mockedDIResult = Mockito.mock(DescribeInstancesResult.class);
+        Reservation mockedReservation = Mockito.mock(Reservation.class);
         List<Reservation> reservationResults = Collections.singletonList(mockedReservation);
-        Instance mockedInstance = PowerMockito.mock(Instance.class);
+        Instance mockedInstance = Mockito.mock(Instance.class);
         List<Instance> instanceResults = Collections.singletonList(mockedInstance);
         AmazonServiceException amazonServiceException = new AmazonServiceException("test exception");
         amazonServiceException.setErrorCode("InvalidInstanceID.NotFound");
@@ -99,10 +81,10 @@ public class CloudHelperTest {
             }
         };
 
-        PowerMockito.doReturn(mockEc2).when(spyCloud).connect();
-        PowerMockito.doAnswer(answerWithRetry).when(mockEc2).describeInstances(Mockito.any(DescribeInstancesRequest.class));
-        PowerMockito.doReturn(reservationResults).when(mockedDIResult).getReservations();
-        PowerMockito.doReturn(instanceResults).when(mockedReservation).getInstances();
+        Mockito.doReturn(mockEc2).when(spyCloud).connect();
+        Mockito.doAnswer(answerWithRetry).when(mockEc2).describeInstances(Mockito.any(DescribeInstancesRequest.class));
+        Mockito.doReturn(reservationResults).when(mockedDIResult).getReservations();
+        Mockito.doReturn(instanceResults).when(mockedReservation).getInstances();
 
         /* Actual call to test*/
         Instance result = CloudHelper.getInstanceWithRetry("test-instance-id", spyCloud);
@@ -112,12 +94,12 @@ public class CloudHelperTest {
     @Test
     public void testGetInstanceWithRetryRequestExpired() throws Exception {
         /* Mocked items */
-        EC2Cloud spyCloud = PowerMockito.spy(cloud);
-        AmazonEC2 mockEc2 = PowerMockito.mock(AmazonEC2.class);
-        DescribeInstancesResult mockedDIResult = PowerMockito.mock(DescribeInstancesResult.class);
-        Reservation mockedReservation = PowerMockito.mock(Reservation.class);
+        EC2Cloud spyCloud = Mockito.spy(cloud);
+        AmazonEC2 mockEc2 = Mockito.mock(AmazonEC2.class);
+        DescribeInstancesResult mockedDIResult = Mockito.mock(DescribeInstancesResult.class);
+        Reservation mockedReservation = Mockito.mock(Reservation.class);
         List<Reservation> reservationResults = Collections.singletonList(mockedReservation);
-        Instance mockedInstance = PowerMockito.mock(Instance.class);
+        Instance mockedInstance = Mockito.mock(Instance.class);
         List<Instance> instanceResults = Collections.singletonList(mockedInstance);
         AmazonServiceException amazonServiceException = new AmazonServiceException("test exception");
         amazonServiceException.setErrorCode("RequestExpired");
@@ -134,10 +116,10 @@ public class CloudHelperTest {
             }
         };
 
-        PowerMockito.doReturn(mockEc2).when(spyCloud).connect();
-        PowerMockito.doAnswer(answerWithRetry).when(mockEc2).describeInstances(Mockito.any(DescribeInstancesRequest.class));
-        PowerMockito.doReturn(reservationResults).when(mockedDIResult).getReservations();
-        PowerMockito.doReturn(instanceResults).when(mockedReservation).getInstances();
+        Mockito.doReturn(mockEc2).when(spyCloud).connect();
+        Mockito.doAnswer(answerWithRetry).when(mockEc2).describeInstances(Mockito.any(DescribeInstancesRequest.class));
+        Mockito.doReturn(reservationResults).when(mockedDIResult).getReservations();
+        Mockito.doReturn(instanceResults).when(mockedReservation).getInstances();
 
         /* Actual call to test*/
         Instance result = CloudHelper.getInstanceWithRetry("test-instance-id", spyCloud);

--- a/src/test/java/hudson/plugins/ec2/EC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudTest.java
@@ -5,16 +5,13 @@ import com.amazonaws.services.ec2.model.DescribeInstancesResult;
 import com.amazonaws.services.ec2.model.Instance;
 import hudson.model.Node;
 import jenkins.model.Jenkins;
-import jenkins.model.JenkinsLocationConfiguration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,9 +22,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({JenkinsLocationConfiguration.class, AmazonEC2.class, Jenkins.class, SlaveTemplate.class, DescribeInstancesResult.class, Instance.class, EC2AbstractSlave.class})
-@PowerMockIgnore({"javax.crypto.*", "org.hamcrest.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
+@RunWith(MockitoJUnitRunner.class)
 public class EC2CloudTest {
 
     @Test
@@ -36,24 +31,24 @@ public class EC2CloudTest {
         AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true,
                 "abc", "us-east-1", null, "ghi",
                 "3", Collections.emptyList(), "roleArn", "roleSessionName");
-        EC2Cloud spyCloud = PowerMockito.spy(cloud);
-        AmazonEC2 mockEc2 = PowerMockito.mock(AmazonEC2.class);
-        Jenkins mockJenkins = PowerMockito.mock(Jenkins.class);
-        EC2AbstractSlave mockOrphanNode = PowerMockito.mock(EC2AbstractSlave.class);
-        SlaveTemplate mockSlaveTemplate = PowerMockito.mock(SlaveTemplate.class);
-        DescribeInstancesResult mockedDIResult = PowerMockito.mock(DescribeInstancesResult.class);
-        Instance mockedInstance = PowerMockito.mock(Instance.class);
+        EC2Cloud spyCloud = Mockito.spy(cloud);
+        AmazonEC2 mockEc2 = Mockito.mock(AmazonEC2.class);
+        Jenkins mockJenkins = Mockito.mock(Jenkins.class);
+        EC2AbstractSlave mockOrphanNode = Mockito.mock(EC2AbstractSlave.class);
+        SlaveTemplate mockSlaveTemplate = Mockito.mock(SlaveTemplate.class);
+        DescribeInstancesResult mockedDIResult = Mockito.mock(DescribeInstancesResult.class);
+        Instance mockedInstance = Mockito.mock(Instance.class);
         List<Instance> listOfMockedInstances = new ArrayList<>();
         listOfMockedInstances.add(mockedInstance);
 
 
-        PowerMockito.mockStatic(Jenkins.class);
-        Mockito.when(Jenkins.getInstanceOrNull()).thenReturn(mockJenkins);
+        try (MockedStatic<Jenkins> mocked = Mockito.mockStatic(Jenkins.class)) {
+        mocked.when(Jenkins::getInstanceOrNull).thenReturn(mockJenkins);
         EC2AbstractSlave[] orphanNodes = {mockOrphanNode};
-        PowerMockito.doReturn(Arrays.asList(orphanNodes)).when(mockSlaveTemplate).toSlaves(eq(listOfMockedInstances));
+        Mockito.doReturn(Arrays.asList(orphanNodes)).when(mockSlaveTemplate).toSlaves(eq(listOfMockedInstances));
         List<Node> listOfJenkinsNodes = new ArrayList<>();
 
-        PowerMockito.doAnswer(new Answer<Void>() {
+        Mockito.doAnswer(new Answer<Void>() {
             public Void answer(InvocationOnMock invocation) {
                 Node n = (Node) invocation.getArguments()[0];
                 listOfJenkinsNodes.add(n);
@@ -61,12 +56,12 @@ public class EC2CloudTest {
             }
         }).when(mockJenkins).addNode(Mockito.any(Node.class));
 
-        PowerMockito.doReturn(null).when(mockOrphanNode).toComputer();
-        PowerMockito.doReturn(false).when(mockOrphanNode).getStopOnTerminate();
-        PowerMockito.doReturn(mockEc2).when(spyCloud).connect();
-        PowerMockito.doReturn(mockedDIResult).when(mockSlaveTemplate).getDescribeInstanceResult(Mockito.any(AmazonEC2.class), eq(true));
-        PowerMockito.doReturn(listOfMockedInstances).when(mockSlaveTemplate).findOrphansOrStopped(eq(mockedDIResult), Mockito.anyInt());
-        PowerMockito.doNothing().when(mockSlaveTemplate).wakeOrphansOrStoppedUp(Mockito.any(AmazonEC2.class), eq(listOfMockedInstances));
+        Mockito.doReturn(null).when(mockOrphanNode).toComputer();
+        Mockito.doReturn(false).when(mockOrphanNode).getStopOnTerminate();
+        Mockito.doReturn(mockEc2).when(spyCloud).connect();
+        Mockito.doReturn(mockedDIResult).when(mockSlaveTemplate).getDescribeInstanceResult(Mockito.any(AmazonEC2.class), eq(true));
+        Mockito.doReturn(listOfMockedInstances).when(mockSlaveTemplate).findOrphansOrStopped(eq(mockedDIResult), Mockito.anyInt());
+        Mockito.doNothing().when(mockSlaveTemplate).wakeOrphansOrStoppedUp(Mockito.any(AmazonEC2.class), eq(listOfMockedInstances));
 
         /* Actual call to test*/
         spyCloud.attemptReattachOrphanOrStoppedNodes(mockJenkins, mockSlaveTemplate, 1);
@@ -75,5 +70,6 @@ public class EC2CloudTest {
         Mockito.verify(mockSlaveTemplate, times(1)).wakeOrphansOrStoppedUp(Mockito.any(AmazonEC2.class), eq(listOfMockedInstances));
         Node[] expectedNodes = {mockOrphanNode};
         assertArrayEquals(expectedNodes, listOfJenkinsNodes.toArray());
+        }
     }
 }

--- a/src/test/java/hudson/plugins/ec2/EC2StepTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2StepTest.java
@@ -15,9 +15,7 @@ import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Mock;
 import org.mockito.internal.stubbing.answers.ThrowsException;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,9 +32,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Alicia Doblas
  */
-@PowerMockIgnore({"javax.crypto.*", "org.hamcrest.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({EC2AbstractSlave.class, SlaveTemplate.class})
+@RunWith(MockitoJUnitRunner.class)
 public class EC2StepTest {
     @Rule
     public JenkinsRule r = new JenkinsRule();


### PR DESCRIPTION
Without this PR, running the test suite with `jenkins.version` set to the latest weekly fails with:

```
java.lang.IllegalArgumentException: org.kohsuke.stapler.ClassLoaderValue$X referenced from a method is not visible from class loader
        at java.base/java.lang.reflect.Proxy$ProxyBuilder.ensureVisible(Proxy.java:858)
        at java.base/java.lang.reflect.Proxy$ProxyBuilder.validateProxyInterfaces(Proxy.java:681)
        at java.base/java.lang.reflect.Proxy$ProxyBuilder.<init>(Proxy.java:627)
        at java.base/java.lang.reflect.Proxy$ProxyBuilder.<init>(Proxy.java:635)
        at java.base/java.lang.reflect.Proxy.lambda$getProxyConstructor$0(Proxy.java:415)
        at java.base/jdk.internal.loader.AbstractClassLoaderValue$Memoizer.get(AbstractClassLoaderValue.java:329)
        at java.base/jdk.internal.loader.AbstractClassLoaderValue.computeIfAbsent(AbstractClassLoaderValue.java:205)
        at java.base/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:413)
        at java.base/java.lang.reflect.Proxy.getProxyClass(Proxy.java:384)
        at org.kohsuke.stapler.ClassLoaderValue.get(ClassLoaderValue.java:55)
        at org.kohsuke.stapler.MetaClassLoader.get(MetaClassLoader.java:53)
        at org.kohsuke.stapler.MetaClassLoader.<init>(MetaClassLoader.java:46)
        at org.jvnet.hudson.test.JenkinsRule.<clinit>(JenkinsRule.java:2878)
        ... 30 more
```

CC @res0nance