### PR TITLE
Ensure that IMDSv2 Configuration Option is set to `true` by default

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -77,7 +77,7 @@ import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 @SuppressWarnings("serial")
 public abstract class EC2AbstractSlave extends Slave {
     public static final Boolean DEFAULT_METADATA_ENDPOINT_ENABLED = Boolean.TRUE;
-    public static final Boolean DEFAULT_METADATA_TOKENS_REQUIRED = Boolean.FALSE;
+    public static final Boolean DEFAULT_METADATA_TOKENS_REQUIRED = Boolean.TRUE;
     public static final Integer DEFAULT_METADATA_HOPS_LIMIT = 1;
     public static final String DEFAULT_JAVA_PATH = "java";
 

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -490,7 +490,7 @@ public class SlaveTemplateTest {
         RunInstancesRequest actualRequest = riRequestCaptor.getValue();
         InstanceMetadataOptionsRequest metadataOptionsRequest = actualRequest.getMetadataOptions();
         assertEquals(metadataOptionsRequest.getHttpEndpoint(), InstanceMetadataEndpointState.Enabled.toString());
-        assertEquals(metadataOptionsRequest.getHttpTokens(), HttpTokensState.Optional.toString());
+        assertEquals(metadataOptionsRequest.getHttpTokens(), HttpTokensState.Required.toString());
         assertEquals(metadataOptionsRequest.getHttpPutResponseHopLimit(), Integer.valueOf(1));
     }
 

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -459,6 +459,24 @@ public class SlaveTemplateTest {
     }
 
     @Test
+    public void provisionOnDemandSetsMetadataV1Options() throws Exception {
+        SlaveTemplate template = new  SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", true, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, true, false, 2);
+
+        AmazonEC2 mockedEC2 = setupTestForProvisioning(template);
+
+        ArgumentCaptor<RunInstancesRequest> riRequestCaptor = ArgumentCaptor.forClass(RunInstancesRequest.class);
+
+        template.provision(2, EnumSet.noneOf(ProvisionOptions.class));
+        verify(mockedEC2).runInstances(riRequestCaptor.capture());
+
+        RunInstancesRequest actualRequest = riRequestCaptor.getValue();
+        InstanceMetadataOptionsRequest metadataOptionsRequest = actualRequest.getMetadataOptions();
+        assertEquals(metadataOptionsRequest.getHttpEndpoint(), InstanceMetadataEndpointState.Enabled.toString());
+        assertEquals(metadataOptionsRequest.getHttpTokens(), HttpTokensState.Optional.toString());
+        assertEquals(metadataOptionsRequest.getHttpPutResponseHopLimit(), Integer.valueOf(2));
+    }
+
+    @Test
     public void provisionOnDemandSetsMetadataV2Options() throws Exception {
         SlaveTemplate template = new  SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", true, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, true, true, 2);
 

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -478,7 +478,7 @@ public class SlaveTemplateTest {
 
     @Test
     public void provisionOnDemandSetsMetadataDefaultOptions() throws Exception {
-        SlaveTemplate template = new  SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", true, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, null, null, null);
+        SlaveTemplate template = new  SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", true, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, null, true, null);
 
         AmazonEC2 mockedEC2 = setupTestForProvisioning(template);
 

--- a/src/test/resources/hudson/plugins/ec2/MacDataExport.yml
+++ b/src/test/resources/hudson/plugins/ec2/MacDataExport.yml
@@ -23,7 +23,7 @@
       maxTotalUses: -1
       metadataEndpointEnabled: true
       metadataHopsLimit: 1
-      metadataTokensRequired: false
+      metadataTokensRequired: true
       minimumNumberOfInstances: 0
       minimumNumberOfSpareInstances: 0
       mode: NORMAL

--- a/src/test/resources/hudson/plugins/ec2/UnixDataExport-withAltEndpointAndJavaPath.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixDataExport-withAltEndpointAndJavaPath.yml
@@ -23,7 +23,7 @@
       maxTotalUses: -1
       metadataEndpointEnabled: true
       metadataHopsLimit: 1
-      metadataTokensRequired: false
+      metadataTokensRequired: true
       minimumNumberOfInstances: 0
       minimumNumberOfSpareInstances: 0
       mode: NORMAL

--- a/src/test/resources/hudson/plugins/ec2/UnixDataExport.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixDataExport.yml
@@ -23,7 +23,7 @@
       maxTotalUses: -1
       metadataEndpointEnabled: true
       metadataHopsLimit: 1
-      metadataTokensRequired: false
+      metadataTokensRequired: true
       minimumNumberOfInstances: 0
       minimumNumberOfSpareInstances: 0
       mode: NORMAL


### PR DESCRIPTION
# Background
This PR properly builds upon part of the aim of https://github.com/jenkinsci/ec2-plugin/pull/748. I had had an issue (my issue, unrelated to the plugin) locally building and installing the plugin to test that the default value of `metadataTokensRequired` was set to true by default. After the release of `2.x.x` of the plugin was released, I upgraded the EC2 plugin on my own Jenkins controller and saw that value of still false by default.

_This screencast shows the current behavior, using ec2 plugin 2.0.2_
https://user-images.githubusercontent.com/18095335/189275546-3d3895d2-ffdd-47af-b773-3377aeec49bf.mov

- As a result, I'm creating this follow up PR, which I have been able to successfully build, install on a Jenkins controller, and verify that `metadataTokensRequired` is checked by default (seen screencast below).
- I've also updated the tests accordingly and added a test to capture the use case of someone wanting to opt out of IMDSv2, using IMDSv1.

_This screencast shows what will be the new behavior, using a locally generated ec2 plugin with the PR's changes_
https://user-images.githubusercontent.com/18095335/189274511-7803f5cc-fa99-4b56-ab3d-31174ed41593.mov

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
