### PR TITLE
JENKINS-69581: Install java-11-openjdk

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -236,7 +236,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
 
             // TODO: parse the version number. maven-enforcer-plugin might help
             final String javaPath = node.javaPath;
-            executeRemote(computer, conn, javaPath + " -fullversion", "sudo yum install -y java-1.8.0-openjdk.x86_64", logger, listener);
+            executeRemote(computer, conn, javaPath + " -fullversion", "sudo amazon-linux-extras install java-openjdk11 -y; sudo yum install -y fontconfig java-11-openjdk", logger, listener);
             executeRemote(computer, conn, "which scp", "sudo yum install -y openssh-clients", logger, listener);
 
             // Always copy so we get the most recent remoting.jar


### PR DESCRIPTION
If Jenkins recieves a non-zero error code when runing `java -fullversion` on the remote agent then it will install java 11 using yum.

Previously this installed java 8 which is no longer supported on Jenkins agents where the controller is running version 2.361.x or higher.

This issue is discussed further in [JENKINS-69581](https://issues.jenkins.io/browse/JENKINS-69581)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
