### PR TITLE
Add support for EC2 Placement Host Resource Group Arn parameter [JENKINS-66901]

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ def slaveTemplateUsEast1Parameters = [
   connectionStrategy:            ConnectionStrategy.valueOf('PRIVATE_IP'),
   hostKeyVerificationStrategy:   HostKeyVerificationStrategyEnum.valueOf('CHECK_NEW_HARD'),
   tenancy:                       Tenancy.valueOf('Default'),
+  hostResourceGroupArn:          null,
   ebsEncryptRootVolume:          EbsEncryptRootVolume.valueOf('ENCRYPTED'),
   nodeProperties:                null
 ]
@@ -443,6 +444,7 @@ SlaveTemplate slaveTemplateUsEast1 = new SlaveTemplate(
   slaveTemplateUsEast1Parameters.nodeProperties,
   slaveTemplateUsEast1Parameters.hostKeyVerificationStrategy,
   slaveTemplateUsEast1Parameters.tenancy,
+  slaveTemplateUsEast1Parameters.hostResourceGroupArn,
   slaveTemplateUsEast1Parameters.ebsEncryptRootVolume,
   slaveTemplateUsEast1Parameters.metadataEndpointEnabled,
   slaveTemplateUsEast1Parameters.metadataTokensRequired,

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -109,6 +109,7 @@ public abstract class EC2AbstractSlave extends Slave {
     public AMITypeData amiType;
     public int maxTotalUses;
     public final Tenancy tenancy;
+    public final String hostResourceGroupArn;
     private String instanceType;
 
     private Boolean metadataEndpointEnabled;
@@ -156,7 +157,7 @@ public abstract class EC2AbstractSlave extends Slave {
     public static final String TEST_ZONE = "testZone";
 
     public EC2AbstractSlave(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy<EC2Computer> retentionStrategy, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, Tenancy tenancy,
-                            Boolean metadataEndpointEnabled, Boolean metadataTokensRequired, Integer metadataHopsLimit)
+                            String hostResourceGroupArn, Boolean metadataEndpointEnabled, Boolean metadataTokensRequired, Integer metadataHopsLimit)
             throws FormException, IOException {
         super(name, remoteFS, launcher);
         setNumExecutors(numExecutors);
@@ -182,10 +183,17 @@ public abstract class EC2AbstractSlave extends Slave {
         this.amiType = amiType;
         this.maxTotalUses = maxTotalUses;
         this.tenancy = tenancy != null ? tenancy : Tenancy.Default;
+        this.hostResourceGroupArn = hostResourceGroupArn;
         this.metadataEndpointEnabled = metadataEndpointEnabled;
         this.metadataTokensRequired = metadataTokensRequired;
         this.metadataHopsLimit = metadataHopsLimit;
         readResolve();
+    }
+
+    @Deprecated
+    public EC2AbstractSlave(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy<EC2Computer> retentionStrategy, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, Tenancy tenancy, Boolean metadataEndpointEnabled, Boolean metadataTokensRequired, Integer metadataHopsLimit)
+            throws FormException, IOException {
+        this(name, instanceId, templateDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, initScript, tmpDir, nodeProperties, remoteAdmin, javaPath, jvmopts, stopOnTerminate, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, tenancy, null, metadataEndpointEnabled, metadataTokensRequired, metadataHopsLimit);
     }
 
     @Deprecated

--- a/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
@@ -65,13 +65,20 @@ public class EC2OndemandSlave extends EC2AbstractSlave {
          this(name, instanceId, templateDescription, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, nodeProperties, remoteAdmin, DEFAULT_JAVA_PATH, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, tenancy, DEFAULT_METADATA_ENDPOINT_ENABLED, DEFAULT_METADATA_TOKENS_REQUIRED, DEFAULT_METADATA_HOPS_LIMIT);
     }
 
-    @DataBoundConstructor
+    @Deprecated
     public EC2OndemandSlave(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, Tenancy tenancy,
                             Boolean metadataEndpointEnabled, Boolean metadataTokensRequired, Integer metadataHopsLimit)
             throws FormException, IOException {
+        this(name, instanceId, templateDescription, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, nodeProperties, remoteAdmin, javaPath, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, tenancy, null, metadataEndpointEnabled, metadataTokensRequired, metadataHopsLimit);
+    }
+
+    @DataBoundConstructor
+    public EC2OndemandSlave(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, Tenancy tenancy,
+                            String hostResourceGroupArn, Boolean metadataEndpointEnabled, Boolean metadataTokensRequired, Integer metadataHopsLimit)
+            throws FormException, IOException {
 
         super(name, instanceId, templateDescription, remoteFS, numExecutors, mode, labelString, (amiType.isWindows() ? new EC2WindowsLauncher() : (amiType.isMac() ? new EC2MacLauncher():
-                new EC2UnixLauncher())), new EC2RetentionStrategy(idleTerminationMinutes), initScript, tmpDir, nodeProperties, remoteAdmin, javaPath, jvmopts, stopOnTerminate, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, tenancy, metadataEndpointEnabled, metadataTokensRequired, metadataHopsLimit);
+                new EC2UnixLauncher())), new EC2RetentionStrategy(idleTerminationMinutes), initScript, tmpDir, nodeProperties, remoteAdmin, javaPath, jvmopts, stopOnTerminate, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, tenancy, hostResourceGroupArn, metadataEndpointEnabled, metadataTokensRequired, metadataHopsLimit);
 
         this.publicDNS = publicDNS;
         this.privateDNS = privateDNS;

--- a/src/main/java/hudson/plugins/ec2/util/EC2AgentConfig.java
+++ b/src/main/java/hudson/plugins/ec2/util/EC2AgentConfig.java
@@ -60,6 +60,7 @@ public abstract class EC2AgentConfig {
         final String publicDNS;
         final String privateDNS;
         final Tenancy tenancy;
+        final String hostResourceGroupArn;
         @Deprecated
         final boolean useDedicatedTenancy;
         final Boolean metadataEndpointEnabled;
@@ -73,6 +74,7 @@ public abstract class EC2AgentConfig {
             this.publicDNS = builder.getPublicDNS();
             this.privateDNS = builder.getPrivateDNS();
             this.tenancy = builder.getTenancyAttribute();
+            this.hostResourceGroupArn = builder.getHostResourceGroupArn();
             this.useDedicatedTenancy = builder.isUseDedicatedTenancy();
             this.metadataHopsLimit = builder.metadataHopsLimit;
             this.metadataEndpointEnabled = builder.metadataEndpointEnabled;
@@ -223,6 +225,7 @@ public abstract class EC2AgentConfig {
         private String publicDNS;
         private String privateDNS;
         private Tenancy tenancy;
+        private String hostResourceGroupArn;
         @Deprecated
         private boolean useDedicatedTenancy;
         private Boolean metadataEndpointEnabled;
@@ -282,6 +285,15 @@ public abstract class EC2AgentConfig {
         }
 
         public Tenancy getTenancyAttribute(){ return tenancy;}
+
+        public OnDemandBuilder withHostResourceGroupArn(String hostResourceGroupArn) {
+            this.hostResourceGroupArn = hostResourceGroupArn;
+            return this;
+        }
+
+        public String getHostResourceGroupArn() {
+            return this.hostResourceGroupArn;
+        }
 
         public OnDemandBuilder withMetadataEndpointEnabled(Boolean metadataEndpointEnabled) {
             this.metadataEndpointEnabled = metadataEndpointEnabled;

--- a/src/main/java/hudson/plugins/ec2/util/EC2AgentFactoryImpl.java
+++ b/src/main/java/hudson/plugins/ec2/util/EC2AgentFactoryImpl.java
@@ -12,7 +12,7 @@ public class EC2AgentFactoryImpl implements EC2AgentFactory {
     @Override
     public EC2OndemandSlave createOnDemandAgent(EC2AgentConfig.OnDemand config)
             throws Descriptor.FormException, IOException {
-        return new EC2OndemandSlave(config.name, config.instanceId, config.description, config.remoteFS, config.numExecutors, config.labelString, config.mode, config.initScript, config.tmpDir, config.nodeProperties, config.remoteAdmin, config.javaPath, config.jvmopts, config.stopOnTerminate, config.idleTerminationMinutes, config.publicDNS, config.privateDNS, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses, config.tenancy, config.metadataEndpointEnabled, config.metadataTokensRequired, config.metadataHopsLimit);
+        return new EC2OndemandSlave(config.name, config.instanceId, config.description, config.remoteFS, config.numExecutors, config.labelString, config.mode, config.initScript, config.tmpDir, config.nodeProperties, config.remoteAdmin, config.javaPath, config.jvmopts, config.stopOnTerminate, config.idleTerminationMinutes, config.publicDNS, config.privateDNS, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses, config.tenancy, config.hostResourceGroupArn, config.metadataEndpointEnabled, config.metadataTokensRequired, config.metadataHopsLimit);
     }
 
     @Override

--- a/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly
@@ -54,11 +54,11 @@ THE SOFTWARE.
         <f:entry title="${%Instance ID}" field="instanceId">
           <f:readOnlyTextbox />
         </f:entry>
-        
+
         <f:entry title="${%EC2 Type}" field="ec2Type">
           <f:readOnlyTextbox />
         </f:entry>
-        
+
         <f:entry title="${%Uptime}">
           <f:readOnlyTextbox value="${it.uptimeString}"/>
         </f:entry>
@@ -78,7 +78,7 @@ THE SOFTWARE.
         <f:entry title="${%# of executors}" field="numExecutors">
           <f:textbox />
         </f:entry>
-                
+
         <f:entry title="${%Labels}" field="labelString">
           <f:textbox />
         </f:entry>
@@ -96,7 +96,7 @@ THE SOFTWARE.
         <f:entry title="${%Remote user}" field="remoteAdmin">
           <f:textbox />
         </f:entry>
-        
+
 	    <f:entry title="${%Stop/Disconnect on Idle Timeout}" field="stopOnTerminate">
     	  <f:checkbox />
     	</f:entry>
@@ -115,9 +115,13 @@ THE SOFTWARE.
 	    <f:entry title="${%Use private DNS}" field="usePrivateDnsName">
     	  <f:checkbox />
     	</f:entry>
-    	
+
     	<f:entry title="${%Tenancy}" field="tenancy">
             <f:enum>${it.name()}</f:enum>
+        </f:entry>
+
+    	<f:entry title="${%Host Resource Group ARN}" field="hostResourceGroupArn">
+            <f:textbox />
         </f:entry>
 
         <f:dropdownList name="amiType" title="${%AMI Type}">

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -209,6 +209,10 @@ THE SOFTWARE.
         <f:enum>${it.name()}</f:enum>
     </f:entry>
 
+    <f:entry title="${%Host Resource Group ARN}" field="hostResourceGroupArn">
+        <f:textbox />
+    </f:entry>
+
     <f:entry title="${%Connection Strategy}" field="connectionStrategy">
       <f:select default="${descriptor.getDefaultConnectionStrategy()}"/>
     </f:entry>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-hostResourceGroupArn.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-hostResourceGroupArn.html
@@ -1,0 +1,4 @@
+<div>
+    The ARN of the host resource group in which to launch the instances.
+    If you specify a host resource group ARN, set Tenancy parameter to host.
+</div>

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -101,7 +101,7 @@ public class SlaveTemplateTest {
 
         r.submit(r.createWebClient().goTo("configureClouds").getFormByName("config"));
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
-        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,javaPath,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,iamInstanceProfile,useEphemeralDevices,useDedicatedTenancy,connectionStrategy,hostKeyVerificationStrategy,tenancy,ebsEncryptRootVolume");
+        r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,javaPath,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,iamInstanceProfile,useEphemeralDevices,useDedicatedTenancy,connectionStrategy,hostKeyVerificationStrategy,tenancy,hostResourceGroupArn,ebsEncryptRootVolume");
         // For already existing strategies, the default is this one
         assertEquals(HostKeyVerificationStrategyEnum.CHECK_NEW_SOFT, received.getHostKeyVerificationStrategy());
     }

--- a/src/test/java/hudson/plugins/ec2/util/EC2AgentFactoryMockImpl.java
+++ b/src/test/java/hudson/plugins/ec2/util/EC2AgentFactoryMockImpl.java
@@ -49,7 +49,7 @@ public class EC2AgentFactoryMockImpl implements EC2AgentFactory {
                                      AMITypeData amiType, ConnectionStrategy connectionStrategy,
                                      int maxTotalUses, Tenancy tenancy)
                 throws Descriptor.FormException, IOException {
-            super(name, instanceId, description, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, nodeProperties, remoteAdmin, javaPath, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, tenancy, DEFAULT_METADATA_ENDPOINT_ENABLED, DEFAULT_METADATA_TOKENS_REQUIRED, DEFAULT_METADATA_HOPS_LIMIT);
+            super(name, instanceId, description, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, nodeProperties, remoteAdmin, javaPath, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, tenancy, null, DEFAULT_METADATA_ENDPOINT_ENABLED, DEFAULT_METADATA_TOKENS_REQUIRED, DEFAULT_METADATA_HOPS_LIMIT);
         }
 
         @Override

--- a/src/test/resources/hudson/plugins/ec2/MacDataExport.yml
+++ b/src/test/resources/hudson/plugins/ec2/MacDataExport.yml
@@ -33,6 +33,7 @@
       stopOnTerminate: false
       t2Unlimited: false
       tenancy: Host
+      hostResourceGroupArn: null
       type: Mac1Metal
       useEphemeralDevices: false
     useInstanceProfileForCredentials: true

--- a/src/test/resources/hudson/plugins/ec2/UnixDataExport-withAltEndpointAndJavaPath.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixDataExport-withAltEndpointAndJavaPath.yml
@@ -38,6 +38,7 @@
       stopOnTerminate: false
       t2Unlimited: false
       tenancy: Default
+      hostResourceGroupArn: null
       type: T2Micro
       useEphemeralDevices: false
     useInstanceProfileForCredentials: true

--- a/src/test/resources/hudson/plugins/ec2/UnixDataExport.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixDataExport.yml
@@ -38,6 +38,7 @@
       stopOnTerminate: false
       t2Unlimited: false
       tenancy: Default
+      hostResourceGroupArn: null
       type: T2Micro
       useEphemeralDevices: false
     useInstanceProfileForCredentials: true


### PR DESCRIPTION
Implemented JENKINS-66901 parameter to set host resource group, to be used to dynamically allocate and release dedicated hosts, in particular for Mac instances.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

I have manually tested the change works to successfully launch Mac instances, with or without host resource group set. I was not able to run the tests in my local environment and not sure how this could be meaningfully unit tested.

This is authored by me and copyright my employer WithSecure Corporation and I have permission to contribute it to the project under original license.