### PR TITLE
Add getters for IMDSv2 metadata fields

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -773,6 +773,18 @@ public abstract class EC2AbstractSlave extends Slave {
         return amiType.getBootDelayInMillis();
     }
 
+    public Boolean getMetadataEndpointEnabled() {
+      return metadataEndpointEnabled;
+    }
+
+    public Boolean getMetadataTokensRequired() {
+        return metadataTokensRequired;
+    }
+
+    public Integer getMetadataHopsLimit() {
+        return metadataHopsLimit;
+    }
+
     public boolean isSpecifyPassword() {
         return amiType.isWindows() && ((WindowsData) amiType).isSpecifyPassword();
     }


### PR DESCRIPTION
Currently, in the configuration page for a node it incorrectly always displays the default values for these 3 fields, which can be really confusing.  Getters are required so that these private fields appear correctly in this template https://github.com/jenkinsci/ec2-plugin/blob/master/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly#L142.



- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
