### PR TITLE
Use `Cloud#getUrl` in /provision URL

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/computerSet.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/computerSet.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
     <tr>
       <td />
       <td colspan="${monitors.size()+1}">
-        <f:form action="${rootURL}/cloud/${it.name}/provision" method="post" name="provision">
+        <f:form action="${rootURL}/${it.url}/provision" method="post" name="provision">
           <input type="submit" class="ec2-provision-button" value="${%Provision via} ${it.displayName}" />
           <select name="template">
             <j:forEach var="t" items="${it.templates}">


### PR DESCRIPTION
Follow up of https://github.com/jenkinsci/jenkins/pull/7573.

This has no effect on older versions of Jenkins. On newer versions of Jenkins this prevents a bug that I've briefly described in the PR linked above.