### PR TITLE
Adding rosetta terminal support for mac2.metal instance type

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
@@ -227,7 +227,7 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
                 Instance nodeInstance = computer.describeInstance();
                 if (nodeInstance.getInstanceType().equals("mac2.metal")) {
                     LOGGER.info("Running Command for mac2.metal");
-                    executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg; sudo softwareupdate --install-rosetta --agree-to-license; sudo installer -pkg amazon-corretto-8-x64-macos-jdk.pkg -target /", logger, listener);
+                    executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-8-aarch64-macos-jdk.pkg; sudo installer -pkg amazon-corretto-8-aarch64-macos-jdk.pkg -target /", logger, listener);
                 }
                 else{
                     executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg; sudo installer -pkg amazon-corretto-8-x64-macos-jdk.pkg -target /", logger, listener);

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
@@ -227,7 +227,7 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
                 Instance nodeInstance = computer.describeInstance();
                 if (nodeInstance.getInstanceType().equals("mac2.metal")) {
                     LOGGER.info("Running Command for mac2.metal");
-                    executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-8-aarch64-macos-jdk.pkg; sudo installer -pkg amazon-corretto-8-aarch64-macos-jdk.pkg -target /", logger, listener);
+                    executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-11-aarch64-macos-jdk.pkg; sudo installer -pkg amazon-corretto-8-aarch64-macos-jdk.pkg -target /", logger, listener);
                 }
                 else{
                     executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg; sudo installer -pkg amazon-corretto-8-x64-macos-jdk.pkg -target /", logger, listener);

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
@@ -223,7 +223,18 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
 
             // TODO: parse the version number. maven-enforcer-plugin might help
             final String javaPath = node.javaPath;
-            executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg; sudo installer -pkg amazon-corretto-8-x64-macos-jdk.pkg -target /", logger, listener);
+            try {
+                Instance nodeInstance = computer.describeInstance();
+                if (nodeInstance.getInstanceType().equals("mac2.metal")) {
+                    LOGGER.info("Running Command for mac2.metal");
+                    executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg; sudo softwareupdate --install-rosetta --agree-to-license; sudo installer -pkg amazon-corretto-8-x64-macos-jdk.pkg -target /", logger, listener);
+                }
+                else{
+                    executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg; sudo installer -pkg amazon-corretto-8-x64-macos-jdk.pkg -target /", logger, listener);
+                }
+            } catch (InterruptedException ex) {
+                LOGGER.warning(ex.getMessage());
+            }
 
             // Always copy so we get the most recent remoting.jar
             logInfo(computer, listener, "Copying remoting.jar to: " + tmpDir);

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
@@ -227,10 +227,10 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
                 Instance nodeInstance = computer.describeInstance();
                 if (nodeInstance.getInstanceType().equals("mac2.metal")) {
                     LOGGER.info("Running Command for mac2.metal");
-                    executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-11-aarch64-macos-jdk.pkg; sudo installer -pkg amazon-corretto-8-aarch64-macos-jdk.pkg -target /", logger, listener);
+                    executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-11-aarch64-macos-jdk.pkg; sudo installer -pkg amazon-corretto-11-aarch64-macos-jdk.pkg -target /", logger, listener);
                 }
                 else{
-                    executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg; sudo installer -pkg amazon-corretto-8-x64-macos-jdk.pkg -target /", logger, listener);
+                    executeRemote(computer, conn, javaPath + " -fullversion", "curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.pkg; sudo installer -pkg amazon-corretto-11-x64-macos-jdk.pkg -target /", logger, listener);
                 }
             } catch (InterruptedException ex) {
                 LOGGER.warning(ex.getMessage());


### PR DESCRIPTION
To install the java to mac2.metal instance type , we will need to install the rosetta terminal so that the java can be install once the system is booted up.

We added the condition where if the current computer instance type is mac2.metal then only install the rosetta terminal.