### PR TITLE
Adds support for custom name for Eucalyptus. Also fixes roundtrip for ec2Endpoint and s3Endpoint

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -49,6 +49,7 @@ import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ProxyConfiguration;
+import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.ItemGroup;
@@ -176,8 +177,8 @@ public abstract class EC2Cloud extends Cloud {
         this.useInstanceProfileForCredentials = useInstanceProfileForCredentials;
         this.roleArn = roleArn;
         this.roleSessionName = roleSessionName;
-        this.credentialsId = credentialsId;
-        this.sshKeysCredentialsId = sshKeysCredentialsId;
+        this.credentialsId = Util.fixEmpty(credentialsId);
+        this.sshKeysCredentialsId = Util.fixEmpty(sshKeysCredentialsId);
 
         if (templates == null) {
             this.templates = Collections.emptyList();

--- a/src/main/java/hudson/plugins/ec2/Eucalyptus.java
+++ b/src/main/java/hudson/plugins/ec2/Eucalyptus.java
@@ -48,19 +48,22 @@ public class Eucalyptus extends EC2Cloud {
     private final URL s3endpoint;
 
     @DataBoundConstructor
-    public Eucalyptus(URL ec2endpoint, URL s3endpoint, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String sshKeysCredentialsId, String instanceCapStr, List<SlaveTemplate> templates, String roleArn, String roleSessionName)
-            throws IOException {
-        super("eucalyptus", useInstanceProfileForCredentials, credentialsId, privateKey, sshKeysCredentialsId, instanceCapStr, templates, roleArn, roleSessionName);
-        this.ec2endpoint = ec2endpoint;
-        this.s3endpoint = s3endpoint;
+    public Eucalyptus(String name, URL ec2EndpointUrl, URL s3EndpointUrl, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String sshKeysCredentialsId, String instanceCapStr, List<SlaveTemplate> templates, String roleArn, String roleSessionName) {
+        super(name, useInstanceProfileForCredentials, credentialsId, privateKey, sshKeysCredentialsId, instanceCapStr, templates, roleArn, roleSessionName);
+        this.ec2endpoint = ec2EndpointUrl;
+        this.s3endpoint = s3EndpointUrl;
     }
 
     @Deprecated
-    public Eucalyptus(URL ec2endpoint, URL s3endpoint, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String instanceCapStr, List<SlaveTemplate> templates, String roleArn, String roleSessionName)
+    public Eucalyptus(URL ec2EndpointUrl, URL s3EndpointUrl, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String sshKeysCredentialsId, String instanceCapStr, List<SlaveTemplate> templates, String roleArn, String roleSessionName)
             throws IOException {
-        super("eucalyptus", useInstanceProfileForCredentials, credentialsId, privateKey, instanceCapStr, templates, roleArn, roleSessionName);
-        this.ec2endpoint = ec2endpoint;
-        this.s3endpoint = s3endpoint;
+        this("eucalyptus", ec2EndpointUrl, s3EndpointUrl, useInstanceProfileForCredentials, credentialsId, privateKey, sshKeysCredentialsId, instanceCapStr, templates, roleArn, roleSessionName);
+    }
+
+    @Deprecated
+    public Eucalyptus(URL ec2EndpointUrl, URL s3EndpointUrl, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String instanceCapStr, List<SlaveTemplate> templates, String roleArn, String roleSessionName)
+            throws IOException {
+        this("eucalyptus", ec2EndpointUrl, s3EndpointUrl, useInstanceProfileForCredentials, credentialsId, privateKey, null, instanceCapStr, templates, roleArn, roleSessionName);
     }
 
     @Override

--- a/src/main/resources/hudson/plugins/ec2/Eucalyptus/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/Eucalyptus/config-entries.jelly
@@ -19,10 +19,13 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-  <f:entry title="${%Eucalyptus EC2 URL}" field="ec2endpoint">
+  <f:entry title="${%Name}" field="name">
     <f:textbox />
   </f:entry>
-  <f:entry title="${%Eucalyptus S3 URL}" field="s3endpoint">
+  <f:entry title="${%Eucalyptus EC2 URL}" field="ec2EndpointUrl">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="${%Eucalyptus S3 URL}" field="s3EndpointUrl">
     <f:textbox />
   </f:entry>
   <f:entry field="credentialsId" title="${%Amazon EC2 Credentials}" description="AWS IAM Access Key used to connect to EC2. If not specified, implicit authentication mechanisms are used (IAM roles...)">

--- a/src/test/java/hudson/plugins/ec2/EucalyptusTest.java
+++ b/src/test/java/hudson/plugins/ec2/EucalyptusTest.java
@@ -1,0 +1,25 @@
+package hudson.plugins.ec2;
+
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import java.net.URL;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class EucalyptusTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void configRoundTrip() throws Exception {
+        Eucalyptus cloud = new Eucalyptus("test", new URL("https://ec2"), new URL("https://s3"), false, null, "test", null, "0", null, null, null);
+        r.jenkins.clouds.add(cloud);
+        r.jenkins.save();
+        JenkinsRule.WebClient wc = r.createWebClient();
+        HtmlPage p = wc.goTo("configureClouds/");
+        HtmlForm f = p.getFormByName("config");
+        r.submit(f);
+        r.assertEqualBeans(cloud, r.jenkins.getCloud("test"), "name,ec2EndpointUrl,s3EndpointUrl,useInstanceProfileForCredentials,roleArn,roleSessionName,credentialsId,sshKeysCredentialsId,instanceCap,templates");
+    }
+}


### PR DESCRIPTION
Context: https://github.com/jenkinsci/jenkins/pull/7658 is adding support for copying clouds. Clouds defining a fixed name should now support a name provided by the user.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
