### PR TITLE
ec2-plugin: Install java-11-amazon-corretto for Amazon Linux 2023

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -237,7 +237,9 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
 
             // TODO: parse the version number. maven-enforcer-plugin might help
             final String javaPath = node.javaPath;
-            executeRemote(computer, conn, javaPath + " -fullversion", "sudo amazon-linux-extras install java-openjdk11 -y; sudo yum install -y fontconfig java-11-openjdk", logger, listener);
+            executeRemote(computer, conn, javaPath + " -fullversion",
+                    "sudo amazon-linux-extras install java-openjdk11 -y; sudo dnf -y install java-11-amazon-corretto; sudo yum install -y fontconfig java-11-openjdk",
+                    logger, listener);
             executeRemote(computer, conn, "which scp", "sudo yum install -y openssh-clients", logger, listener);
 
             // Always copy so we get the most recent remoting.jar


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
java-11-openjdk doesn't seem to exist anymore for AL2023 so install java-11-amazon-corretto which does exist.


- [ x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x ] Ensure that the pull request title represents the desired changelog entry
- [ x ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
