### PR TITLE
Update AWS SDK to support M7g* EC2 instances

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,14 +116,14 @@ THE SOFTWARE.
             <artifactId>bouncycastle-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-ec2</artifactId>
-            <version>1.12.406-374.v4cdf53953691</version>
+            <version>1.12.447</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
-            <artifactId>aws-java-sdk-minimal</artifactId>
-            <version>1.12.406-374.v4cdf53953691</version>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>1.12.447</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -116,14 +116,14 @@ THE SOFTWARE.
             <artifactId>bouncycastle-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
             <artifactId>aws-java-sdk-ec2</artifactId>
-            <version>1.12.447</version>
+            <version>1.12.447-380.v65b_d0c044a_b_a_</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.12.447</version>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-minimal</artifactId>
+            <version>1.12.447-380.v65b_d0c044a_b_a_</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Updates Amazon SDK to allow new Graviton3 build agensts to be created with M7gXlarge (and related) constants.  Example: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ec2/model/InstanceType.html#M7gXlarge.

Jira: https://issues.jenkins.io/browse/JENKINS-71059

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
