### PR TITLE
Created method that would allow to programmatically add new slave templates to an EC2Cloud

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -165,7 +165,7 @@ public abstract class EC2Cloud extends Cloud {
      */
     private final int instanceCap;
 
-    private final List<? extends SlaveTemplate> templates;
+    private List<? extends SlaveTemplate> templates;
 
     private transient KeyPair usableKeyPair;
 
@@ -216,7 +216,16 @@ public abstract class EC2Cloud extends Cloud {
 
     public abstract URL getS3EndpointUrl() throws IOException;
 
-    private void migratePrivateSshKeyToCredential(String privateKey){
+    public void addTemplate(SlaveTemplate newTemplate) throws Exception {
+        String newTemplateDescription = newTemplate.description;
+        if (getTemplate(newTemplateDescription) != null) throw new Exception(
+                String.format("A SlaveTemplate with description %s already exists", newTemplateDescription));
+        List<SlaveTemplate> templatesHolder = new ArrayList<>(templates);
+        templatesHolder.add(newTemplate);
+        templates = templatesHolder;
+    }
+
+    private void migratePrivateSshKeyToCredential(String privateKey) {
         // GET matching private key credential from Credential API if exists
         Optional<SSHUserPrivateKey> keyCredential = SystemCredentialsProvider.getInstance().getCredentials()
                 .stream()

--- a/src/test/java/hudson/plugins/ec2/EC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudTest.java
@@ -3,6 +3,7 @@ package hudson.plugins.ec2;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
 import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.InstanceType;
 import hudson.model.Node;
 import jenkins.model.Jenkins;
 import org.junit.Test;
@@ -19,11 +20,22 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EC2CloudTest {
+
+    @Test
+    public void testSlaveTemplateAddition() throws Exception {
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true,
+                "abc", "us-east-1", null, "ghi",
+                "3", Collections.emptyList(), "roleArn", "roleSessionName");
+        SlaveTemplate orig = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "iamInstanceProfile", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default, EbsEncryptRootVolume.DEFAULT);
+        cloud.addTemplate(orig);
+        assertNotNull(cloud.getTemplate(orig.description));
+    }
 
     @Test
     public void testReattachOrphanStoppedNodes() throws Exception {


### PR DESCRIPTION
**PR Description:**

+ Added a method which would access the templates SlaveTemplate list and add a new one if a template with the same description doesn't already exist.

+ Added Unit test to verify that the new  SlaveTemplate has been added successfully 

**Use Case:**

We have a few packer jobs that create new slave template agents  on demand, the issue with the current state of the ec2-plugin (prior to the changes) is that whenever we run a packer job someone will have to go and manually add the new SlaveTemplete to the EC2Cloud. 
I found out that there was a partial solution in this PR https://github.com/jenkinsci/ec2-plugin/pull/154, but it assumes that there is a SlaveTemplate to modify, where in our case we need to add new templates.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

**Local Test Result:**
![image](https://user-images.githubusercontent.com/76135058/234253706-0a745710-75c9-498a-9162-8f3498630ab4.png)

```
Tests run: 165, Failures: 0, Errors: 0, Skipped: 1
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  09:03 min
[INFO] Finished at: 2023-04-25T13:50:39+03:00
[INFO] ------------------------------------------------------------------------
```

**Possible Relevant Jira Issue**
https://issues.jenkins.io/browse/JENKINS-71002