### PR TITLE
JENKINS-63660 slave to agent term sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,9 @@ Role permission has to be extended with:
 - JENKINS-55203 - Do not log private key material
 
 ### Version 1.43 (May 9, 2019)
-- JENKINS-8618 - Maximum builds on slave
-- JENKINS-54329 - User able to choose slave connection strategy
-#### WARNING: This might imply some changes in the address used to connect to the EC2 slave.
+- JENKINS-8618 - Maximum builds on agent
+- JENKINS-54329 - User able to choose agent connection strategy
+#### WARNING: This might imply some changes in the address used to connect to the EC2 agent.
 - JENKINS-51526 - Clone AMI's Root Block device
 - JENKINS-54536 - Allow all T3 types
 - JENKINS-56443 - Don't provision nodes if Jenkins is shutting down
@@ -70,7 +70,7 @@ Role permission has to be extended with:
 - Add remoting workdir
 - Add M5a instance support and fix M4
 - Reduced call to  internalCheck in EC2RetentionStrategy
-- Rename slave to remoting or agent
+- Rename agent to remoting or agent
 - JENKINS-56907 - Query AMI for platform before checking spot price
 
 ### Version 1.43 (May 9, 2019)
@@ -80,8 +80,8 @@ Role permission has to be extended with:
 - Allow launching spot instances without a bid price
 - Allow alternate ec2 endpoint for API region calls
 - Security FIX
-- JENKINS-8618 - Support maximum builds on slave
-- JENKINS-54329 - Allow user to choose slave connection strategy
+- JENKINS-8618 - Support maximum builds on agent
+- JENKINS-54329 - Allow user to choose agent connection strategy
 - JENKINS-57357 - Fix migration config from old configuration
 - JENKINS-56443 - Fix Don't provision a node if Jenkins is quieting down or terminating
 - JENKINS-54536 - Allow all T3 types
@@ -115,8 +115,8 @@ The existing nodes has to be terminated due a new tag schema
 - JENKINS-54071 - Fix plugin not spooling up stopped nodes
 - JENKINS-49814 - Fix Jenkins trying to stop already stopped agent
 - JENKINS-35708 - Allow users to supply multiple subnets for launching EC2 instances. This is useful for resources that may need to spread across availability zones such as GPUs.
-- JENKINS-52828 - Add slave suffix command.
-- PR-310 - Tag slave instances to their jenkins master (breaking change)
+- JENKINS-52828 - Add agent suffix command.
+- PR-310 - Tag agent instances to their jenkins master (breaking change)
 - PR-309 - Add M5 instance types
 
 ### Version 1.40.1 (Oct 2nd, 2018)
@@ -125,13 +125,13 @@ The existing nodes has to be terminated due a new tag schema
 
 ### Version 1.40 (Oct 1st, 2018)
 - PR-250 - Add support for c5 and m5 instance types.
-- JENKINS-25832 - Launch multiple slaves in parallel for jobs with same node label
+- JENKINS-25832 - Launch multiple agents in parallel for jobs with same node label
 - JENKINS-48979 - Race condition when setting tags
 - PR-259 - Make fetch time configurable via system property
 - PR-263 - Fix intermittent "Pipe closed" exception when communicating with WinRM protocol agent
 - PR-265 - Mark dependencies used only in tests as test scope
 - JENKINS-50105 - EC2 Step provisioning incorrectly specifies a label
-- JENKINS-38311 - Disconnected dynamic ec2 slaves reconnected after jenkins restart
+- JENKINS-38311 - Disconnected dynamic ec2 agents reconnected after jenkins restart
 - PR-272 - Improving debug messaging for WinConnector.
 - PR-275 - Terminate spot instances properly
 - PR-276 - Start agent in cygwin friendly way
@@ -150,7 +150,7 @@ The existing nodes has to be terminated due a new tag schema
 ### Version 1.39 (Mar 11, 2018)
 - JENKINS-47985 EC2 Plugin doesn't store AMITypeData in config.xml
 - JENKINS-46869 Can not register an EC2 instance as a node agent
-- JENKINS-47130 EC2 plugin 1.37 fails to provision previously defined slaves
+- JENKINS-47130 EC2 plugin 1.37 fails to provision previously defined agents
 
 ### Version 1.38 (Dec 6, 2017)
 - This is a bad scary version due to: JENKINS-47130 (see above), please use 1.39 or higher instead
@@ -162,36 +162,36 @@ The existing nodes has to be terminated due a new tag schema
 #### Warning:  This version introduces a bug ( JENKINS-47985 - EC2 Plugin doesn't store AMITypeData in config.xml CLOSED ) which drops stored passwords from Windows AMIs.  The fix has been merged to mainline and should hopefully be available when version 1.39 gets released.
 
 ### Version 1.36 (Oct 2, 2016)
-- JENKINS-38481 AWS method change causes too many slaves to be launched
+- JENKINS-38481 AWS method change causes too many agents to be launched
 
 ### Version 1.33 (May 9, 2016)
-- JENKINS-34667 Provision attempt is made when possible slaves count is zero (backed out)
+- JENKINS-34667 Provision attempt is made when possible agents count is zero (backed out)
 
 ### Version 1.32 (May 8, 2016)
 #### Warning: Please use 1.33 instead, it has a critical fix.
 #### Welcome Johnny Shields as co-maintainer!
 - JENKINS-26371 Ensure instance initiated shutdown behavior is consistent with stopOnTerminate flag
 - JENKINS-27529 Poll for spot instances instead of JNLP launcher
-- JENKINS-32588 Unable to launch linux slaves using ec2 plugin using Eucalyptus
-- JENKINS-32584 ec2-plugin counts every instance (not just Jenkins slave instances) when counting slaves; incorrectly hits slave cap
+- JENKINS-32588 Unable to launch linux agents using ec2 plugin using Eucalyptus
+- JENKINS-32584 ec2-plugin counts every instance (not just Jenkins agent instances) when counting agents; incorrectly hits agent cap
 - JENKINS-32690 Make manually provision really work
 - JENKINS-32915 Spot instance launched one after another until capacity reached for single task in queue
 - JENKINS-33945 can't provision new nodes when a matching node is marked offline
-- JENKINS-34667 Provision attempt is made when possible slaves count is zero
+- JENKINS-34667 Provision attempt is made when possible agents count is zero
 - EC2UnixLauncher can survive Connection IOExceptions
 - Bootstrap retries with fresh connection
 - Many pmd/squid fixes
 - Remove AWS fault instance
 - Increase minimal supported version to 1.625.1 (to enable JDK7)
 - Use AWS credentials to manage the IAM access key
-- Applied logic to create block device mappings for both ondemand and spot slaves
-- With slaves now being fully controlled by Jenkins master, there is no longer a need to be able to set "persistent" spot bids
+- Applied logic to create block device mappings for both ondemand and spot agents
+- With agents now being fully controlled by Jenkins master, there is no longer a need to be able to set "persistent" spot bids
 
 ### Version 1.31 (Jan 25, 2016)
-- JENKINS-32584 ec2-plugin counts every instance (not just Jenkins slave instances) when counting slaves; incorrectly hits slave cap
+- JENKINS-32584 ec2-plugin counts every instance (not just Jenkins agent instances) when counting agents; incorrectly hits agent cap
 
 ### Version 1.30 (Jan 23, 2016)
-- Add config to prefer the public IP to private IP when ssh-ing into slave
+- Add config to prefer the public IP to private IP when ssh-ing into agent
 - Added common method to compute tag value and also created constants for demand and spot
 - JENKINS-27601 instance caps incorrectly calculated
 - JENKINS-23787 EC2-plugin not spooling up stopped nodes
@@ -201,13 +201,13 @@ The existing nodes has to be terminated due a new tag schema
 - JENKINS-27260 SPNEGO for Windows in the EC2 Plugin
 - JENKINS-26493 Use new EC2 API endpoint hostnames
 - JCIFS first tries to resolve a dfs path would timeout causing a long startup delay
-- JENKINS-28754 Jenkins EC2 Plugin should show timestamp in slave logs
+- JENKINS-28754 Jenkins EC2 Plugin should show timestamp in agent logs
 - JENKINS-30284 EC2 plugin too aggressive in timing in contacting new AWS instance over SSH
 - Use AWS4SignerType instead of QueryStringSignerType
 - Add minimum timeout for windows launching
 - Better exception handling in uptime check
 - JENKINS-29851 Global instance cap not calculated for spot instances
-- JENKINS-32439 JENKINS-32439 Incorrect slave template (AMI) found when launching slave
+- JENKINS-32439 JENKINS-32439 Incorrect agent template (AMI) found when launching agent
 - Improve logging to be less verbose
 
 ### Version 1.29 (Aug 2, 2015)
@@ -224,7 +224,7 @@ The existing nodes has to be terminated due a new tag schema
 - Masking BouncyCastle for when the system version is incompatible with the required version
 - Fix java download/install
 - Check more places where passing a null instanceID can do a search of random spot instances
-- WiP - Launch slave agent via ssh client process
+- WiP - Launch agent agent via ssh client process
 - JENKINS-24359 - Overcoming limit of one cloud per region.
 - JENKINS-27260 - SPNEGO for Windows in EC2 Plugin
 
@@ -242,15 +242,15 @@ The existing nodes has to be terminated due a new tag schema
 - Fixing zombie workers
 - Add option to obtain EC2 credentials from instance meta data service
 - Retry updating remote tags also for on-demand instances
-- Support cloud-formation compatible user-data in spot-instance slaves
-- Handle AssociatePublicIp in spot instance slaves
-- Consider only slaves for the requested label when decrementing excess Workload by number of pending spot instance slaves
-- Fix the stopping/pending message when launching a slave
+- Support cloud-formation compatible user-data in spot-instance agents
+- Handle AssociatePublicIp in spot instance agents
+- Consider only agents for the requested label when decrementing excess Workload by number of pending spot instance agents
+- Fix the stopping/pending message when launching a agent
 - Fix bug that caused infinite loop of NullPointerExceptions during provisioning of windows instances.
-- Fix connection to Windows slaves outside us-east-1. (JENKINS-19943)
+- Fix connection to Windows agents outside us-east-1. (JENKINS-19943)
 - Give the user a readable error message when testing the connection instead of stack trace if their credentials are incorrect. (JENKINS-24676)
 - EC2 plugin incorrectly reports current instance count (JENKINS-19845)
-- Fix EC2SpotSlaves from fetching tags from a completely different instance
+- Fix EC2SpotAgents from fetching tags from a completely different instance
 
 ### Version 1.24 (Aug 5, 2014)
  
@@ -271,22 +271,22 @@ The existing nodes has to be terminated due a new tag schema
 - Amazon IAM support (JENKINS-17086)
 - Fixed Eucalyptus connectivity support (JENKINS-18854)
 - Fix: spot instance feature cannot be used within VPC (JENKINS-19301)
-- Remove slave from Jenkins even when instance termination fails (JENKINS-19500)
+- Remove agent from Jenkins even when instance termination fails (JENKINS-19500)
 
 ### Version 1.18 (April 9, 2013)
 - Add m3.xlarge and m3.2xlarge instance types
-- Failure starting slave nodes (JENKINS-15319)
+- Failure starting agent nodes (JENKINS-15319)
 - Tags feature is broken (JENKINS-15239)
 - EC2 Nodes which share an AMI ID get the wrong labels (JENKINS-7690)
 - Sometimes starts the wrong instance (JENKINS-15158)
-- Stopped (as opposed to terminated) slaves are counted against the active instance count for the purpose of launching; can prevent launching of instances (JENKINS-7883)
+- Stopped (as opposed to terminated) agents are counted against the active instance count for the purpose of launching; can prevent launching of instances (JENKINS-7883)
 - Upgrade aws-java-sdk dependency to 1.3.30
 - Explicitly add MIT license to all plugin code
 - Fallback a manual or timeout-based terminate to stop if terminate fails (to avoid charges)
 - Give Jenkins nodes useful names (JENKINS-15078)
 - Keep track of instances being provisioned; use this count when determining total/AMI instance caps (JENKINS-6691)
-- Bring back remoteFS in the slave configuration page
-- Let user configure node.mode for EC2 slaves
+- Bring back remoteFS in the agent configuration page
+- Let user configure node.mode for EC2 agents
 
 ### Version 1.17 (September 12, 2012)
 - Resume stopped EC2 instances (JENKINS-14884)
@@ -298,10 +298,10 @@ The existing nodes has to be terminated due a new tag schema
 - EC2 Userdata not being Base64 encoded (JENKINS-13897)
 
 ### Version 1.15 (May 21, 2012)
-- Stopped (as opposed to terminated) slaves are counted against the active instance count for the purpose of launching; can prevent launching of instance (JENKINS-7883)
+- Stopped (as opposed to terminated) agents are counted against the active instance count for the purpose of launching; can prevent launching of instance (JENKINS-7883)
 - Clarification and updating of help (JENKINS-12789)
 - The init script was called each time instance was connected to (JENKINS-12771)
-- EC2 slaves fail to launch when using versions prior to 1.9 (JENKINS-7219)
+- EC2 agents fail to launch when using versions prior to 1.9 (JENKINS-7219)
 - Force registration of converter (JENKINS-10118)
 - Convert to Amazon EC2 libraries(JENKINS-12539)
 - Allow non-root user name (JENKINS-5867)

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ started up:
 
 # Read user data for the EC2 instance. It is available from [http://169.254.169.254/latest/user-data]
 
-# Values are passed in with the format of JENKINS_URL=[Jenkins_Url]&SLAVE_NAME=[Agent_Name]&USER_DATA=[other_user_data]
+# Values are passed in with the format of JENKINS_URL=[Jenkins_Url]&AGENT_NAME=[Agent_Name]&USER_DATA=[other_user_data]
 
 # Parse the values to retrieve the Jenkins_Url and Agent_Name
 # Fetch the agent.jar from the Jenkins controller using wget (or something similar)
@@ -222,7 +222,7 @@ started up:
 wget [Jenkins_Url]jnlpJars/agent.jar -O agent.jar
 # Register the agent to the Jenkins controller node
 
-java -jar agent.jar -jnlpUrl [Jenkins_Url]computer/ [Agent_Name] slave-agent.jnlp
+java -jar agent.jar -jnlpUrl [Jenkins_Url]computer/ [Agent_Name] agent-agent.jnlp
 ```
 
 ## IAM setup
@@ -291,7 +291,7 @@ import hudson.model.*
 import hudson.plugins.ec2.AmazonEC2Cloud
 import hudson.plugins.ec2.AMITypeData
 import hudson.plugins.ec2.EC2Tag
-import hudson.plugins.ec2.SlaveTemplate
+import hudson.plugins.ec2.AgentTemplate
 import hudson.plugins.ec2.SpotConfiguration
 import hudson.plugins.ec2.UnixData
 import jenkins.model.Jenkins
@@ -303,7 +303,7 @@ import hudson.plugins.ec2.EbsEncryptRootVolume
 def sshPortToConnectWith = '22'
 
 // store parameters
-def slaveTemplateUsEast1Parameters = [
+def agentTemplateUsEast1Parameters = [
   ami:                           'ami-AAAAAAAA',
   associatePublicIp:             false,
   spotConfig:                    null,
@@ -402,51 +402,51 @@ AWSCredentialsImpl aWSCredentialsImpl = new AWSCredentialsImpl(
   AWSCredentialsImplParameters.description
 )
 
-// https://javadoc.jenkins.io/plugin/ec2/hudson/plugins/ec2/SlaveTemplate.html
-SlaveTemplate slaveTemplateUsEast1 = new SlaveTemplate(
-  slaveTemplateUsEast1Parameters.ami,
-  slaveTemplateUsEast1Parameters.zone,
-  slaveTemplateUsEast1Parameters.spotConfig,
-  slaveTemplateUsEast1Parameters.securityGroups,
-  slaveTemplateUsEast1Parameters.remoteFS,
-  InstanceType.fromValue(slaveTemplateUsEast1Parameters.type),
-  slaveTemplateUsEast1Parameters.ebsOptimized,
-  slaveTemplateUsEast1Parameters.labelString,
+// https://javadoc.jenkins.io/plugin/ec2/hudson/plugins/ec2/AgentTemplate.html
+AgentTemplate agentTemplateUsEast1 = new AgentTemplate(
+  agentTemplateUsEast1Parameters.ami,
+  agentTemplateUsEast1Parameters.zone,
+  agentTemplateUsEast1Parameters.spotConfig,
+  agentTemplateUsEast1Parameters.securityGroups,
+  agentTemplateUsEast1Parameters.remoteFS,
+  InstanceType.fromValue(agentTemplateUsEast1Parameters.type),
+  agentTemplateUsEast1Parameters.ebsOptimized,
+  agentTemplateUsEast1Parameters.labelString,
   Node.Mode.NORMAL,
-  slaveTemplateUsEast1Parameters.description,
-  slaveTemplateUsEast1Parameters.initScript,
-  slaveTemplateUsEast1Parameters.tmpDir,
-  slaveTemplateUsEast1Parameters.userData,
-  slaveTemplateUsEast1Parameters.numExecutors,
-  slaveTemplateUsEast1Parameters.remoteAdmin,
-  slaveTemplateUsEast1Parameters.unixData,
-  slaveTemplateUsEast1Parameters.javaPath,
-  slaveTemplateUsEast1Parameters.jvmopts,
-  slaveTemplateUsEast1Parameters.stopOnTerminate,
-  slaveTemplateUsEast1Parameters.subnetId,
-  [slaveTemplateUsEast1Parameters.tags],
-  slaveTemplateUsEast1Parameters.idleTerminationMinutes,
-  slaveTemplateUsEast1Parameters.minimumNumberOfInstances,
-  slaveTemplateUsEast1Parameters.minimumNumberOfSpareInstances,
-  slaveTemplateUsEast1Parameters.instanceCapStr,
-  slaveTemplateUsEast1Parameters.iamInstanceProfile,
-  slaveTemplateUsEast1Parameters.deleteRootOnTermination,
-  slaveTemplateUsEast1Parameters.useEphemeralDevices,
-  slaveTemplateUsEast1Parameters.launchTimeoutStr,
-  slaveTemplateUsEast1Parameters.associatePublicIp,
-  slaveTemplateUsEast1Parameters.customDeviceMapping,
-  slaveTemplateUsEast1Parameters.connectBySSHProcess,
-  slaveTemplateUsEast1Parameters.monitoring,
-  slaveTemplateUsEast1Parameters.t2Unlimited,
-  slaveTemplateUsEast1Parameters.connectionStrategy,
-  slaveTemplateUsEast1Parameters.maxTotalUses,
-  slaveTemplateUsEast1Parameters.nodeProperties,
-  slaveTemplateUsEast1Parameters.hostKeyVerificationStrategy,
-  slaveTemplateUsEast1Parameters.tenancy,
-  slaveTemplateUsEast1Parameters.ebsEncryptRootVolume,
-  slaveTemplateUsEast1Parameters.metadataEndpointEnabled,
-  slaveTemplateUsEast1Parameters.metadataTokensRequired,
-  slaveTemplateUsEast1Parameters.metadataHopsLimit,
+  agentTemplateUsEast1Parameters.description,
+  agentTemplateUsEast1Parameters.initScript,
+  agentTemplateUsEast1Parameters.tmpDir,
+  agentTemplateUsEast1Parameters.userData,
+  agentTemplateUsEast1Parameters.numExecutors,
+  agentTemplateUsEast1Parameters.remoteAdmin,
+  agentTemplateUsEast1Parameters.unixData,
+  agentTemplateUsEast1Parameters.javaPath,
+  agentTemplateUsEast1Parameters.jvmopts,
+  agentTemplateUsEast1Parameters.stopOnTerminate,
+  agentTemplateUsEast1Parameters.subnetId,
+  [agentTemplateUsEast1Parameters.tags],
+  agentTemplateUsEast1Parameters.idleTerminationMinutes,
+  agentTemplateUsEast1Parameters.minimumNumberOfInstances,
+  agentTemplateUsEast1Parameters.minimumNumberOfSpareInstances,
+  agentTemplateUsEast1Parameters.instanceCapStr,
+  agentTemplateUsEast1Parameters.iamInstanceProfile,
+  agentTemplateUsEast1Parameters.deleteRootOnTermination,
+  agentTemplateUsEast1Parameters.useEphemeralDevices,
+  agentTemplateUsEast1Parameters.launchTimeoutStr,
+  agentTemplateUsEast1Parameters.associatePublicIp,
+  agentTemplateUsEast1Parameters.customDeviceMapping,
+  agentTemplateUsEast1Parameters.connectBySSHProcess,
+  agentTemplateUsEast1Parameters.monitoring,
+  agentTemplateUsEast1Parameters.t2Unlimited,
+  agentTemplateUsEast1Parameters.connectionStrategy,
+  agentTemplateUsEast1Parameters.maxTotalUses,
+  agentTemplateUsEast1Parameters.nodeProperties,
+  agentTemplateUsEast1Parameters.hostKeyVerificationStrategy,
+  agentTemplateUsEast1Parameters.tenancy,
+  agentTemplateUsEast1Parameters.ebsEncryptRootVolume,
+  agentTemplateUsEast1Parameters.metadataEndpointEnabled,
+  agentTemplateUsEast1Parameters.metadataTokensRequired,
+  agentTemplateUsEast1Parameters.metadataHopsLimit,
 )
 
 // https://javadoc.jenkins.io/plugin/ec2/index.html?hudson/plugins/ec2/AmazonEC2Cloud.html
@@ -457,7 +457,7 @@ AmazonEC2Cloud amazonEC2Cloud = new AmazonEC2Cloud(
   AmazonEC2CloudParameters.region,
   AmazonEC2CloudParameters.privateKey,
   AmazonEC2CloudParameters.instanceCapStr,
-  [slaveTemplateUsEast1],
+  [agentTemplateUsEast1],
   '',
   ''
 )
@@ -627,7 +627,7 @@ If you are using a Amazon Linux AMI and encounter exceptions like
 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.201.b09-0.amzn2.x86\_64/jre/lib/currency.data
 (No such file or directory)*** or ***Remote call on EC2
 \[...\] failed*** then chances are that the Amazon Linux is doing some
-security upgrades in the background and causes the slave to be in an
+security upgrades in the background and causes the agent to be in an
 invalid state.
 
 From the

--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -74,13 +74,13 @@ public class AmazonEC2Cloud extends EC2Cloud {
     private boolean noDelayProvisioning;
 
     @DataBoundConstructor
-    public AmazonEC2Cloud(String cloudName, boolean useInstanceProfileForCredentials, String credentialsId, String region, String privateKey, String sshKeysCredentialsId, String instanceCapStr, List<? extends SlaveTemplate> templates, String roleArn, String roleSessionName) {
+    public AmazonEC2Cloud(String cloudName, boolean useInstanceProfileForCredentials, String credentialsId, String region, String privateKey, String sshKeysCredentialsId, String instanceCapStr, List<? extends AgentTemplate> templates, String roleArn, String roleSessionName) {
         super(cloudName, useInstanceProfileForCredentials, credentialsId, privateKey, sshKeysCredentialsId, instanceCapStr, templates, roleArn, roleSessionName);
         this.region = region;
     }
 
     @Deprecated
-    public AmazonEC2Cloud(String cloudName, boolean useInstanceProfileForCredentials, String credentialsId, String region, String privateKey, String instanceCapStr, List<? extends SlaveTemplate> templates, String roleArn, String roleSessionName) {
+    public AmazonEC2Cloud(String cloudName, boolean useInstanceProfileForCredentials, String credentialsId, String region, String privateKey, String instanceCapStr, List<? extends AgentTemplate> templates, String roleArn, String roleSessionName) {
         super(cloudName, useInstanceProfileForCredentials, credentialsId, privateKey, instanceCapStr, templates, roleArn, roleSessionName);
         this.region = region;
     }

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -28,12 +28,12 @@ import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Node;
-import hudson.model.Slave;
+import hudson.model.Agent;
 import hudson.plugins.ec2.util.AmazonEC2Factory;
 import hudson.plugins.ec2.util.ResettableCountDownLatch;
-import hudson.slaves.NodeProperty;
-import hudson.slaves.ComputerLauncher;
-import hudson.slaves.RetentionStrategy;
+import hudson.agents.NodeProperty;
+import hudson.agents.ComputerLauncher;
+import hudson.agents.RetentionStrategy;
 import hudson.util.ListBoxModel;
 
 import java.io.IOException;
@@ -76,18 +76,18 @@ import org.kohsuke.stapler.verb.POST;
  * @author Kohsuke Kawaguchi
  */
 @SuppressWarnings("serial")
-public abstract class EC2AbstractSlave extends Slave {
+public abstract class EC2AbstractAgent extends Agent {
     public static final Boolean DEFAULT_METADATA_ENDPOINT_ENABLED = Boolean.TRUE;
     public static final Boolean DEFAULT_METADATA_TOKENS_REQUIRED = Boolean.TRUE;
     public static final Integer DEFAULT_METADATA_HOPS_LIMIT = 1;
     public static final String DEFAULT_JAVA_PATH = "java";
 
-    private static final Logger LOGGER = Logger.getLogger(EC2AbstractSlave.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(EC2AbstractAgent.class.getName());
 
     protected String instanceId;
 
     /**
-     * Comes from {@link SlaveTemplate#initScript}.
+     * Comes from {@link AgentTemplate#initScript}.
      */
     public final String initScript;
     public final String tmpDir;
@@ -132,7 +132,7 @@ public abstract class EC2AbstractSlave extends Slave {
      * The time (in milliseconds) after which we will always re-fetch externally changeable EC2 data when we are asked
      * for it
      */
-    protected static final long MIN_FETCH_TIME = Long.getLong("hudson.plugins.ec2.EC2AbstractSlave.MIN_FETCH_TIME",
+    protected static final long MIN_FETCH_TIME = Long.getLong("hudson.plugins.ec2.EC2AbstractAgent.MIN_FETCH_TIME",
             TimeUnit.SECONDS.toMillis(20));
 
     protected final int launchTimeout;
@@ -147,15 +147,15 @@ public abstract class EC2AbstractSlave extends Slave {
     @Deprecated
     public transient boolean usePrivateDnsName;
 
-    public transient String slaveCommandPrefix;
+    public transient String agentCommandPrefix;
 
-    public transient String slaveCommandSuffix;
+    public transient String agentCommandSuffix;
 
     private transient long createdTime;
 
     public static final String TEST_ZONE = "testZone";
 
-    public EC2AbstractSlave(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy<EC2Computer> retentionStrategy, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, Tenancy tenancy,
+    public EC2AbstractAgent(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy<EC2Computer> retentionStrategy, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, Tenancy tenancy,
                             Boolean metadataEndpointEnabled, Boolean metadataTokensRequired, Integer metadataHopsLimit)
             throws FormException, IOException {
         super(name, remoteFS, launcher);
@@ -189,21 +189,21 @@ public abstract class EC2AbstractSlave extends Slave {
     }
 
     @Deprecated
-    public EC2AbstractSlave(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy<EC2Computer> retentionStrategy, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, Tenancy tenancy)
+    public EC2AbstractAgent(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy<EC2Computer> retentionStrategy, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, Tenancy tenancy)
             throws FormException, IOException {
         this(name, instanceId, templateDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, initScript, tmpDir, nodeProperties, remoteAdmin, DEFAULT_JAVA_PATH, jvmopts, stopOnTerminate, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, tenancy, DEFAULT_METADATA_ENDPOINT_ENABLED, DEFAULT_METADATA_TOKENS_REQUIRED, DEFAULT_METADATA_HOPS_LIMIT);
 
     }
 
     @Deprecated
-    public EC2AbstractSlave(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy<EC2Computer> retentionStrategy, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
+    public EC2AbstractAgent(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy<EC2Computer> retentionStrategy, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
             throws FormException, IOException {
 
         this(name, instanceId, templateDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, initScript, tmpDir, nodeProperties, remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, Tenancy.backwardsCompatible(useDedicatedTenancy));
     }
 
     @Deprecated
-    public EC2AbstractSlave(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy<EC2Computer> retentionStrategy, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType)
+    public EC2AbstractAgent(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy<EC2Computer> retentionStrategy, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
         this(name, instanceId, templateDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, initScript, tmpDir, nodeProperties, remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, tags, cloudName, useDedicatedTenancy, launchTimeout, amiType, ConnectionStrategy.backwardsCompatible(usePrivateDnsName, false, false), -1);
     }
@@ -220,13 +220,13 @@ public abstract class EC2AbstractSlave extends Slave {
         }
 
         if (amiType == null) {
-            amiType = new UnixData(rootCommandPrefix, slaveCommandPrefix, slaveCommandSuffix, Integer.toString(sshPort), null);
+            amiType = new UnixData(rootCommandPrefix, agentCommandPrefix, agentCommandSuffix, Integer.toString(sshPort), null);
         }
 
         if (maxTotalUses == 0) {
             EC2Cloud cloud = getCloud();
             if (cloud != null) {
-                SlaveTemplate template = cloud.getTemplate(templateDescription);
+                AgentTemplate template = cloud.getTemplate(templateDescription);
                 if (template != null) {
                     if (template.getMaxTotalUses() == -1) {
                         maxTotalUses = -1;
@@ -497,7 +497,7 @@ public abstract class EC2AbstractSlave extends Slave {
             return null;
         }
 
-        EC2AbstractSlave result = (EC2AbstractSlave) super.reconfigure(req, form);
+        EC2AbstractAgent result = (EC2AbstractAgent) super.reconfigure(req, form);
 
         if (result != null) {
             /* Get rid of the old tags, as represented by ourselves. */
@@ -547,15 +547,15 @@ public abstract class EC2AbstractSlave extends Slave {
         return commandPrefix + " ";
     }
 
-    String getSlaveCommandPrefix() {
-        String commandPrefix = (amiType.isUnix() ? ((UnixData) amiType).getSlaveCommandPrefix() :(amiType.isMac() ? ((MacData) amiType).getSlaveCommandPrefix() : ""));
+    String getAgentCommandPrefix() {
+        String commandPrefix = (amiType.isUnix() ? ((UnixData) amiType).getAgentCommandPrefix() :(amiType.isMac() ? ((MacData) amiType).getAgentCommandPrefix() : ""));
         if (commandPrefix == null || commandPrefix.length() == 0)
             return "";
         return commandPrefix + " ";
     }
 
-    String getSlaveCommandSuffix() {
-        String commandSuffix = (amiType.isUnix() ? ((UnixData) amiType).getSlaveCommandSuffix() :(amiType.isMac() ? ((MacData) amiType).getSlaveCommandSuffix() : ""));
+    String getAgentCommandSuffix() {
+        String commandSuffix = (amiType.isUnix() ? ((UnixData) amiType).getAgentCommandSuffix() :(amiType.isMac() ? ((MacData) amiType).getAgentCommandSuffix() : ""));
         if (commandSuffix == null || commandSuffix.length() == 0)
             return "";
         return " " + commandSuffix;
@@ -617,7 +617,7 @@ public abstract class EC2AbstractSlave extends Slave {
 
         if (getInstanceId() == null || getInstanceId().isEmpty()) {
             /*
-             * The getInstanceId() implementation on EC2SpotSlave can return null if the spot request doesn't yet know
+             * The getInstanceId() implementation on EC2SpotAgent can return null if the spot request doesn't yet know
              * the instance id that it is starting. What happens is that null is passed to getInstanceId() which
              * searches AWS but without an instanceID the search returns some random box. We then fetch its metadata,
              * including tags, and then later, when the spot request eventually gets the instanceID correctly we push
@@ -813,7 +813,7 @@ public abstract class EC2AbstractSlave extends Slave {
      */
     abstract public String getEc2Type();
 
-    public static abstract class DescriptorImpl extends SlaveDescriptor {
+    public static abstract class DescriptorImpl extends AgentDescriptor {
 
         @Override
         public abstract String getDisplayName();

--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -27,7 +27,7 @@ import com.amazonaws.services.ec2.model.*;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Util;
 import hudson.model.Node;
-import hudson.slaves.SlaveComputer;
+import hudson.agents.AgentComputer;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.logging.Level;
@@ -43,7 +43,7 @@ import org.kohsuke.stapler.verb.POST;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class EC2Computer extends SlaveComputer {
+public class EC2Computer extends AgentComputer {
 
     private static final Logger LOGGER = Logger.getLogger(EC2Computer.class.getName());
 
@@ -54,42 +54,42 @@ public class EC2Computer extends SlaveComputer {
 
     private volatile Boolean isNitro;
 
-    public EC2Computer(EC2AbstractSlave slave) {
-        super(slave);
+    public EC2Computer(EC2AbstractAgent agent) {
+        super(agent);
     }
 
     @Override
-    public EC2AbstractSlave getNode() {
-        return (EC2AbstractSlave) super.getNode();
+    public EC2AbstractAgent getNode() {
+        return (EC2AbstractAgent) super.getNode();
     }
 
     @CheckForNull
     public String getInstanceId() {
-        EC2AbstractSlave node = getNode();
+        EC2AbstractAgent node = getNode();
         return node == null ? null : node.getInstanceId();
     }
 
     public String getEc2Type() {
-        EC2AbstractSlave node = getNode();
+        EC2AbstractAgent node = getNode();
         return node == null ? null : node.getEc2Type();
     }
 
     public String getSpotInstanceRequestId() {
-        EC2AbstractSlave node = getNode();
-        if (node instanceof EC2SpotSlave) {
-            return ((EC2SpotSlave) node).getSpotInstanceRequestId();
+        EC2AbstractAgent node = getNode();
+        if (node instanceof EC2SpotAgent) {
+            return ((EC2SpotAgent) node).getSpotInstanceRequestId();
         }
         return "";
     }
 
     public EC2Cloud getCloud() {
-        EC2AbstractSlave node = getNode();
+        EC2AbstractAgent node = getNode();
         return node == null ? null : node.getCloud();
     }
 
     @CheckForNull
-    public SlaveTemplate getSlaveTemplate() {
-        EC2AbstractSlave node = getNode();
+    public AgentTemplate getAgentTemplate() {
+        EC2AbstractAgent node = getNode();
         if (node != null) {
             return node.getCloud().getTemplate(node.templateDescription);
         }
@@ -218,7 +218,7 @@ public class EC2Computer extends SlaveComputer {
     @POST
     public HttpResponse doDoDelete() throws IOException {
         checkPermission(DELETE);
-        EC2AbstractSlave node = getNode();
+        EC2AbstractAgent node = getNode();
         if (node != null)
             node.terminate();
         return new HttpRedirect("..");
@@ -231,32 +231,32 @@ public class EC2Computer extends SlaveComputer {
      */
     @CheckForNull
     public String getRemoteAdmin() {
-        EC2AbstractSlave node = getNode();
+        EC2AbstractAgent node = getNode();
         return node == null ? null : node.getRemoteAdmin();
     }
 
     public int getSshPort() {
-        EC2AbstractSlave node = getNode();
+        EC2AbstractAgent node = getNode();
         return node == null ? 22 : node.getSshPort();
     }
 
     public String getRootCommandPrefix() {
-        EC2AbstractSlave node = getNode();
+        EC2AbstractAgent node = getNode();
         return node == null ? "" : node.getRootCommandPrefix();
     }
 
-    public String getSlaveCommandPrefix() {
-        EC2AbstractSlave node = getNode();
-        return node == null ? "" : node.getSlaveCommandPrefix();
+    public String getAgentCommandPrefix() {
+        EC2AbstractAgent node = getNode();
+        return node == null ? "" : node.getAgentCommandPrefix();
     }
 
-    public String getSlaveCommandSuffix() {
-        EC2AbstractSlave node = getNode();
-        return node == null ? "" : node.getSlaveCommandSuffix();
+    public String getAgentCommandSuffix() {
+        EC2AbstractAgent node = getNode();
+        return node == null ? "" : node.getAgentCommandSuffix();
     }
 
     public void onConnected() {
-        EC2AbstractSlave node = getNode();
+        EC2AbstractAgent node = getNode();
         if (node != null) {
             node.onConnected();
         }

--- a/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
@@ -24,8 +24,8 @@
 package hudson.plugins.ec2;
 
 import hudson.model.TaskListener;
-import hudson.slaves.ComputerLauncher;
-import hudson.slaves.SlaveComputer;
+import hudson.agents.ComputerLauncher;
+import hudson.agents.AgentComputer;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -42,27 +42,27 @@ public abstract class EC2ComputerLauncher extends ComputerLauncher {
     private static final Logger LOGGER = Logger.getLogger(EC2ComputerLauncher.class.getName());
 
     @Override
-    public void launch(SlaveComputer slaveComputer, TaskListener listener) {
+    public void launch(AgentComputer agentComputer, TaskListener listener) {
         try {
-            EC2Computer computer = (EC2Computer) slaveComputer;
+            EC2Computer computer = (EC2Computer) agentComputer;
             launchScript(computer, listener);
         } catch (AmazonClientException | IOException e) {
             e.printStackTrace(listener.error(e.getMessage()));
-            if (slaveComputer.getNode() instanceof  EC2AbstractSlave) {
-                LOGGER.log(Level.FINE, String.format("Terminating the ec2 agent %s due a problem launching or connecting to it", slaveComputer.getName()), e);
-                EC2AbstractSlave ec2AbstractSlave = (EC2AbstractSlave) slaveComputer.getNode();
-                if (ec2AbstractSlave != null) {
-                    ec2AbstractSlave.terminate();
+            if (agentComputer.getNode() instanceof  EC2AbstractAgent) {
+                LOGGER.log(Level.FINE, String.format("Terminating the ec2 agent %s due a problem launching or connecting to it", agentComputer.getName()), e);
+                EC2AbstractAgent ec2AbstractAgent = (EC2AbstractAgent) agentComputer.getNode();
+                if (ec2AbstractAgent != null) {
+                    ec2AbstractAgent.terminate();
                 }
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             e.printStackTrace(listener.error(e.getMessage()));
-            if (slaveComputer.getNode() instanceof  EC2AbstractSlave) {
-                LOGGER.log(Level.FINE, String.format("Terminating the ec2 agent %s due a problem launching or connecting to it", slaveComputer.getName()), e);
-                EC2AbstractSlave ec2AbstractSlave = (EC2AbstractSlave) slaveComputer.getNode();
-                if (ec2AbstractSlave != null) {
-                    ec2AbstractSlave.terminate();
+            if (agentComputer.getNode() instanceof  EC2AbstractAgent) {
+                LOGGER.log(Level.FINE, String.format("Terminating the ec2 agent %s due a problem launching or connecting to it", agentComputer.getName()), e);
+                EC2AbstractAgent ec2AbstractAgent = (EC2AbstractAgent) agentComputer.getNode();
+                if (ec2AbstractAgent != null) {
+                    ec2AbstractAgent.terminate();
                 }
             }
         }

--- a/src/main/java/hudson/plugins/ec2/EC2ComputerListener.java
+++ b/src/main/java/hudson/plugins/ec2/EC2ComputerListener.java
@@ -3,7 +3,7 @@ package hudson.plugins.ec2;
 import hudson.Extension;
 import hudson.model.TaskListener;
 import hudson.model.Computer;
-import hudson.slaves.ComputerListener;
+import hudson.agents.ComputerListener;
 
 @Extension
 public class EC2ComputerListener extends ComputerListener {

--- a/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2OndemandSlave.java
@@ -7,7 +7,7 @@ import hudson.model.Node;
 import hudson.plugins.ec2.ssh.EC2UnixLauncher;
 import hudson.plugins.ec2.win.EC2WindowsLauncher;
 import hudson.plugins.ec2.ssh.EC2MacLauncher;
-import hudson.slaves.NodeProperty;
+import hudson.agents.NodeProperty;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -31,42 +31,42 @@ import com.amazonaws.services.ec2.model.*;
  *
  * @author Kohsuke Kawaguchi
  */
-public class EC2OndemandSlave extends EC2AbstractSlave {
-    private static final Logger LOGGER = Logger.getLogger(EC2OndemandSlave.class.getName());
+public class EC2OndemandAgent extends EC2AbstractAgent {
+    private static final Logger LOGGER = Logger.getLogger(EC2OndemandAgent.class.getName());
 
     @Deprecated
-    public EC2OndemandSlave(String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType)
+    public EC2OndemandAgent(String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
         this(instanceId, templateDescription, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, false, launchTimeout, amiType);
     }
 
     @Deprecated
-    public EC2OndemandSlave(String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType)
+    public EC2OndemandAgent(String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
         this(instanceId, templateDescription, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, false, useDedicatedTenancy, launchTimeout, amiType);
     }
 
     @Deprecated
-    public EC2OndemandSlave(String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType)
+    public EC2OndemandAgent(String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
         this(templateDescription + " (" + instanceId + ")", instanceId, templateDescription, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, Collections.emptyList(), remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, useDedicatedTenancy, launchTimeout, amiType, ConnectionStrategy.backwardsCompatible(usePrivateDnsName, false, false), -1);
     }
 
     @Deprecated
-    public EC2OndemandSlave(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
+    public EC2OndemandAgent(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, boolean useDedicatedTenancy, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
             throws FormException, IOException {
 
         this(name, instanceId, templateDescription, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, nodeProperties, remoteAdmin, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, Tenancy.backwardsCompatible(useDedicatedTenancy));
     }
 
     @Deprecated
-    public EC2OndemandSlave(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, Tenancy tenancy)
+    public EC2OndemandAgent(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, Tenancy tenancy)
             throws FormException, IOException {
          this(name, instanceId, templateDescription, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, nodeProperties, remoteAdmin, DEFAULT_JAVA_PATH, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses, tenancy, DEFAULT_METADATA_ENDPOINT_ENABLED, DEFAULT_METADATA_TOKENS_REQUIRED, DEFAULT_METADATA_HOPS_LIMIT);
     }
 
     @DataBoundConstructor
-    public EC2OndemandSlave(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, Tenancy tenancy,
+    public EC2OndemandAgent(String name, String instanceId, String templateDescription, String remoteFS, int numExecutors, String labelString, Mode mode, String initScript, String tmpDir, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts, boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses, Tenancy tenancy,
                             Boolean metadataEndpointEnabled, Boolean metadataTokensRequired, Integer metadataHopsLimit)
             throws FormException, IOException {
 
@@ -80,7 +80,7 @@ public class EC2OndemandSlave extends EC2AbstractSlave {
     /**
      * Constructor for debugging.
      */
-    public EC2OndemandSlave(String instanceId) throws FormException, IOException {
+    public EC2OndemandAgent(String instanceId) throws FormException, IOException {
         this(instanceId, instanceId, "debug", "/tmp/hudson", 1, "debug", Mode.NORMAL, "", "/tmp", Collections.emptyList(), null, null, false, null, "Fake public", "Fake private", null, null, false, 0, new UnixData(null, null, null, null, null), ConnectionStrategy.PRIVATE_IP, -1);
     }
 
@@ -142,15 +142,15 @@ public class EC2OndemandSlave extends EC2AbstractSlave {
     }
 
     @Extension
-    public static final class DescriptorImpl extends EC2AbstractSlave.DescriptorImpl {
+    public static final class DescriptorImpl extends EC2AbstractAgent.DescriptorImpl {
         @Override
         public String getDisplayName() {
-            return Messages.EC2OndemandSlave_AmazonEC2();
+            return Messages.EC2OndemandAgent_AmazonEC2();
         }
     }
 
     @Override
     public String getEc2Type() {
-        return Messages.EC2OndemandSlave_OnDemand();
+        return Messages.EC2OndemandAgent_OnDemand();
     }
 }

--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -25,29 +25,29 @@ import hudson.model.Computer;
 import hudson.model.Descriptor.FormException;
 import hudson.plugins.ec2.ssh.EC2UnixLauncher;
 import hudson.plugins.ec2.win.EC2WindowsLauncher;
-import hudson.slaves.NodeProperty;
+import hudson.agents.NodeProperty;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
-public class EC2SpotSlave extends EC2AbstractSlave implements EC2Readiness {
-    private static final Logger LOGGER = Logger.getLogger(EC2SpotSlave.class.getName());
+public class EC2SpotAgent extends EC2AbstractAgent implements EC2Readiness {
+    private static final Logger LOGGER = Logger.getLogger(EC2SpotAgent.class.getName());
 
     private final String spotInstanceRequestId;
 
     @Deprecated
-    public EC2SpotSlave(String name, String spotInstanceRequestId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType)
+    public EC2SpotAgent(String name, String spotInstanceRequestId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
         this(name, spotInstanceRequestId, templateDescription, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, remoteAdmin, jvmopts, idleTerminationMinutes, tags, cloudName, false, launchTimeout, amiType);
     }
 
     @Deprecated
-    public EC2SpotSlave(String name, String spotInstanceRequestId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout, AMITypeData amiType)
+    public EC2SpotAgent(String name, String spotInstanceRequestId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, String remoteAdmin, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, boolean usePrivateDnsName, int launchTimeout, AMITypeData amiType)
             throws FormException, IOException {
         this(templateDescription + " (" + name + ")", spotInstanceRequestId, templateDescription, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, Collections.emptyList(), remoteAdmin, DEFAULT_JAVA_PATH, jvmopts, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, ConnectionStrategy.backwardsCompatible(usePrivateDnsName, false, false), -1);
     }
 
     @DataBoundConstructor
-    public EC2SpotSlave(String name, String spotInstanceRequestId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
+    public EC2SpotAgent(String name, String spotInstanceRequestId, String templateDescription, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
             throws FormException, IOException {
 
         super(name, "", templateDescription, remoteFS, numExecutors, mode, labelString, amiType.isWindows() ? new EC2WindowsLauncher() :
@@ -191,11 +191,11 @@ public class EC2SpotSlave extends EC2AbstractSlave implements EC2Readiness {
     }
 
     @Extension
-    public static final class DescriptorImpl extends EC2AbstractSlave.DescriptorImpl {
+    public static final class DescriptorImpl extends EC2AbstractAgent.DescriptorImpl {
 
         @Override
         public String getDisplayName() {
-            return Messages.EC2SpotSlave_AmazonEC2SpotInstance();
+            return Messages.EC2SpotAgent_AmazonEC2SpotInstance();
         }
     }
 
@@ -204,8 +204,8 @@ public class EC2SpotSlave extends EC2AbstractSlave implements EC2Readiness {
         SpotInstanceRequest spotRequest = getSpotRequest();
         if (spotRequest != null) {
             String spotMaxBidPrice = spotRequest.getSpotPrice();
-            return Messages.EC2SpotSlave_Spot1() + spotMaxBidPrice.substring(0, spotMaxBidPrice.length() - 3)
-                    + Messages.EC2SpotSlave_Spot2();
+            return Messages.EC2SpotAgent_Spot1() + spotMaxBidPrice.substring(0, spotMaxBidPrice.length() - 3)
+                    + Messages.EC2SpotAgent_Spot2();
         }
         return null;
     }

--- a/src/main/java/hudson/plugins/ec2/EC2Step.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Step.java
@@ -27,7 +27,7 @@ import com.amazonaws.services.ec2.model.Instance;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
-import hudson.slaves.Cloud;
+import hudson.agents.Cloud;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.steps.*;
@@ -104,7 +104,7 @@ public class EC2Step extends Step {
             Cloud cloud = Jenkins.get().getCloud(Util.fixEmpty(cloudName));
             if (cloud instanceof AmazonEC2Cloud) {
                 AmazonEC2Cloud ec2Cloud = (AmazonEC2Cloud) cloud;
-                for (SlaveTemplate template : ec2Cloud.getTemplates()) {
+                for (AgentTemplate template : ec2Cloud.getTemplates()) {
                     for (String labelList : template.labels.split(" ")) {
                         r.add(labelList + "  (AMI: " + template.getAmi() + ", REGION: " + ec2Cloud.getRegion() + ", TYPE: " + template.type.name() + ")", labelList);
                     }
@@ -136,20 +136,20 @@ public class EC2Step extends Step {
         protected Instance run() throws Exception {
             Cloud cl = getByDisplayName(jenkins.model.Jenkins.get().clouds, this.cloud);
             if (cl instanceof AmazonEC2Cloud) {
-                SlaveTemplate t;
+                AgentTemplate t;
                 t = ((AmazonEC2Cloud) cl).getTemplate(this.template);
                 if (t != null) {
-                    SlaveTemplate.ProvisionOptions universe = SlaveTemplate.ProvisionOptions.ALLOW_CREATE;
-                    EnumSet<SlaveTemplate.ProvisionOptions> opt = EnumSet.noneOf(SlaveTemplate.ProvisionOptions.class);
+                    AgentTemplate.ProvisionOptions universe = AgentTemplate.ProvisionOptions.ALLOW_CREATE;
+                    EnumSet<AgentTemplate.ProvisionOptions> opt = EnumSet.noneOf(AgentTemplate.ProvisionOptions.class);
                     opt.add(universe);
 
-                    List<EC2AbstractSlave> instances = t.provision(1, opt);
+                    List<EC2AbstractAgent> instances = t.provision(1, opt);
                     if (instances == null) {
                         throw new IllegalArgumentException("Error in AWS Cloud. Please review AWS template defined in Jenkins configuration.");
                     }
 
-                    EC2AbstractSlave slave = instances.get(0);
-                    return CloudHelper.getInstanceWithRetry(slave.getInstanceId(), (AmazonEC2Cloud) cl);
+                    EC2AbstractAgent agent = instances.get(0);
+                    return CloudHelper.getInstanceWithRetry(agent.getInstanceId(), (AmazonEC2Cloud) cl);
                 } else {
                     throw new IllegalArgumentException("Error in AWS Cloud. Please review AWS template defined in Jenkins configuration.");
                 }

--- a/src/main/java/hudson/plugins/ec2/EC2Tag.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Tag.java
@@ -42,7 +42,7 @@ public class EC2Tag extends AbstractDescribableImpl<EC2Tag> {
     /**
      * Tag name for the specific jenkins agent type tag, used to identify the EC2 instances provisioned by this plugin.
      */
-    public static final String TAG_NAME_JENKINS_SLAVE_TYPE = "jenkins_slave_type";
+    public static final String TAG_NAME_JENKINS_AGENT_TYPE = "jenkins_agent_type";
     public static final String TAG_NAME_JENKINS_SERVER_URL = "jenkins_server_url";
 
     @DataBoundConstructor

--- a/src/main/java/hudson/plugins/ec2/Eucalyptus.java
+++ b/src/main/java/hudson/plugins/ec2/Eucalyptus.java
@@ -48,20 +48,20 @@ public class Eucalyptus extends EC2Cloud {
     private final URL s3endpoint;
 
     @DataBoundConstructor
-    public Eucalyptus(String name, URL ec2EndpointUrl, URL s3EndpointUrl, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String sshKeysCredentialsId, String instanceCapStr, List<SlaveTemplate> templates, String roleArn, String roleSessionName) {
+    public Eucalyptus(String name, URL ec2EndpointUrl, URL s3EndpointUrl, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String sshKeysCredentialsId, String instanceCapStr, List<AgentTemplate> templates, String roleArn, String roleSessionName) {
         super(name, useInstanceProfileForCredentials, credentialsId, privateKey, sshKeysCredentialsId, instanceCapStr, templates, roleArn, roleSessionName);
         this.ec2endpoint = ec2EndpointUrl;
         this.s3endpoint = s3EndpointUrl;
     }
 
     @Deprecated
-    public Eucalyptus(URL ec2EndpointUrl, URL s3EndpointUrl, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String sshKeysCredentialsId, String instanceCapStr, List<SlaveTemplate> templates, String roleArn, String roleSessionName)
+    public Eucalyptus(URL ec2EndpointUrl, URL s3EndpointUrl, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String sshKeysCredentialsId, String instanceCapStr, List<AgentTemplate> templates, String roleArn, String roleSessionName)
             throws IOException {
         this("eucalyptus", ec2EndpointUrl, s3EndpointUrl, useInstanceProfileForCredentials, credentialsId, privateKey, sshKeysCredentialsId, instanceCapStr, templates, roleArn, roleSessionName);
     }
 
     @Deprecated
-    public Eucalyptus(URL ec2EndpointUrl, URL s3EndpointUrl, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String instanceCapStr, List<SlaveTemplate> templates, String roleArn, String roleSessionName)
+    public Eucalyptus(URL ec2EndpointUrl, URL s3EndpointUrl, boolean useInstanceProfileForCredentials, String credentialsId, String privateKey, String instanceCapStr, List<AgentTemplate> templates, String roleArn, String roleSessionName)
             throws IOException {
         this("eucalyptus", ec2EndpointUrl, s3EndpointUrl, useInstanceProfileForCredentials, credentialsId, privateKey, null, instanceCapStr, templates, roleArn, roleSessionName);
     }

--- a/src/main/java/hudson/plugins/ec2/MacData.java
+++ b/src/main/java/hudson/plugins/ec2/MacData.java
@@ -8,16 +8,16 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 public class MacData extends AMITypeData {
     private final String rootCommandPrefix;
-    private final String slaveCommandPrefix;
-    private final String slaveCommandSuffix;
+    private final String agentCommandPrefix;
+    private final String agentCommandSuffix;
     private final String sshPort;
     private final String bootDelay;
 
     @DataBoundConstructor
-    public MacData(String rootCommandPrefix, String slaveCommandPrefix, String slaveCommandSuffix, String sshPort, String bootDelay) {
+    public MacData(String rootCommandPrefix, String agentCommandPrefix, String agentCommandSuffix, String sshPort, String bootDelay) {
         this.rootCommandPrefix = rootCommandPrefix;
-        this.slaveCommandPrefix = slaveCommandPrefix;
-        this.slaveCommandSuffix = slaveCommandSuffix;
+        this.agentCommandPrefix = agentCommandPrefix;
+        this.agentCommandSuffix = agentCommandSuffix;
         this.sshPort = sshPort;
         this.bootDelay = bootDelay;
 
@@ -60,12 +60,12 @@ public class MacData extends AMITypeData {
         return rootCommandPrefix;
     }
 
-    public String getSlaveCommandPrefix() {
-        return slaveCommandPrefix;
+    public String getAgentCommandPrefix() {
+        return agentCommandPrefix;
     }
 
-    public String getSlaveCommandSuffix() {
-        return slaveCommandSuffix;
+    public String getAgentCommandSuffix() {
+        return agentCommandSuffix;
     }
 
     public String getSshPort() {
@@ -77,8 +77,8 @@ public class MacData extends AMITypeData {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((rootCommandPrefix == null) ? 0 : rootCommandPrefix.hashCode());
-        result = prime * result + ((slaveCommandPrefix == null) ? 0 : slaveCommandPrefix.hashCode());
-        result = prime * result + ((slaveCommandSuffix == null) ? 0 : slaveCommandSuffix.hashCode());
+        result = prime * result + ((agentCommandPrefix == null) ? 0 : agentCommandPrefix.hashCode());
+        result = prime * result + ((agentCommandSuffix == null) ? 0 : agentCommandSuffix.hashCode());
         result = prime * result + ((sshPort == null) ? 0 : sshPort.hashCode());
         return result;
     }
@@ -97,15 +97,15 @@ public class MacData extends AMITypeData {
                 return false;
         } else if (!rootCommandPrefix.equals(other.rootCommandPrefix))
             return false;
-        if (StringUtils.isEmpty(slaveCommandPrefix)) {
-            if (!StringUtils.isEmpty(other.slaveCommandPrefix))
+        if (StringUtils.isEmpty(agentCommandPrefix)) {
+            if (!StringUtils.isEmpty(other.agentCommandPrefix))
                 return false;
-        } else if (!slaveCommandPrefix.equals(other.slaveCommandPrefix))
+        } else if (!agentCommandPrefix.equals(other.agentCommandPrefix))
             return false;
-        if (StringUtils.isEmpty(slaveCommandSuffix)) {
-            if (!StringUtils.isEmpty(other.slaveCommandSuffix))
+        if (StringUtils.isEmpty(agentCommandSuffix)) {
+            if (!StringUtils.isEmpty(other.agentCommandSuffix))
                 return false;
-        } else if (!slaveCommandSuffix.equals(other.slaveCommandSuffix))
+        } else if (!agentCommandSuffix.equals(other.agentCommandSuffix))
             return false;
         if (StringUtils.isEmpty(sshPort)) {
             if (!StringUtils.isEmpty(other.sshPort))

--- a/src/main/java/hudson/plugins/ec2/NoDelayProvisionerStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/NoDelayProvisionerStrategy.java
@@ -3,8 +3,8 @@ package hudson.plugins.ec2;
 import hudson.Extension;
 import hudson.model.Label;
 import hudson.model.LoadStatistics;
-import hudson.slaves.Cloud;
-import hudson.slaves.NodeProvisioner;
+import hudson.agents.Cloud;
+import hudson.agents.NodeProvisioner;
 import jenkins.model.Jenkins;
 
 import java.util.Collection;

--- a/src/main/java/hudson/plugins/ec2/PluginImpl.java
+++ b/src/main/java/hudson/plugins/ec2/PluginImpl.java
@@ -79,7 +79,7 @@ public class PluginImpl extends Plugin implements Describable<PluginImpl> {
     public void postInitialize() throws IOException {
         // backward compatibility with the legacy class name
         Jenkins.XSTREAM.alias("hudson.plugins.ec2.EC2Cloud", AmazonEC2Cloud.class);
-        Jenkins.XSTREAM.alias("hudson.plugins.ec2.EC2Slave", EC2OndemandSlave.class);
+        Jenkins.XSTREAM.alias("hudson.plugins.ec2.EC2Agent", EC2OndemandAgent.class);
         // backward compatibility with the legacy instance type
         Jenkins.XSTREAM.registerConverter(new InstanceTypeConverter());
 

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -17,10 +17,10 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package hudson.plugins.ec2;
-import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED;
-import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED;
-import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT;
-import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_JAVA_PATH;
+import static hudson.plugins.ec2.EC2AbstractAgent.DEFAULT_METADATA_ENDPOINT_ENABLED;
+import static hudson.plugins.ec2.EC2AbstractAgent.DEFAULT_METADATA_TOKENS_REQUIRED;
+import static hudson.plugins.ec2.EC2AbstractAgent.DEFAULT_METADATA_HOPS_LIMIT;
+import static hudson.plugins.ec2.EC2AbstractAgent.DEFAULT_JAVA_PATH;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
@@ -91,15 +91,15 @@ import hudson.plugins.ec2.util.EC2AgentFactory;
 import hudson.plugins.ec2.util.MinimumInstanceChecker;
 import hudson.plugins.ec2.util.MinimumNumberOfInstancesTimeRangeConfig;
 import hudson.security.Permission;
-import hudson.slaves.NodeProperty;
-import hudson.slaves.NodePropertyDescriptor;
+import hudson.agents.NodeProperty;
+import hudson.agents.NodePropertyDescriptor;
 import hudson.util.DescribableList;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
-import jenkins.slaves.iterators.api.NodeIterator;
+import jenkins.agents.iterators.api.NodeIterator;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -137,12 +137,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Template of {@link EC2AbstractSlave} to launch.
+ * Template of {@link EC2AbstractAgent} to launch.
  *
  * @author Kohsuke Kawaguchi
  */
-public class SlaveTemplate implements Describable<SlaveTemplate> {
-    private static final Logger LOGGER = Logger.getLogger(SlaveTemplate.class.getName());
+public class AgentTemplate implements Describable<AgentTemplate> {
+    private static final Logger LOGGER = Logger.getLogger(AgentTemplate.class.getName());
 
     private static final String EC2_RESOURCE_ID_DELIMETERS = "[\\s,;]+";
 
@@ -269,10 +269,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public transient String rootCommandPrefix;
 
     @Deprecated
-    public transient String slaveCommandPrefix;
+    public transient String agentCommandPrefix;
 
     @Deprecated
-    public transient String slaveCommandSuffix;
+    public transient String agentCommandSuffix;
 
     @Deprecated
     public boolean usePrivateDnsName;
@@ -284,7 +284,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public transient boolean useDedicatedTenancy;
 
     @DataBoundConstructor
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
                          InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
                          String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String javaPath, String jvmopts,
                          boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, int minimumNumberOfInstances,
@@ -374,7 +374,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     @Deprecated
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
                          InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
                          String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts,
                          boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, int minimumNumberOfInstances,
@@ -396,7 +396,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     @Deprecated
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
                          InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
                          String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts,
                          boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, int minimumNumberOfInstances,
@@ -417,7 +417,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     @Deprecated
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
                          InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
                          String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts,
                          boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, int minimumNumberOfInstances,
@@ -438,7 +438,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     @Deprecated
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
             InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
             String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts,
             boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, int minimumNumberOfInstances,
@@ -459,7 +459,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     @Deprecated
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
             InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
             String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts,
             boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, int minimumNumberOfInstances,
@@ -475,7 +475,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     @Deprecated
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
             InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
             String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts,
             boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes, int minimumNumberOfInstances,
@@ -491,7 +491,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     @Deprecated
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
                          InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
                          String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts,
                          boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes,
@@ -507,7 +507,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     @Deprecated
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
             InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
             String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts,
             boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes,
@@ -523,7 +523,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     @Deprecated
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
             InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
             String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts,
             boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes,
@@ -538,7 +538,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     @Deprecated
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
             InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
             String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts,
             boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes,
@@ -552,7 +552,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     @Deprecated
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
             InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description, String initScript,
             String tmpDir, String userData, String numExecutors, String remoteAdmin, AMITypeData amiType, String jvmopts,
             boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes,
@@ -567,21 +567,21 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     /**
      * Backward compatible constructor for reloading previous version data
      */
-    public SlaveTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
+    public AgentTemplate(String ami, String zone, SpotConfiguration spotConfig, String securityGroups, String remoteFS,
             String sshPort, InstanceType type, boolean ebsOptimized, String labelString, Node.Mode mode, String description,
             String initScript, String tmpDir, String userData, String numExecutors, String remoteAdmin, String rootCommandPrefix,
-            String slaveCommandPrefix, String slaveCommandSuffix, String jvmopts, boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes,
+            String agentCommandPrefix, String agentCommandSuffix, String jvmopts, boolean stopOnTerminate, String subnetId, List<EC2Tag> tags, String idleTerminationMinutes,
             boolean usePrivateDnsName, String instanceCapStr, String iamInstanceProfile, boolean useEphemeralDevices,
             String launchTimeoutStr) {
         this(ami, zone, spotConfig, securityGroups, remoteFS, type, ebsOptimized, labelString, mode, description, initScript,
-                tmpDir, userData, numExecutors, remoteAdmin, new UnixData(rootCommandPrefix, slaveCommandPrefix, slaveCommandSuffix, sshPort, null),
+                tmpDir, userData, numExecutors, remoteAdmin, new UnixData(rootCommandPrefix, agentCommandPrefix, agentCommandSuffix, sshPort, null),
                 jvmopts, stopOnTerminate, subnetId, tags, idleTerminationMinutes, usePrivateDnsName, instanceCapStr, iamInstanceProfile,
                 useEphemeralDevices, false, launchTimeoutStr, false, null);
     }
 
     public boolean isConnectBySSHProcess() {
         // See
-        // src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-connectBySSHProcess.html
+        // src/main/resources/hudson/plugins/ec2/AgentTemplate/help-connectBySSHProcess.html
         return connectBySSHProcess;
     }
 
@@ -601,7 +601,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return String.format("EC2 (%s) - %s", parent.getDisplayName(), description);
     }
 
-    public String getSlaveName(String instanceId) {
+    public String getAgentName(String instanceId) {
         final String agentName = String.format("%s (%s)", getDisplayName(), instanceId);
         try {
             Jenkins.checkGoodName(agentName);
@@ -635,7 +635,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         try {
             return Integer.parseInt(numExecutors);
         } catch (NumberFormatException e) {
-            return EC2AbstractSlave.toNumExecutors(type);
+            return EC2AbstractAgent.toNumExecutors(type);
         }
     }
 
@@ -662,12 +662,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return (amiType.isUnix() ? ((UnixData) amiType).getRootCommandPrefix() : (amiType.isMac() ? ((MacData) amiType).getRootCommandPrefix():""));
     }
 
-    public String getSlaveCommandPrefix() {
-        return (amiType.isUnix() ? ((UnixData) amiType).getSlaveCommandPrefix() : (amiType.isMac() ? ((MacData) amiType).getSlaveCommandPrefix() : ""));
+    public String getAgentCommandPrefix() {
+        return (amiType.isUnix() ? ((UnixData) amiType).getAgentCommandPrefix() : (amiType.isMac() ? ((MacData) amiType).getAgentCommandPrefix() : ""));
     }
 
-    public String getSlaveCommandSuffix() {
-        return (amiType.isUnix() ? ((UnixData) amiType).getSlaveCommandSuffix() : (amiType.isMac() ? ((MacData) amiType).getSlaveCommandSuffix() : ""));
+    public String getAgentCommandSuffix() {
+        return (amiType.isUnix() ? ((UnixData) amiType).getAgentCommandSuffix() : (amiType.isMac() ? ((MacData) amiType).getAgentCommandSuffix() : ""));
     }
 
     public String chooseSubnetId() {
@@ -859,7 +859,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     @Override
     public String toString() {
-        return "SlaveTemplate{" +
+        return "AgentTemplate{" +
                 "description='" + description + '\'' +
                 ", labels='" + labels + '\'' +
                 '}';
@@ -897,7 +897,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @return always non-null. This needs to be then added to {@link Hudson#addNode(Node)}.
      */
     @NonNull
-    public List<EC2AbstractSlave> provision(int number, EnumSet<ProvisionOptions> provisionOptions) throws AmazonClientException, IOException {
+    public List<EC2AbstractAgent> provision(int number, EnumSet<ProvisionOptions> provisionOptions) throws AmazonClientException, IOException {
         final Image image = getImage();
         if (this.spotConfig != null) {
             if (provisionOptions.contains(ProvisionOptions.ALLOW_CREATE) || provisionOptions.contains(ProvisionOptions.FORCE_CREATE))
@@ -911,7 +911,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * Safely we can pickup only instance that is not known by Jenkins at all.
      */
     private boolean checkInstance(Instance instance) {
-        for (EC2AbstractSlave node : NodeIterator.nodes(EC2AbstractSlave.class)) {
+        for (EC2AbstractAgent node : NodeIterator.nodes(EC2AbstractAgent.class)) {
             if ( (node.getInstanceId().equals(instance.getInstanceId())) &&
                     (! (instance.getState().getName().equalsIgnoreCase(InstanceStateName.Stopped.toString())
                 ))
@@ -1060,7 +1060,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             riRequest.withNetworkInterfaces(net);
         }
 
-        HashSet<Tag> instTags = buildTags(EC2Cloud.EC2_SLAVE_TYPE_DEMAND);
+        HashSet<Tag> instTags = buildTags(EC2Cloud.EC2_AGENT_TYPE_DEMAND);
         for (Tag tag : instTags) {
             diFilters.add(new Filter("tag:" + tag.getKey()).withValues(tag.getValue()));
         }
@@ -1078,7 +1078,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         InstanceMetadataOptionsRequest instanceMetadataOptionsRequest = new InstanceMetadataOptionsRequest();
         instanceMetadataOptionsRequest.setHttpEndpoint(metadataEndpointEnabled ? InstanceMetadataEndpointState.Enabled.toString() : InstanceMetadataEndpointState.Disabled.toString());
-        instanceMetadataOptionsRequest.setHttpPutResponseHopLimit(metadataHopsLimit == null ? EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT : metadataHopsLimit);
+        instanceMetadataOptionsRequest.setHttpPutResponseHopLimit(metadataHopsLimit == null ? EC2AbstractAgent.DEFAULT_METADATA_HOPS_LIMIT : metadataHopsLimit);
         instanceMetadataOptionsRequest.setHttpTokens(
                     metadataTokensRequired ? HttpTokensState.Required.toString() : HttpTokensState.Optional.toString());
         riRequest.setMetadataOptions(instanceMetadataOptionsRequest);
@@ -1096,7 +1096,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     /**
      * Provisions an On-demand EC2 agent by launching a new instance or starting a previously-stopped instance.
      */
-    private List<EC2AbstractSlave> provisionOndemand(Image image, int number, EnumSet<ProvisionOptions> provisionOptions)
+    private List<EC2AbstractAgent> provisionOndemand(Image image, int number, EnumSet<ProvisionOptions> provisionOptions)
             throws IOException {
         return provisionOndemand(image, number, provisionOptions, false, false);
     }
@@ -1104,7 +1104,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     /**
      * Provisions an On-demand EC2 agent by launching a new instance or starting a previously-stopped instance.
      */
-    private List<EC2AbstractSlave> provisionOndemand(Image image, int number, EnumSet<ProvisionOptions> provisionOptions, boolean spotWithoutBidPrice, boolean fallbackSpotToOndemand)
+    private List<EC2AbstractAgent> provisionOndemand(Image image, int number, EnumSet<ProvisionOptions> provisionOptions, boolean spotWithoutBidPrice, boolean fallbackSpotToOndemand)
             throws IOException {
         AmazonEC2 ec2 = getParent().connect();
 
@@ -1131,7 +1131,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         wakeOrphansOrStoppedUp(ec2, orphansOrStopped);
 
         if (orphansOrStopped.size() == number) {
-            return toSlaves(orphansOrStopped);
+            return toAgents(orphansOrStopped);
         }
 
         riRequest.setMaxCount(number - orphansOrStopped.size());
@@ -1166,7 +1166,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         newInstances.addAll(orphansOrStopped);
 
-        return toSlaves(newInstances);
+        return toAgents(newInstances);
     }
 
     void wakeOrphansOrStoppedUp(AmazonEC2 ec2, List<Instance> orphansOrStopped) {
@@ -1190,14 +1190,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     }
 
-    List<EC2AbstractSlave> toSlaves(List<Instance> newInstances) throws IOException {
+    List<EC2AbstractAgent> toAgents(List<Instance> newInstances) throws IOException {
         try {
-            List<EC2AbstractSlave> slaves = new ArrayList<>(newInstances.size());
+            List<EC2AbstractAgent> agents = new ArrayList<>(newInstances.size());
             for (Instance instance : newInstances) {
-                slaves.add(newOndemandSlave(instance));
+                agents.add(newOndemandAgent(instance));
                 logProvisionInfo("Return instance: " + instance);
             }
-            return slaves;
+            return agents;
         } catch (FormException e) {
             throw new AssertionError(e); // we should have discovered all
             // configuration issues upfront
@@ -1364,7 +1364,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     /**
      * Provision a new agent for an EC2 spot instance to call back to Jenkins
      */
-    private List<EC2AbstractSlave> provisionSpot(Image image, int number, EnumSet<ProvisionOptions> provisionOptions)
+    private List<EC2AbstractAgent> provisionSpot(Image image, int number, EnumSet<ProvisionOptions> provisionOptions)
             throws IOException {
         if (!spotConfig.useBidPrice) {
             return provisionOndemand(image, 1, provisionOptions, true, spotConfig.getFallbackToOndemand());
@@ -1434,7 +1434,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             net.setDeviceIndex(0);
             launchSpecification.withNetworkInterfaces(net);
 
-            HashSet<Tag> instTags = buildTags(EC2Cloud.EC2_SLAVE_TYPE_SPOT);
+            HashSet<Tag> instTags = buildTags(EC2Cloud.EC2_AGENT_TYPE_SPOT);
 
             if (StringUtils.isNotBlank(getIamInstanceProfile())) {
                 launchSpecification.setIamInstanceProfile(new IamInstanceProfileSpecification().withArn(getIamInstanceProfile()));
@@ -1466,19 +1466,19 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 throw new AmazonClientException("No spot instances found");
             }
 
-            List<EC2AbstractSlave> slaves = new ArrayList<>(reqInstances.size());
+            List<EC2AbstractAgent> agents = new ArrayList<>(reqInstances.size());
             for(SpotInstanceRequest spotInstReq : reqInstances) {
                 if (spotInstReq == null) {
                     throw new AmazonClientException("Spot instance request is null");
                 }
-                String slaveName = spotInstReq.getSpotInstanceRequestId();
+                String agentName = spotInstReq.getSpotInstanceRequestId();
 
                 if (spotConfig.getFallbackToOndemand()) {
                     for (int i = 0; i < 2 && spotInstReq.getStatus().getCode().equals("pending-evaluation"); i++) {
-                        LOGGER.info("Spot request " + slaveName + " is still pending evaluation");
+                        LOGGER.info("Spot request " + agentName + " is still pending evaluation");
                         Thread.sleep(5000);
-                        LOGGER.info("Fetching info about spot request " + slaveName);
-                        DescribeSpotInstanceRequestsRequest describeRequest = new DescribeSpotInstanceRequestsRequest().withSpotInstanceRequestIds(slaveName);
+                        LOGGER.info("Fetching info about spot request " + agentName);
+                        DescribeSpotInstanceRequestsRequest describeRequest = new DescribeSpotInstanceRequestsRequest().withSpotInstanceRequestIds(agentName);
                         spotInstReq = ec2.describeSpotInstanceRequests(describeRequest).getSpotInstanceRequests().get(0);
                     }
 
@@ -1500,10 +1500,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
                 LOGGER.info("Spot instance id in provision: " + spotInstReq.getSpotInstanceRequestId());
 
-                slaves.add(newSpotSlave(spotInstReq));
+                agents.add(newSpotAgent(spotInstReq));
             }
 
-            return slaves;
+            return agents;
 
         } catch (FormException e) {
             throw new AssertionError(); // we should have discovered all
@@ -1523,14 +1523,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
     }
 
-    private HashSet<Tag> buildTags(String slaveType) {
+    private HashSet<Tag> buildTags(String agentType) {
         boolean hasCustomTypeTag = false;
         boolean hasJenkinsServerUrlTag = false;
         HashSet<Tag> instTags = new HashSet<>();
         if (tags != null && !tags.isEmpty()) {
             for (EC2Tag t : tags) {
                 instTags.add(new Tag(t.getName(), t.getValue()));
-                if (StringUtils.equals(t.getName(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE)) {
+                if (StringUtils.equals(t.getName(), EC2Tag.TAG_NAME_JENKINS_AGENT_TYPE)) {
                     hasCustomTypeTag = true;
                 }
                 if (StringUtils.equals(t.getName(), EC2Tag.TAG_NAME_JENKINS_SERVER_URL)) {
@@ -1539,8 +1539,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             }
         }
         if (!hasCustomTypeTag) {
-            instTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, EC2Cloud.getSlaveTypeTagValue(
-                    slaveType, description)));
+            instTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_AGENT_TYPE, EC2Cloud.getAgentTypeTagValue(
+                    agentType, description)));
         }
         JenkinsLocationConfiguration jenkinsLocation = JenkinsLocationConfiguration.get();
         if (!hasJenkinsServerUrlTag && jenkinsLocation.getUrl() != null) {
@@ -1549,9 +1549,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return instTags;
     }
 
-    protected EC2OndemandSlave newOndemandSlave(Instance inst) throws FormException, IOException {
+    protected EC2OndemandAgent newOndemandAgent(Instance inst) throws FormException, IOException {
         EC2AgentConfig.OnDemand config = new EC2AgentConfig.OnDemandBuilder()
-            .withName(getSlaveName(inst.getInstanceId()))
+            .withName(getAgentName(inst.getInstanceId()))
             .withInstanceId(inst.getInstanceId())
             .withDescription(description)
             .withRemoteFS(remoteFS)
@@ -1582,9 +1582,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return EC2AgentFactory.getInstance().createOnDemandAgent(config);
     }
 
-    protected EC2SpotSlave newSpotSlave(SpotInstanceRequest sir) throws FormException, IOException {
+    protected EC2SpotAgent newSpotAgent(SpotInstanceRequest sir) throws FormException, IOException {
         EC2AgentConfig.Spot config = new EC2AgentConfig.SpotBuilder()
-            .withName(getSlaveName(sir.getSpotInstanceRequestId()))
+            .withName(getAgentName(sir.getSpotInstanceRequestId()))
             .withSpotInstanceRequestId(sir.getSpotInstanceRequestId())
             .withDescription(description)
             .withRemoteFS(remoteFS)
@@ -1697,7 +1697,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     /**
      * Provisions a new EC2 agent based on the currently running instance on EC2, instead of starting a new one.
      */
-    public EC2AbstractSlave attach(String instanceId, TaskListener listener) throws AmazonClientException, IOException {
+    public EC2AbstractAgent attach(String instanceId, TaskListener listener) throws AmazonClientException, IOException {
         PrintStream logger = listener.getLogger();
         AmazonEC2 ec2 = getParent().connect();
 
@@ -1707,7 +1707,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             DescribeInstancesRequest request = new DescribeInstancesRequest();
             request.setInstanceIds(Collections.singletonList(instanceId));
             Instance inst = ec2.describeInstances(request).getReservations().get(0).getInstances().get(0);
-            return newOndemandSlave(inst);
+            return newOndemandAgent(inst);
         } catch (FormException e) {
             throw new AssertionError(); // we should have discovered all
                                         // configuration issues upfront
@@ -1738,7 +1738,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
 
         if (amiType == null) {
-            amiType = new UnixData(rootCommandPrefix, slaveCommandPrefix, slaveCommandSuffix, sshPort, null);
+            amiType = new UnixData(rootCommandPrefix, agentCommandPrefix, agentCommandSuffix, sshPort, null);
         }
 
          // 1.43 new parameters
@@ -1768,13 +1768,13 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
 
         if (metadataEndpointEnabled == null) {
-            metadataEndpointEnabled = EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED;
+            metadataEndpointEnabled = EC2AbstractAgent.DEFAULT_METADATA_ENDPOINT_ENABLED;
         }
         if (metadataTokensRequired == null) {
-            metadataTokensRequired = EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED;
+            metadataTokensRequired = EC2AbstractAgent.DEFAULT_METADATA_TOKENS_REQUIRED;
         }
         if (metadataHopsLimit == null) {
-            metadataHopsLimit = EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT;
+            metadataHopsLimit = EC2AbstractAgent.DEFAULT_METADATA_HOPS_LIMIT;
         }
         if (StringUtils.isBlank(javaPath)) {
             javaPath = DEFAULT_JAVA_PATH;
@@ -1783,7 +1783,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return this;
     }
 
-    public Descriptor<SlaveTemplate> getDescriptor() {
+    public Descriptor<AgentTemplate> getDescriptor() {
         return Jenkins.get().getDescriptor(getClass());
     }
 
@@ -1799,11 +1799,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
     }
 
-    public boolean isWindowsSlave() {
+    public boolean isWindowsAgent() {
         return amiType.isWindows();
     }
 
-    public boolean isUnixSlave() {
+    public boolean isUnixAgent() {
         return amiType.isUnix();
     }
 
@@ -1822,8 +1822,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     /**
      *
      * @param ec2
-     * @param allSubnets if true, uses all subnets defined for this SlaveTemplate as the filter, else will only use the current subnet
-     * @return DescribeInstancesResult of DescribeInstanceRequst constructed from this SlaveTemplate's configs
+     * @param allSubnets if true, uses all subnets defined for this AgentTemplate as the filter, else will only use the current subnet
+     * @return DescribeInstancesResult of DescribeInstanceRequst constructed from this AgentTemplate's configs
      */
     DescribeInstancesResult getDescribeInstanceResult(AmazonEC2 ec2, boolean allSubnets) throws IOException {
         HashMap<RunInstancesRequest, List<Filter>> runInstancesRequestFilterMap = makeRunInstancesRequestAndFilters(getImage(), 1, ec2, false);
@@ -1842,7 +1842,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 diFilters.remove(f);
             }
 
-            /* Add filter using all subnets defined for this SlaveTemplate */
+            /* Add filter using all subnets defined for this AgentTemplate */
             Filter subnetFilter = new Filter("subnet-id");
             subnetFilter.setValues(Arrays.asList(getSubnetId().split(EC2_RESOURCE_ID_DELIMETERS)));
             diFilters.add(subnetFilter);
@@ -1867,7 +1867,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     @Extension
-    public static final class DescriptorImpl extends Descriptor<SlaveTemplate> {
+    public static final class DescriptorImpl extends Descriptor<AgentTemplate> {
 
         @Override
         public String getDisplayName() {
@@ -1886,15 +1886,15 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             String p = super.getHelpFile(fieldName);
             if (p != null)
                 return p;
-            Descriptor slaveDescriptor = Jenkins.get().getDescriptor(EC2OndemandSlave.class);
-            if (slaveDescriptor != null) {
-                p = slaveDescriptor.getHelpFile(fieldName);
+            Descriptor agentDescriptor = Jenkins.get().getDescriptor(EC2OndemandAgent.class);
+            if (agentDescriptor != null) {
+                p = agentDescriptor.getHelpFile(fieldName);
                 if (p != null)
                     return p;
             }
-            slaveDescriptor = Jenkins.get().getDescriptor(EC2SpotSlave.class);
-            if (slaveDescriptor != null)
-                return slaveDescriptor.getHelpFile(fieldName);
+            agentDescriptor = Jenkins.get().getDescriptor(EC2SpotAgent.class);
+            if (agentDescriptor != null)
+                return agentDescriptor.getHelpFile(fieldName);
             return null;
         }
 
@@ -2114,7 +2114,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 throws IOException, ServletException {
             checkPermission(EC2Cloud.PROVISION);
             AWSCredentialsProvider credentialsProvider = EC2Cloud.createCredentialsProvider(useInstanceProfileForCredentials, credentialsId, roleArn, roleSessionName, region);
-            return EC2AbstractSlave.fillZoneItems(credentialsProvider, region);
+            return EC2AbstractAgent.fillZoneItems(credentialsProvider, region);
         }
 
         public String getDefaultTenancy() {
@@ -2138,7 +2138,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
 
         public List<NodePropertyDescriptor> getNodePropertyDescriptors() {
-            return NodePropertyDescriptor.for_(NodeProperty.all(), EC2AbstractSlave.class);
+            return NodePropertyDescriptor.for_(NodeProperty.all(), EC2AbstractAgent.class);
         }
 
         @POST

--- a/src/main/java/hudson/plugins/ec2/UnixData.java
+++ b/src/main/java/hudson/plugins/ec2/UnixData.java
@@ -8,16 +8,16 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 public class UnixData extends AMITypeData {
     private final String rootCommandPrefix;
-    private final String slaveCommandPrefix;
-    private final String slaveCommandSuffix;
+    private final String agentCommandPrefix;
+    private final String agentCommandSuffix;
     private final String sshPort;
     private final String bootDelay;
 
     @DataBoundConstructor
-    public UnixData(String rootCommandPrefix, String slaveCommandPrefix, String slaveCommandSuffix, String sshPort, String bootDelay) {
+    public UnixData(String rootCommandPrefix, String agentCommandPrefix, String agentCommandSuffix, String sshPort, String bootDelay) {
         this.rootCommandPrefix = rootCommandPrefix;
-        this.slaveCommandPrefix = slaveCommandPrefix;
-        this.slaveCommandSuffix = slaveCommandSuffix;
+        this.agentCommandPrefix = agentCommandPrefix;
+        this.agentCommandSuffix = agentCommandSuffix;
         this.sshPort = sshPort;
         this.bootDelay = bootDelay;
 
@@ -59,12 +59,12 @@ public class UnixData extends AMITypeData {
         return rootCommandPrefix;
     }
 
-    public String getSlaveCommandPrefix() {
-        return slaveCommandPrefix;
+    public String getAgentCommandPrefix() {
+        return agentCommandPrefix;
     }
 
-    public String getSlaveCommandSuffix() {
-        return slaveCommandSuffix;
+    public String getAgentCommandSuffix() {
+        return agentCommandSuffix;
     }
 
     public String getSshPort() {
@@ -80,8 +80,8 @@ public class UnixData extends AMITypeData {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((rootCommandPrefix == null) ? 0 : rootCommandPrefix.hashCode());
-        result = prime * result + ((slaveCommandPrefix == null) ? 0 : slaveCommandPrefix.hashCode());
-        result = prime * result + ((slaveCommandSuffix == null) ? 0 : slaveCommandSuffix.hashCode());
+        result = prime * result + ((agentCommandPrefix == null) ? 0 : agentCommandPrefix.hashCode());
+        result = prime * result + ((agentCommandSuffix == null) ? 0 : agentCommandSuffix.hashCode());
         result = prime * result + ((sshPort == null) ? 0 : sshPort.hashCode());
         result = prime * result + ((bootDelay == null) ? 0 : bootDelay.hashCode());
         return result;
@@ -101,15 +101,15 @@ public class UnixData extends AMITypeData {
                 return false;
         } else if (!rootCommandPrefix.equals(other.rootCommandPrefix))
             return false;
-        if (StringUtils.isEmpty(slaveCommandPrefix)) {
-            if (!StringUtils.isEmpty(other.slaveCommandPrefix))
+        if (StringUtils.isEmpty(agentCommandPrefix)) {
+            if (!StringUtils.isEmpty(other.agentCommandPrefix))
                 return false;
-        } else if (!slaveCommandPrefix.equals(other.slaveCommandPrefix))
+        } else if (!agentCommandPrefix.equals(other.agentCommandPrefix))
             return false;
-        if (StringUtils.isEmpty(slaveCommandSuffix)) {
-            if (!StringUtils.isEmpty(other.slaveCommandSuffix))
+        if (StringUtils.isEmpty(agentCommandSuffix)) {
+            if (!StringUtils.isEmpty(other.agentCommandSuffix))
                 return false;
-        } else if (!slaveCommandSuffix.equals(other.slaveCommandSuffix))
+        } else if (!agentCommandSuffix.equals(other.agentCommandSuffix))
             return false;
         if (StringUtils.isEmpty(sshPort)) {
             if (!StringUtils.isEmpty(other.sshPort))

--- a/src/main/java/hudson/plugins/ec2/ssh/verifiers/AcceptNewStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/verifiers/AcceptNewStrategy.java
@@ -26,7 +26,7 @@ package hudson.plugins.ec2.ssh.verifiers;
 import hudson.model.TaskListener;
 import hudson.plugins.ec2.EC2Cloud;
 import hudson.plugins.ec2.EC2Computer;
-import hudson.slaves.OfflineCause;
+import hudson.agents.OfflineCause;
 
 import java.io.IOException;
 import java.util.logging.Level;

--- a/src/main/java/hudson/plugins/ec2/ssh/verifiers/CheckNewHardStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/verifiers/CheckNewHardStrategy.java
@@ -26,7 +26,7 @@ package hudson.plugins.ec2.ssh.verifiers;
 import hudson.model.TaskListener;
 import hudson.plugins.ec2.EC2Cloud;
 import hudson.plugins.ec2.EC2Computer;
-import hudson.slaves.OfflineCause;
+import hudson.agents.OfflineCause;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/hudson/plugins/ec2/ssh/verifiers/CheckNewSoftStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/verifiers/CheckNewSoftStrategy.java
@@ -26,7 +26,7 @@ package hudson.plugins.ec2.ssh.verifiers;
 import hudson.model.TaskListener;
 import hudson.plugins.ec2.EC2Cloud;
 import hudson.plugins.ec2.EC2Computer;
-import hudson.slaves.OfflineCause;
+import hudson.agents.OfflineCause;
 
 import java.io.IOException;
 import java.util.logging.Level;

--- a/src/main/java/hudson/plugins/ec2/ssh/verifiers/HostKey.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/verifiers/HostKey.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Original work from ssh-slaves-plugin Copyright (c) 2016, Michael Clarke
+ * Original work from ssh-agents-plugin Copyright (c) 2016, Michael Clarke
  * Modified work Copyright (c) 2020-, M Ramon Leon, CloudBees, Inc.
  * Modified work:
  * - Just the since annotation

--- a/src/main/java/hudson/plugins/ec2/ssh/verifiers/HostKeyHelper.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/verifiers/HostKeyHelper.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Original work from ssh-slaves-plugin Copyright (c) 2016, Michael Clarke
+ * Original work from ssh-agents-plugin Copyright (c) 2016, Michael Clarke
  * Modified work Copyright (c) 2020-, M Ramon Leon, CloudBees, Inc.
  * Modified work:
  * - Just the since annotation

--- a/src/main/java/hudson/plugins/ec2/ssh/verifiers/SshHostKeyVerificationAdministrativeMonitor.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/verifiers/SshHostKeyVerificationAdministrativeMonitor.java
@@ -28,8 +28,8 @@ import hudson.model.AdministrativeMonitor;
 import hudson.plugins.ec2.EC2Cloud;
 import hudson.plugins.ec2.HostKeyVerificationStrategyEnum;
 import hudson.plugins.ec2.PluginImpl;
-import hudson.plugins.ec2.SlaveTemplate;
-import hudson.slaves.Cloud;
+import hudson.plugins.ec2.AgentTemplate;
+import hudson.agents.Cloud;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
@@ -107,10 +107,10 @@ public class SshHostKeyVerificationAdministrativeMonitor extends AdministrativeM
     }
 
     private boolean gatherInsecureTemplate(EC2Cloud cloud) {
-        List<SlaveTemplate> templates = cloud.getTemplates();
-        for (SlaveTemplate template : templates) {
+        List<AgentTemplate> templates = cloud.getTemplates();
+        for (AgentTemplate template : templates) {
             // It's only for unix templates
-            if (!template.isUnixSlave() || !template.isMacAgent()) {
+            if (!template.isUnixAgent() || !template.isMacAgent()) {
                 continue;
             }
 

--- a/src/main/java/hudson/plugins/ec2/ssh/verifiers/SshHostKeyVerificationStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/verifiers/SshHostKeyVerificationStrategy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Original work from ssh-slaves-plugin Copyright (c) 2016, Michael Clarke
+ * Original work from ssh-agents-plugin Copyright (c) 2016, Michael Clarke
  * Modified work Copyright (c) 2020-, M Ramon Leon, CloudBees, Inc.
  * Modified work:
  * - getHostKeyFromConsole method and called methods

--- a/src/main/java/hudson/plugins/ec2/util/EC2AgentConfig.java
+++ b/src/main/java/hudson/plugins/ec2/util/EC2AgentConfig.java
@@ -5,7 +5,7 @@ import hudson.model.Node;
 import hudson.plugins.ec2.AMITypeData;
 import hudson.plugins.ec2.ConnectionStrategy;
 import hudson.plugins.ec2.EC2Tag;
-import hudson.slaves.NodeProperty;
+import hudson.agents.NodeProperty;
 
 import java.util.List;
 

--- a/src/main/java/hudson/plugins/ec2/util/EC2AgentFactory.java
+++ b/src/main/java/hudson/plugins/ec2/util/EC2AgentFactory.java
@@ -20,8 +20,8 @@ public interface EC2AgentFactory {
         return instance;
     }
 
-    EC2OndemandSlave createOnDemandAgent(EC2AgentConfig.OnDemand config) throws Descriptor.FormException, IOException;
+    EC2OndemandAgent createOnDemandAgent(EC2AgentConfig.OnDemand config) throws Descriptor.FormException, IOException;
 
-    EC2SpotSlave createSpotAgent(EC2AgentConfig.Spot config) throws Descriptor.FormException, IOException;
+    EC2SpotAgent createSpotAgent(EC2AgentConfig.Spot config) throws Descriptor.FormException, IOException;
 
 }

--- a/src/main/java/hudson/plugins/ec2/util/EC2AgentFactoryImpl.java
+++ b/src/main/java/hudson/plugins/ec2/util/EC2AgentFactoryImpl.java
@@ -10,13 +10,13 @@ import hudson.plugins.ec2.*;
 public class EC2AgentFactoryImpl implements EC2AgentFactory {
 
     @Override
-    public EC2OndemandSlave createOnDemandAgent(EC2AgentConfig.OnDemand config)
+    public EC2OndemandAgent createOnDemandAgent(EC2AgentConfig.OnDemand config)
             throws Descriptor.FormException, IOException {
-        return new EC2OndemandSlave(config.name, config.instanceId, config.description, config.remoteFS, config.numExecutors, config.labelString, config.mode, config.initScript, config.tmpDir, config.nodeProperties, config.remoteAdmin, config.javaPath, config.jvmopts, config.stopOnTerminate, config.idleTerminationMinutes, config.publicDNS, config.privateDNS, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses, config.tenancy, config.metadataEndpointEnabled, config.metadataTokensRequired, config.metadataHopsLimit);
+        return new EC2OndemandAgent(config.name, config.instanceId, config.description, config.remoteFS, config.numExecutors, config.labelString, config.mode, config.initScript, config.tmpDir, config.nodeProperties, config.remoteAdmin, config.javaPath, config.jvmopts, config.stopOnTerminate, config.idleTerminationMinutes, config.publicDNS, config.privateDNS, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses, config.tenancy, config.metadataEndpointEnabled, config.metadataTokensRequired, config.metadataHopsLimit);
     }
 
     @Override
-    public EC2SpotSlave createSpotAgent(EC2AgentConfig.Spot config) throws Descriptor.FormException, IOException {
-        return new EC2SpotSlave(config.name, config.spotInstanceRequestId, config.description, config.remoteFS, config.numExecutors, config.mode, config.initScript, config.tmpDir, config.labelString, config.nodeProperties, config.remoteAdmin, config.javaPath, config.jvmopts, config.idleTerminationMinutes, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses);
+    public EC2SpotAgent createSpotAgent(EC2AgentConfig.Spot config) throws Descriptor.FormException, IOException {
+        return new EC2SpotAgent(config.name, config.spotInstanceRequestId, config.description, config.remoteFS, config.numExecutors, config.mode, config.initScript, config.tmpDir, config.labelString, config.nodeProperties, config.remoteAdmin, config.javaPath, config.jvmopts, config.idleTerminationMinutes, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses);
     }
 }

--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -3,7 +3,7 @@ package hudson.plugins.ec2.util;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.plugins.ec2.EC2Cloud;
 import hudson.plugins.ec2.EC2Computer;
-import hudson.plugins.ec2.SlaveTemplate;
+import hudson.plugins.ec2.AgentTemplate;
 import hudson.model.Computer;
 import hudson.model.Label;
 import hudson.model.Queue;
@@ -25,28 +25,28 @@ public class MinimumInstanceChecker {
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Needs to be overridden from tests")
     public static Clock clock = Clock.systemDefaultZone();
 
-    private static Stream<Computer> agentsForTemplate(@NonNull SlaveTemplate agentTemplate) {
+    private static Stream<Computer> agentsForTemplate(@NonNull AgentTemplate agentTemplate) {
         return (Stream<Computer>) Arrays.stream(Jenkins.get().getComputers())
                 .filter(computer -> computer instanceof EC2Computer)
                 .filter(computer -> {
-                    SlaveTemplate computerTemplate = ((EC2Computer) computer).getSlaveTemplate();
+                    AgentTemplate computerTemplate = ((EC2Computer) computer).getAgentTemplate();
                     return computerTemplate != null
                             && Objects.equals(computerTemplate.description, agentTemplate.description);
                 });
     }
 
-    public static int countCurrentNumberOfAgents(@NonNull SlaveTemplate agentTemplate) {
+    public static int countCurrentNumberOfAgents(@NonNull AgentTemplate agentTemplate) {
         return (int) agentsForTemplate(agentTemplate).count();
     }
 
-    public static int countCurrentNumberOfSpareAgents(@NonNull SlaveTemplate agentTemplate) {
+    public static int countCurrentNumberOfSpareAgents(@NonNull AgentTemplate agentTemplate) {
         return (int) agentsForTemplate(agentTemplate)
             .filter(computer -> computer.countBusy() == 0)
             .filter(computer -> computer.isOnline())
             .count();
     }
 
-    public static int countCurrentNumberOfProvisioningAgents(@NonNull SlaveTemplate agentTemplate) {
+    public static int countCurrentNumberOfProvisioningAgents(@NonNull AgentTemplate agentTemplate) {
         return (int) agentsForTemplate(agentTemplate)
             .filter(computer -> computer.countBusy() == 0)
             .filter(computer -> computer.isOffline())
@@ -57,7 +57,7 @@ public class MinimumInstanceChecker {
     /*
         Get the number of queued builds that match an AMI (agentTemplate)
     */
-    public static int countQueueItemsForAgentTemplate(@NonNull SlaveTemplate agentTemplate) {
+    public static int countQueueItemsForAgentTemplate(@NonNull AgentTemplate agentTemplate) {
         return (int)
             Queue
             .getInstance()

--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -6,7 +6,7 @@ import hudson.plugins.ec2.*;
 import hudson.plugins.ec2.win.winrm.WindowsProcess;
 import hudson.remoting.Channel;
 import hudson.remoting.Channel.Listener;
-import hudson.slaves.ComputerLauncher;
+import hudson.agents.ComputerLauncher;
 import hudson.Util;
 import hudson.os.WindowsUtil;
 
@@ -17,7 +17,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
-import hudson.slaves.OfflineCause;
+import hudson.agents.OfflineCause;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import jenkins.model.Jenkins;
@@ -39,12 +39,12 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
     protected void launchScript(EC2Computer computer, TaskListener listener) throws IOException,
             AmazonClientException, InterruptedException {
         final PrintStream logger = listener.getLogger();
-        EC2AbstractSlave node = computer.getNode();
+        EC2AbstractAgent node = computer.getNode();
         if (node == null) {
             logger.println("Unable to fetch node information");
             return;
         }
-        final SlaveTemplate template = computer.getSlaveTemplate();
+        final AgentTemplate template = computer.getAgentTemplate();
         if (template == null) {
             throw new IOException("Could not find corresponding agent template for " + computer.getDisplayName());
         }
@@ -121,7 +121,7 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
     }
 
     @NonNull
-    private WinConnection connectToWinRM(EC2Computer computer, EC2AbstractSlave node, SlaveTemplate template, PrintStream logger) throws AmazonClientException,
+    private WinConnection connectToWinRM(EC2Computer computer, EC2AbstractAgent node, AgentTemplate template, PrintStream logger) throws AmazonClientException,
             InterruptedException {
         final long minTimeout = 3000;
         long timeout = node.getLaunchTimeoutInMillis(); // timeout is less than 0 when jenkins is booting up.

--- a/src/main/java/hudson/plugins/ec2/win/SelfSignedCertificateAllowedMonitor.java
+++ b/src/main/java/hudson/plugins/ec2/win/SelfSignedCertificateAllowedMonitor.java
@@ -27,9 +27,9 @@ import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
 import hudson.plugins.ec2.AMITypeData;
 import hudson.plugins.ec2.EC2Cloud;
-import hudson.plugins.ec2.SlaveTemplate;
+import hudson.plugins.ec2.AgentTemplate;
 import hudson.plugins.ec2.WindowsData;
-import hudson.slaves.Cloud;
+import hudson.agents.Cloud;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
@@ -82,10 +82,10 @@ public class SelfSignedCertificateAllowedMonitor extends AdministrativeMonitor {
     }
 
     private boolean gatherInsecureTemplate(EC2Cloud cloud) {
-        List<SlaveTemplate> templates = cloud.getTemplates();
-        for (SlaveTemplate template : templates) {
+        List<AgentTemplate> templates = cloud.getTemplates();
+        for (AgentTemplate template : templates) {
             // It's only for window templates
-            if (!template.isWindowsSlave()) {
+            if (!template.isWindowsAgent()) {
                 continue;
             }
 

--- a/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Computer/configure.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <!--
   This is bit unusual, but so that we can override "name" with "Instance ID", override the config page entirely,
-  instead of just supplying EC2Slave/configure-entries.jelly
+  instead of just supplying EC2Agent/configure-entries.jelly
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
@@ -71,7 +71,7 @@ THE SOFTWARE.
           <f:readOnlyTextbox />
         </f:entry>
 
-        <f:entry title="${%Description}" help="/help/system-config/master-slave/description.html">
+        <f:entry title="${%Description}" help="/help/system-config/master-agent/description.html">
           <f:textbox field="nodeDescription" />
         </f:entry>
 
@@ -83,7 +83,7 @@ THE SOFTWARE.
           <f:textbox />
         </f:entry>
 
-        <f:slave-mode name="mode" node="${instance}" />
+        <f:agent-mode name="mode" node="${instance}" />
 
         <f:entry title="${%Init Script}" field="initScript">
           <f:textarea />
@@ -133,13 +133,13 @@ THE SOFTWARE.
 
         <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
 
-        <f:entry title="${%Enable Metadata HTTP Endpoint}" field="metadataEndpointEnabled" help="/descriptor/hudson.plugins.ec2.SlaveTemplate/help/metadataEndpointEnabled">
+        <f:entry title="${%Enable Metadata HTTP Endpoint}" field="metadataEndpointEnabled" help="/descriptor/hudson.plugins.ec2.AgentTemplate/help/metadataEndpointEnabled">
           <f:checkbox default="true"/>
         </f:entry>
-        <f:entry title="${%Metadata Require HTTP Tokens}" field="metadataTokensRequired" help="/descriptor/hudson.plugins.ec2.SlaveTemplate/help/metadataTokensRequired">
+        <f:entry title="${%Metadata Require HTTP Tokens}" field="metadataTokensRequired" help="/descriptor/hudson.plugins.ec2.AgentTemplate/help/metadataTokensRequired">
           <f:checkbox default="true"/>
         </f:entry>
-        <f:entry title="${%Metadata Put Response Hop Limit}" field="metadataHopsLimit" help="/descriptor/hudson.plugins.ec2.SlaveTemplate/help/metadataHopsLimit">
+        <f:entry title="${%Metadata Put Response Hop Limit}" field="metadataHopsLimit" help="/descriptor/hudson.plugins.ec2.AgentTemplate/help/metadataHopsLimit">
           <f:textbox default="1" />
         </f:entry>
 

--- a/src/main/resources/hudson/plugins/ec2/MacData/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/MacData/config.jelly
@@ -27,10 +27,10 @@ THE SOFTWARE.
       <f:entry title="${%Root command prefix}" field="rootCommandPrefix">
 	    <f:textbox/>
 	  </f:entry>
-      <f:entry title="${%Slave command prefix}" field="slaveCommandPrefix">
+      <f:entry title="${%Agent command prefix}" field="agentCommandPrefix">
 	    <f:textbox/>
 	  </f:entry>
-      <f:entry title="${%Slave command suffix}" field="slaveCommandSuffix">
+      <f:entry title="${%Agent command suffix}" field="agentCommandSuffix">
 	    <f:textbox/>
 	  </f:entry>
       <f:entry title="${%Remote ssh port}" field="sshPort">

--- a/src/main/resources/hudson/plugins/ec2/Messages.properties
+++ b/src/main/resources/hudson/plugins/ec2/Messages.properties
@@ -1,12 +1,12 @@
 EC2Cloud.FailedToObtainCredentialsFromEC2=Failed to obtain credentials from EC2 instance profile: %s
 EC2Cloud.Success=Success
 
-EC2OndemandSlave.OnDemand=On Demand
-EC2OndemandSlave.AmazonEC2=Amazon EC2
+EC2OndemandAgent.OnDemand=On Demand
+EC2OndemandAgent.AmazonEC2=Amazon EC2
 
-EC2SpotSlave.AmazonEC2SpotInstance=Amazon EC2 Spot Instance
-EC2SpotSlave.Spot1=Spot $
-EC2SpotSlave.Spot2= max bid price
+EC2SpotAgent.AmazonEC2SpotInstance=Amazon EC2 Spot Instance
+EC2SpotAgent.Spot1=Spot $
+EC2SpotAgent.Spot2= max bid price
 
 AmazonEC2Cloud.NonUniqName=Cloud name must be unique across EC2 clouds
 AmazonEC2Cloud.MalformedUrl=The URL is malformed. The default endpoint will be used

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -47,7 +47,7 @@ THE SOFTWARE.
     <f:textbox />
   </f:entry>
 
-  <f:entry title="${%AMI Filters}" help="/descriptor/hudson.plugins.ec2.SlaveTemplate/help/amiFilters">
+  <f:entry title="${%AMI Filters}" help="/descriptor/hudson.plugins.ec2.AgentTemplate/help/amiFilters">
     <f:repeatableProperty field="amiFilters">
       <f:block>
         <div align="right">
@@ -100,7 +100,7 @@ THE SOFTWARE.
     <f:textbox />
   </f:entry>
 
-  <f:slave-mode name="mode" node="${instance}" />
+  <f:agent-mode name="mode" node="${instance}" />
 
   <f:entry title="${%Idle termination time}" field="idleTerminationMinutes">
     <f:textbox default="30" />
@@ -156,7 +156,7 @@ THE SOFTWARE.
 
     <f:optionalBlock name="minimumNumberOfInstancesTimeRangeConfig"
                      title="${%Only apply minimum number of instances during specific time range}" checked="${instance.minimumNumberOfInstancesTimeRangeConfig != null}"
-        help="/descriptor/hudson.plugins.ec2.SlaveTemplate/help/minimumNumberOfInstancesTimeRangeConfig" >
+        help="/descriptor/hudson.plugins.ec2.AgentTemplate/help/minimumNumberOfInstancesTimeRangeConfig" >
       <f:entry title="${%From/to}" description="${%''13:00'' or ''1:00 PM'' format supported}">
         From: <f:textbox style="width: 25%;" field="minimumNoInstancesActiveTimeRangeFrom" value="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeFrom}" />
         To: <f:textbox style="width: 25%;" field="minimumNoInstancesActiveTimeRangeTo" value="${instance.minimumNumberOfInstancesTimeRangeConfig.minimumNoInstancesActiveTimeRangeTo}" />

--- a/src/main/resources/hudson/plugins/ec2/UnixData/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/UnixData/config.jelly
@@ -27,10 +27,10 @@ THE SOFTWARE.
       <f:entry title="${%Root command prefix}" field="rootCommandPrefix">
 	    <f:textbox/>
 	  </f:entry>
-      <f:entry title="${%Agent command prefix}" field="slaveCommandPrefix">
+      <f:entry title="${%Agent command prefix}" field="agentCommandPrefix">
 	    <f:textbox/>
 	  </f:entry>
-      <f:entry title="${%Agent command suffix}" field="slaveCommandSuffix">
+      <f:entry title="${%Agent command suffix}" field="agentCommandSuffix">
 	    <f:textbox/>
 	  </f:entry>
       <f:entry title="${%Remote ssh port}" field="sshPort">

--- a/src/main/resources/hudson/plugins/ec2/UnixData/help-bootDelay.html
+++ b/src/main/resources/hudson/plugins/ec2/UnixData/help-bootDelay.html
@@ -1,6 +1,6 @@
 <div>
 Indicate here the time in seconds to wait for the machine to be ready once the plugin detects SSH is available.
 Unfortunately, on Windows during the boot, the SSH service might be started, and then several minutes after will be
-restarted. If this restart happens during the slave provisioning, Windows will prevent subsequent SSH connections and
-the slave will not be correctly provisioned.
+restarted. If this restart happens during the agent provisioning, Windows will prevent subsequent SSH connections and
+the agent will not be correctly provisioned.
 </div>

--- a/src/main/webapp/AMI-Scripts/ubuntu-init.py
+++ b/src/main/webapp/AMI-Scripts/ubuntu-init.py
@@ -23,13 +23,13 @@ userdata = response.read()
 
 args = string.split(userdata, "&")
 jenkinsUrl = ""
-slaveName = ""
+agentName = ""
 
 for arg in args:
     if arg.split("=")[0] == "JENKINS_URL":
         jenkinsUrl = arg.split("=")[1]
-    if arg.split("=")[0] == "SLAVE_NAME":
-        slaveName = arg.split("=")[1]
+    if arg.split("=")[0] == "AGENT_NAME":
+        agentName = arg.split("=")[1]
 
-os.system("wget " + jenkinsUrl + "jnlpJars/slave.jar -O slave.jar")
-os.system("java -jar slave.jar -jnlpUrl " + jenkinsUrl + "computer/" + slaveName + "/slave-agent.jnlp")
+os.system("wget " + jenkinsUrl + "jnlpJars/agent.jar -O agent.jar")
+os.system("java -jar agent.jar -jnlpUrl " + jenkinsUrl + "computer/" + agentName + "/agent-agent.jnlp")

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudUnitTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudUnitTest.java
@@ -91,26 +91,26 @@ public class AmazonEC2CloudUnitTest {
                                                     null, "key", null, Collections.emptyList(),
                                                     "roleArn", "roleSessionName"));
         Jenkins jenkinsMock = mock(Jenkins.class);
-        EC2SpotSlave spotSlaveMock = mock(EC2SpotSlave.class);
+        EC2SpotAgent spotAgentMock = mock(EC2SpotAgent.class);
         try (MockedStatic<Jenkins> mocked = Mockito.mockStatic(Jenkins.class)) {
         mocked.when(Jenkins::get).thenReturn(jenkinsMock);
-        Mockito.when(jenkinsMock.getNodes()).thenReturn(Collections.singletonList(spotSlaveMock));
-        when(spotSlaveMock.getSpotRequest()).thenReturn(null);
-        when(spotSlaveMock.getSpotInstanceRequestId()).thenReturn("sir-id");
+        Mockito.when(jenkinsMock.getNodes()).thenReturn(Collections.singletonList(spotAgentMock));
+        when(spotAgentMock.getSpotRequest()).thenReturn(null);
+        when(spotAgentMock.getSpotInstanceRequestId()).thenReturn("sir-id");
 
         List<Instance> instances = new ArrayList<Instance>();
         for(int i=0; i<=numberOfSpotInstanceRequests; i++) {
-            instances.add(new Instance().withInstanceId("id"+i).withTags(new Tag().withKey("jenkins_slave_type").withValue("spot")));
+            instances.add(new Instance().withInstanceId("id"+i).withTags(new Tag().withKey("jenkins_agent_type").withValue("spot")));
         }
         
         AmazonEC2FactoryMockImpl.instances = instances;
         
         Mockito.doReturn(AmazonEC2FactoryMockImpl.createAmazonEC2Mock(null)).when(cloud).connect();
 
-        Method countCurrentEC2SpotSlaves = EC2Cloud.class.getDeclaredMethod("countCurrentEC2SpotSlaves", SlaveTemplate.class, String.class, Set.class);
-        countCurrentEC2SpotSlaves.setAccessible(true);
+        Method countCurrentEC2SpotAgents = EC2Cloud.class.getDeclaredMethod("countCurrentEC2SpotAgents", AgentTemplate.class, String.class, Set.class);
+        countCurrentEC2SpotAgents.setAccessible(true);
         Object[] params = {null, "jenkinsurl", new HashSet<String>()};
-        int n = (int) countCurrentEC2SpotSlaves.invoke(cloud, params);
+        int n = (int) countCurrentEC2SpotAgents.invoke(cloud, params);
         
         // Should equal number of spot instance requests + 1 for spot nodes not having a spot instance request
         assertEquals(numberOfSpotInstanceRequests+1, n);

--- a/src/test/java/hudson/plugins/ec2/ConfigurationAsCodeTest.java
+++ b/src/test/java/hudson/plugins/ec2/ConfigurationAsCodeTest.java
@@ -49,19 +49,19 @@ public class ConfigurationAsCodeTest {
         assertNotNull(ec2Cloud);
         assertTrue(ec2Cloud.isUseInstanceProfileForCredentials());
 
-        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        final List<AgentTemplate> templates = ec2Cloud.getTemplates();
         assertEquals(1, templates.size());
-        final SlaveTemplate slaveTemplate = templates.get(0);
-        assertEquals("ami-12345", slaveTemplate.getAmi());
-        assertEquals("/home/ec2-user", slaveTemplate.remoteFS);
+        final AgentTemplate agentTemplate = templates.get(0);
+        assertEquals("ami-12345", agentTemplate.getAmi());
+        assertEquals("/home/ec2-user", agentTemplate.remoteFS);
 
-        assertEquals("linux ubuntu", slaveTemplate.getLabelString());
-        assertEquals(2, slaveTemplate.getLabelSet().size());
+        assertEquals("linux ubuntu", agentTemplate.getLabelString());
+        assertEquals(2, agentTemplate.getLabelSet().size());
 
         assertTrue(ec2Cloud.canProvision(new LabelAtom("ubuntu")));
         assertTrue(ec2Cloud.canProvision(new LabelAtom("linux")));
 
-        final SpotConfiguration spotConfig = slaveTemplate.spotConfig;
+        final SpotConfiguration spotConfig = agentTemplate.spotConfig;
         assertNotEquals(null, spotConfig);
         assertTrue(spotConfig.getFallbackToOndemand());
         assertEquals(3, spotConfig.getSpotBlockReservationDuration());
@@ -69,13 +69,13 @@ public class ConfigurationAsCodeTest {
         assertTrue(spotConfig.useBidPrice);
 
 
-        final AMITypeData amiType = slaveTemplate.getAmiType();
+        final AMITypeData amiType = agentTemplate.getAmiType();
         assertTrue(amiType.isUnix());
         assertTrue(amiType instanceof UnixData);
         final UnixData unixData = (UnixData) amiType;
         assertEquals("sudo", unixData.getRootCommandPrefix());
-        assertEquals("sudo -u jenkins", unixData.getSlaveCommandPrefix());
-        assertEquals("-fakeFlag", unixData.getSlaveCommandSuffix());
+        assertEquals("sudo -u jenkins", unixData.getAgentCommandPrefix());
+        assertEquals("-fakeFlag", unixData.getAgentCommandSuffix());
         assertEquals("22", unixData.getSshPort());
         assertEquals("180", unixData.getBootDelay());
     }
@@ -87,19 +87,19 @@ public class ConfigurationAsCodeTest {
         assertNotNull(ec2Cloud);
         assertTrue(ec2Cloud.isUseInstanceProfileForCredentials());
 
-        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        final List<AgentTemplate> templates = ec2Cloud.getTemplates();
         assertEquals(1, templates.size());
-        final SlaveTemplate slaveTemplate = templates.get(0);
-        assertEquals("ami-5678", slaveTemplate.getAmi());
-        assertEquals("/mnt/jenkins", slaveTemplate.remoteFS);
+        final AgentTemplate agentTemplate = templates.get(0);
+        assertEquals("ami-5678", agentTemplate.getAmi());
+        assertEquals("/mnt/jenkins", agentTemplate.remoteFS);
 
-        assertEquals("linux clear", slaveTemplate.getLabelString());
-        assertEquals(2, slaveTemplate.getLabelSet().size());
+        assertEquals("linux clear", agentTemplate.getLabelString());
+        assertEquals(2, agentTemplate.getLabelSet().size());
 
         assertTrue(ec2Cloud.canProvision(new LabelAtom("clear")));
         assertTrue(ec2Cloud.canProvision(new LabelAtom("linux")));
 
-        assertNull(slaveTemplate.spotConfig);
+        assertNull(agentTemplate.spotConfig);
     }
 
     @Test
@@ -109,19 +109,19 @@ public class ConfigurationAsCodeTest {
         assertNotNull(ec2Cloud);
         assertTrue(ec2Cloud.isUseInstanceProfileForCredentials());
 
-        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        final List<AgentTemplate> templates = ec2Cloud.getTemplates();
         assertEquals(1, templates.size());
-        final SlaveTemplate slaveTemplate = templates.get(0);
-        assertEquals("ami-abc123", slaveTemplate.getAmi());
-        assertEquals("C:/jenkins", slaveTemplate.remoteFS);
+        final AgentTemplate agentTemplate = templates.get(0);
+        assertEquals("ami-abc123", agentTemplate.getAmi());
+        assertEquals("C:/jenkins", agentTemplate.remoteFS);
 
-        assertEquals("windows vs2019", slaveTemplate.getLabelString());
-        assertEquals(2, slaveTemplate.getLabelSet().size());
+        assertEquals("windows vs2019", agentTemplate.getLabelString());
+        assertEquals(2, agentTemplate.getLabelSet().size());
 
         assertTrue(ec2Cloud.canProvision(new LabelAtom("windows")));
         assertTrue(ec2Cloud.canProvision(new LabelAtom("vs2019")));
 
-        final AMITypeData amiType = slaveTemplate.getAmiType();
+        final AMITypeData amiType = agentTemplate.getAmiType();
         assertFalse(amiType.isUnix());
         assertTrue(amiType.isWindows());
         assertTrue(amiType instanceof WindowsData);
@@ -137,10 +137,10 @@ public class ConfigurationAsCodeTest {
         final AmazonEC2Cloud ec2Cloud = (AmazonEC2Cloud) Jenkins.get().getCloud("us-east-1");
         assertNotNull(ec2Cloud);
 
-        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        final List<AgentTemplate> templates = ec2Cloud.getTemplates();
         assertEquals(1, templates.size());
-        final SlaveTemplate slaveTemplate = templates.get(0);
-        assertEquals(ConnectionStrategy.PRIVATE_DNS,slaveTemplate.connectionStrategy);
+        final AgentTemplate agentTemplate = templates.get(0);
+        assertEquals(ConnectionStrategy.PRIVATE_DNS,agentTemplate.connectionStrategy);
     }
 
     @Test
@@ -172,16 +172,16 @@ public class ConfigurationAsCodeTest {
         assertNotNull(ec2Cloud);
         assertTrue(ec2Cloud.isUseInstanceProfileForCredentials());
 
-        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        final List<AgentTemplate> templates = ec2Cloud.getTemplates();
         assertEquals(1, templates.size());
-        final SlaveTemplate slaveTemplate = templates.get(0);
-        assertEquals("ami-123456", slaveTemplate.getAmi());
-        assertEquals("/home/ec2-user", slaveTemplate.remoteFS);
+        final AgentTemplate agentTemplate = templates.get(0);
+        assertEquals("ami-123456", agentTemplate.getAmi());
+        assertEquals("/home/ec2-user", agentTemplate.remoteFS);
 
-        assertEquals("linux ubuntu", slaveTemplate.getLabelString());
-        assertEquals(2, slaveTemplate.getLabelSet().size());
+        assertEquals("linux ubuntu", agentTemplate.getLabelString());
+        assertEquals(2, agentTemplate.getLabelSet().size());
 
-        final MinimumNumberOfInstancesTimeRangeConfig timeRangeConfig = slaveTemplate.getMinimumNumberOfInstancesTimeRangeConfig();
+        final MinimumNumberOfInstancesTimeRangeConfig timeRangeConfig = agentTemplate.getMinimumNumberOfInstancesTimeRangeConfig();
         assertNotNull(timeRangeConfig);
         assertEquals(LocalTime.parse("01:00"), timeRangeConfig.getMinimumNoInstancesActiveTimeRangeFromAsTime());
         assertEquals(LocalTime.parse("13:00"), timeRangeConfig.getMinimumNoInstancesActiveTimeRangeToAsTime());
@@ -200,32 +200,32 @@ public class ConfigurationAsCodeTest {
         final AmazonEC2Cloud ec2Cloud = (AmazonEC2Cloud) Jenkins.get().getCloud("test");
         assertNotNull(ec2Cloud);
 
-        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        final List<AgentTemplate> templates = ec2Cloud.getTemplates();
         assertEquals(3, templates.size());
 
-        SlaveTemplate slaveTemplate;
+        AgentTemplate agentTemplate;
         List<EC2Filter> expectedFilters;
 
-        slaveTemplate = templates.get(0);
-        assertEquals("ami-0123456789abcdefg", slaveTemplate.ami);
-        assertNull(slaveTemplate.getAmiOwners());
-        assertNull(slaveTemplate.getAmiUsers());
-        assertNull(slaveTemplate.getAmiFilters());
+        agentTemplate = templates.get(0);
+        assertEquals("ami-0123456789abcdefg", agentTemplate.ami);
+        assertNull(agentTemplate.getAmiOwners());
+        assertNull(agentTemplate.getAmiUsers());
+        assertNull(agentTemplate.getAmiFilters());
 
-        slaveTemplate = templates.get(1);
-        assertNull(slaveTemplate.ami);
-        assertEquals("self", slaveTemplate.getAmiOwners());
-        assertEquals("self", slaveTemplate.getAmiUsers());
+        agentTemplate = templates.get(1);
+        assertNull(agentTemplate.ami);
+        assertEquals("self", agentTemplate.getAmiOwners());
+        assertEquals("self", agentTemplate.getAmiUsers());
         expectedFilters = Arrays.asList(new EC2Filter("name", "foo-*"),
                                         new EC2Filter("architecture", "x86_64"));
-        assertEquals(expectedFilters, slaveTemplate.getAmiFilters());
+        assertEquals(expectedFilters, agentTemplate.getAmiFilters());
 
-        slaveTemplate = templates.get(2);
-        assertNull(slaveTemplate.ami);
-        assertNull(slaveTemplate.getAmiOwners());
-        assertNull(slaveTemplate.getAmiUsers());
+        agentTemplate = templates.get(2);
+        assertNull(agentTemplate.ami);
+        assertNull(agentTemplate.getAmiOwners());
+        assertNull(agentTemplate.getAmiUsers());
         expectedFilters = Collections.emptyList();
-        assertEquals(expectedFilters, slaveTemplate.getAmiFilters());
+        assertEquals(expectedFilters, agentTemplate.getAmiFilters());
     }
 
     @Test
@@ -235,25 +235,25 @@ public class ConfigurationAsCodeTest {
         assertNotNull(ec2Cloud);
         assertTrue(ec2Cloud.isUseInstanceProfileForCredentials());
 
-        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        final List<AgentTemplate> templates = ec2Cloud.getTemplates();
         assertEquals(1, templates.size());
-        final SlaveTemplate slaveTemplate = templates.get(0);
-        assertEquals("ami-12345", slaveTemplate.getAmi());
-        assertEquals("/Users/ec2-user", slaveTemplate.remoteFS);
+        final AgentTemplate agentTemplate = templates.get(0);
+        assertEquals("ami-12345", agentTemplate.getAmi());
+        assertEquals("/Users/ec2-user", agentTemplate.remoteFS);
 
-        assertEquals("mac metal", slaveTemplate.getLabelString());
-        assertEquals(2, slaveTemplate.getLabelSet().size());
+        assertEquals("mac metal", agentTemplate.getLabelString());
+        assertEquals(2, agentTemplate.getLabelSet().size());
 
         assertTrue(ec2Cloud.canProvision(new LabelAtom("metal")));
         assertTrue(ec2Cloud.canProvision(new LabelAtom("mac")));
 
-        final AMITypeData amiType = slaveTemplate.getAmiType();
+        final AMITypeData amiType = agentTemplate.getAmiType();
         assertTrue(amiType.isMac());
         assertTrue(amiType instanceof MacData);
         final MacData macData = (MacData) amiType;
         assertEquals("sudo", macData.getRootCommandPrefix());
-        assertEquals("sudo -u jenkins", macData.getSlaveCommandPrefix());
-        assertEquals("-fakeFlag", macData.getSlaveCommandSuffix());
+        assertEquals("sudo -u jenkins", macData.getAgentCommandPrefix());
+        assertEquals("-fakeFlag", macData.getAgentCommandSuffix());
         assertEquals("22", macData.getSshPort());
         assertEquals("180", macData.getBootDelay());
     }
@@ -265,19 +265,19 @@ public class ConfigurationAsCodeTest {
         assertNotNull(ec2Cloud);
         assertTrue(ec2Cloud.isUseInstanceProfileForCredentials());
 
-        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        final List<AgentTemplate> templates = ec2Cloud.getTemplates();
         assertEquals(1, templates.size());
-        final SlaveTemplate slaveTemplate = templates.get(0);
-        assertEquals("ami-5678", slaveTemplate.getAmi());
-        assertEquals("/Users/jenkins", slaveTemplate.remoteFS);
+        final AgentTemplate agentTemplate = templates.get(0);
+        assertEquals("ami-5678", agentTemplate.getAmi());
+        assertEquals("/Users/jenkins", agentTemplate.remoteFS);
 
-        assertEquals("mac clear", slaveTemplate.getLabelString());
-        assertEquals(2, slaveTemplate.getLabelSet().size());
+        assertEquals("mac clear", agentTemplate.getLabelString());
+        assertEquals(2, agentTemplate.getLabelSet().size());
 
         assertTrue(ec2Cloud.canProvision(new LabelAtom("clear")));
         assertTrue(ec2Cloud.canProvision(new LabelAtom("mac")));
 
-        assertNull(slaveTemplate.spotConfig);
+        assertNull(agentTemplate.spotConfig);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
@@ -1,10 +1,10 @@
 package hudson.plugins.ec2;
 
-import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED;
-import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED;
-import static hudson.plugins.ec2.EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT;
+import static hudson.plugins.ec2.EC2AbstractAgent.DEFAULT_METADATA_ENDPOINT_ENABLED;
+import static hudson.plugins.ec2.EC2AbstractAgent.DEFAULT_METADATA_TOKENS_REQUIRED;
+import static hudson.plugins.ec2.EC2AbstractAgent.DEFAULT_METADATA_HOPS_LIMIT;
 
-import hudson.slaves.NodeProperty;
+import hudson.agents.NodeProperty;
 import hudson.model.Node;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +15,7 @@ import com.amazonaws.services.ec2.model.InstanceType;
 
 import static org.junit.Assert.assertEquals;
 
-public class EC2AbstractSlaveTest {
+public class EC2AbstractAgentTest {
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
@@ -24,7 +24,7 @@ public class EC2AbstractSlaveTest {
 
     @Test
     public void testGetLaunchTimeoutInMillisShouldNotOverflow() throws Exception {
-        EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "root", "java", "jvm", false, "idle", null, "cloud", Integer.MAX_VALUE, new UnixData("remote", null, null, "22", null), ConnectionStrategy.PRIVATE_IP, -1, Tenancy.Default,
+        EC2AbstractAgent agent = new EC2AbstractAgent("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "root", "java", "jvm", false, "idle", null, "cloud", Integer.MAX_VALUE, new UnixData("remote", null, null, "22", null), ConnectionStrategy.PRIVATE_IP, -1, Tenancy.Default,
                 DEFAULT_METADATA_ENDPOINT_ENABLED, DEFAULT_METADATA_TOKENS_REQUIRED, DEFAULT_METADATA_HOPS_LIMIT) {
 
             @Override
@@ -40,19 +40,19 @@ public class EC2AbstractSlaveTest {
             }
         };
 
-        assertEquals((long) timeoutInSecs * 1000, slave.getLaunchTimeoutInMillis());
+        assertEquals((long) timeoutInSecs * 1000, agent.getLaunchTimeoutInMillis());
     }
 
     @Test
     public void testMaxUsesBackwardCompat() throws Exception {
         final String description = "description";
-        SlaveTemplate orig = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 1, 1, "", "profile", false, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, DEFAULT_METADATA_ENDPOINT_ENABLED, DEFAULT_METADATA_TOKENS_REQUIRED, DEFAULT_METADATA_HOPS_LIMIT);
-        List<SlaveTemplate> templates = new ArrayList<>();
+        AgentTemplate orig = new AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 1, 1, "", "profile", false, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, DEFAULT_METADATA_ENDPOINT_ENABLED, DEFAULT_METADATA_TOKENS_REQUIRED, DEFAULT_METADATA_HOPS_LIMIT);
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(orig);
         String cloudName = "us-east-1";
         AmazonEC2Cloud ac = new AmazonEC2Cloud(cloudName, false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
-        EC2AbstractSlave slave = new EC2AbstractSlave("name", "", description, "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "root", "jvm", false, "idle", null, cloudName, false, Integer.MAX_VALUE, new UnixData("remote", null, null, "22", null), ConnectionStrategy.PRIVATE_IP, 0)  {
+        EC2AbstractAgent agent = new EC2AbstractAgent("name", "", description, "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "root", "jvm", false, "idle", null, cloudName, false, Integer.MAX_VALUE, new UnixData("remote", null, null, "22", null), ConnectionStrategy.PRIVATE_IP, 0)  {
             @Override
             public void terminate() {
             }
@@ -62,6 +62,6 @@ public class EC2AbstractSlaveTest {
                 return null;
             }
         };
-        assertEquals(-1, slave.maxTotalUses);
+        assertEquals(-1, agent.maxTotalUses);
     }
 }

--- a/src/test/java/hudson/plugins/ec2/EC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudTest.java
@@ -34,8 +34,8 @@ public class EC2CloudTest {
         EC2Cloud spyCloud = Mockito.spy(cloud);
         AmazonEC2 mockEc2 = Mockito.mock(AmazonEC2.class);
         Jenkins mockJenkins = Mockito.mock(Jenkins.class);
-        EC2AbstractSlave mockOrphanNode = Mockito.mock(EC2AbstractSlave.class);
-        SlaveTemplate mockSlaveTemplate = Mockito.mock(SlaveTemplate.class);
+        EC2AbstractAgent mockOrphanNode = Mockito.mock(EC2AbstractAgent.class);
+        AgentTemplate mockAgentTemplate = Mockito.mock(AgentTemplate.class);
         DescribeInstancesResult mockedDIResult = Mockito.mock(DescribeInstancesResult.class);
         Instance mockedInstance = Mockito.mock(Instance.class);
         List<Instance> listOfMockedInstances = new ArrayList<>();
@@ -44,8 +44,8 @@ public class EC2CloudTest {
 
         try (MockedStatic<Jenkins> mocked = Mockito.mockStatic(Jenkins.class)) {
         mocked.when(Jenkins::getInstanceOrNull).thenReturn(mockJenkins);
-        EC2AbstractSlave[] orphanNodes = {mockOrphanNode};
-        Mockito.doReturn(Arrays.asList(orphanNodes)).when(mockSlaveTemplate).toSlaves(eq(listOfMockedInstances));
+        EC2AbstractAgent[] orphanNodes = {mockOrphanNode};
+        Mockito.doReturn(Arrays.asList(orphanNodes)).when(mockAgentTemplate).toAgents(eq(listOfMockedInstances));
         List<Node> listOfJenkinsNodes = new ArrayList<>();
 
         Mockito.doAnswer(new Answer<Void>() {
@@ -59,15 +59,15 @@ public class EC2CloudTest {
         Mockito.doReturn(null).when(mockOrphanNode).toComputer();
         Mockito.doReturn(false).when(mockOrphanNode).getStopOnTerminate();
         Mockito.doReturn(mockEc2).when(spyCloud).connect();
-        Mockito.doReturn(mockedDIResult).when(mockSlaveTemplate).getDescribeInstanceResult(Mockito.any(AmazonEC2.class), eq(true));
-        Mockito.doReturn(listOfMockedInstances).when(mockSlaveTemplate).findOrphansOrStopped(eq(mockedDIResult), Mockito.anyInt());
-        Mockito.doNothing().when(mockSlaveTemplate).wakeOrphansOrStoppedUp(Mockito.any(AmazonEC2.class), eq(listOfMockedInstances));
+        Mockito.doReturn(mockedDIResult).when(mockAgentTemplate).getDescribeInstanceResult(Mockito.any(AmazonEC2.class), eq(true));
+        Mockito.doReturn(listOfMockedInstances).when(mockAgentTemplate).findOrphansOrStopped(eq(mockedDIResult), Mockito.anyInt());
+        Mockito.doNothing().when(mockAgentTemplate).wakeOrphansOrStoppedUp(Mockito.any(AmazonEC2.class), eq(listOfMockedInstances));
 
         /* Actual call to test*/
-        spyCloud.attemptReattachOrphanOrStoppedNodes(mockJenkins, mockSlaveTemplate, 1);
+        spyCloud.attemptReattachOrphanOrStoppedNodes(mockJenkins, mockAgentTemplate, 1);
 
         /* Checks */
-        Mockito.verify(mockSlaveTemplate, times(1)).wakeOrphansOrStoppedUp(Mockito.any(AmazonEC2.class), eq(listOfMockedInstances));
+        Mockito.verify(mockAgentTemplate, times(1)).wakeOrphansOrStoppedUp(Mockito.any(AmazonEC2.class), eq(listOfMockedInstances));
         Node[] expectedNodes = {mockOrphanNode};
         assertArrayEquals(expectedNodes, listOfJenkinsNodes.toArray());
         }

--- a/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
@@ -9,18 +9,18 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
-public class EC2OndemandSlaveTest {
+public class EC2OndemandAgentTest {
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
     @Test
     public void testSpecifyMode() throws Exception {
-        EC2OndemandSlave slaveNormal = new EC2OndemandSlave("name", "instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.NORMAL, "initScript", "tmpDir", Collections.emptyList(), "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", Collections.emptyList(), "cloudName", false,  0, new UnixData("a", null, null, "b", null), ConnectionStrategy.PRIVATE_IP, -1);
-        assertEquals(Node.Mode.NORMAL, slaveNormal.getMode());
+        EC2OndemandAgent agentNormal = new EC2OndemandAgent("name", "instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.NORMAL, "initScript", "tmpDir", Collections.emptyList(), "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", Collections.emptyList(), "cloudName", false,  0, new UnixData("a", null, null, "b", null), ConnectionStrategy.PRIVATE_IP, -1);
+        assertEquals(Node.Mode.NORMAL, agentNormal.getMode());
 
-        EC2OndemandSlave slaveExclusive = new EC2OndemandSlave("name", "instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.EXCLUSIVE, "initScript", "tmpDir", Collections.emptyList(), "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", Collections.emptyList(), "cloudName", false,  0, new UnixData("a", null, null, "b", null), ConnectionStrategy.PRIVATE_IP, -1);
+        EC2OndemandAgent agentExclusive = new EC2OndemandAgent("name", "instanceId", "description", "remoteFS", 1, "labelString", Node.Mode.EXCLUSIVE, "initScript", "tmpDir", Collections.emptyList(), "remoteAdmin", "jvmopts", false, "30", "publicDNS", "privateDNS", Collections.emptyList(), "cloudName", false,  0, new UnixData("a", null, null, "b", null), ConnectionStrategy.PRIVATE_IP, -1);
 
-        assertEquals(Node.Mode.EXCLUSIVE, slaveExclusive.getMode());
+        assertEquals(Node.Mode.EXCLUSIVE, agentExclusive.getMode());
     }
 }

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -18,8 +18,8 @@ import hudson.plugins.ec2.util.SSHCredentialHelper;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;import hudson.model.Executor;
-import hudson.slaves.NodeProperty;
-import hudson.slaves.OfflineCause;
+import hudson.agents.NodeProperty;
+import hudson.agents.OfflineCause;
 import jenkins.util.NonLocalizable;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -208,7 +208,7 @@ public class EC2RetentionStrategyTest {
      * the computer returns the value established.
      */
     private EC2Computer computerWithIdleTime(final int minutes, final int seconds, final Boolean isOffline, final Boolean isConnecting) throws Exception {
-        final EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "remote", "jvm", false, "idle", null, "cloud", false, Integer.MAX_VALUE, null, ConnectionStrategy.PRIVATE_IP, -1) {
+        final EC2AbstractAgent agent = new EC2AbstractAgent("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "remote", "jvm", false, "idle", null, "cloud", false, Integer.MAX_VALUE, null, ConnectionStrategy.PRIVATE_IP, -1) {
             @Override
             public void terminate() {
             }
@@ -223,13 +223,13 @@ public class EC2RetentionStrategyTest {
                 idleTimeoutCalled.set(true);
             }
         };
-        EC2Computer computer = new EC2Computer(slave) {
+        EC2Computer computer = new EC2Computer(agent) {
 
             private final long launchedAtMs = Instant.now().minus(Duration.ofSeconds(minutes * 60L + seconds)).toEpochMilli();
 
             @Override
-            public EC2AbstractSlave getNode() {
-                return slave;
+            public EC2AbstractAgent getNode() {
+                return agent;
             }
 
             @Override
@@ -253,8 +253,8 @@ public class EC2RetentionStrategyTest {
             }
 
             @Override
-            public SlaveTemplate getSlaveTemplate() {
-                return new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123 subnet-456", null, null, true, null, "", false, false, "", false, "");
+            public AgentTemplate getAgentTemplate() {
+                return new AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123 subnet-456", null, null, true, null, "", false, false, "", false, "");
             }
 
             @Override
@@ -277,7 +277,7 @@ public class EC2RetentionStrategyTest {
      */
     private EC2Computer computerWithUpTime(final int minutes, final int seconds, final Boolean isOffline, final Boolean isConnecting) throws Exception {
         idleTimeoutCalled.set(false);
-        final EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "remote", "jvm", false, "idle", null, "cloud", false, Integer.MAX_VALUE, null, ConnectionStrategy.PRIVATE_IP, -1) {
+        final EC2AbstractAgent agent = new EC2AbstractAgent("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "remote", "jvm", false, "idle", null, "cloud", false, Integer.MAX_VALUE, null, ConnectionStrategy.PRIVATE_IP, -1) {
             @Override
             public void terminate() {
             }
@@ -292,12 +292,12 @@ public class EC2RetentionStrategyTest {
                 idleTimeoutCalled.set(true);
             }
         };
-        EC2Computer computer = new EC2Computer(slave) {
+        EC2Computer computer = new EC2Computer(agent) {
             private final long launchedAtMs = Instant.now().minus(Duration.ofSeconds(minutes * 60L + seconds)).toEpochMilli();
 
             @Override
-            public EC2AbstractSlave getNode() {
-                return slave;
+            public EC2AbstractAgent getNode() {
+                return agent;
             }
 
             @Override
@@ -321,8 +321,8 @@ public class EC2RetentionStrategyTest {
             }
 
             @Override
-            public SlaveTemplate getSlaveTemplate() {
-                return new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123 subnet-456", null, null, true, null, "", false, false, "", false, "");
+            public AgentTemplate getAgentTemplate() {
+                return new AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123 subnet-456", null, null, true, null, "", false, false, "", false, "");
             }
 
             @Override
@@ -366,7 +366,7 @@ public class EC2RetentionStrategyTest {
     }
 
     private EC2Computer computerWithUsageLimit(final int usageLimit) throws Exception {
-        final EC2AbstractSlave slave = new EC2AbstractSlave("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "remote", "jvm", false, "idle", null, "cloud", false, Integer.MAX_VALUE, null, ConnectionStrategy.PRIVATE_IP, usageLimit) {
+        final EC2AbstractAgent agent = new EC2AbstractAgent("name", "id", "description", "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "remote", "jvm", false, "idle", null, "cloud", false, Integer.MAX_VALUE, null, ConnectionStrategy.PRIVATE_IP, usageLimit) {
             @Override
             public void terminate() {
                 terminateCalled.set(true);
@@ -377,10 +377,10 @@ public class EC2RetentionStrategyTest {
                 return null;
             }
         };
-        return new EC2Computer(slave) {
+        return new EC2Computer(agent) {
             @Override
-            public EC2AbstractSlave getNode() {
-                return slave;
+            public EC2AbstractAgent getNode() {
+                return agent;
             }
         };
     }
@@ -520,7 +520,7 @@ public class EC2RetentionStrategyTest {
     @Test
     public void testRetentionDespiteIdleWithMinimumInstances() throws Exception {
 
-        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo",
+        AgentTemplate template = new AgentTemplate("ami1", EC2AbstractAgent.TEST_ZONE, null, "default", "foo",
           InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null,
           "-Xmx1g", false, "subnet 456", null, null, 2, 0, "10", null, true, true, false, "", false, "", false, false,
           true, ConnectionStrategy.PRIVATE_IP, 0, Collections.emptyList());
@@ -580,7 +580,7 @@ public class EC2RetentionStrategyTest {
 
     @Test
     public void testRetentionDespiteIdleWithMinimumInstanceActiveTimeRange() throws Exception {
-        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo",
+        AgentTemplate template = new AgentTemplate("ami1", EC2AbstractAgent.TEST_ZONE, null, "default", "foo",
             InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null,
             "-Xmx1g", false, "subnet 456", null, null, 2, 0, "10", null, true, true, false, "", false, "", false, false,
             true, ConnectionStrategy.PRIVATE_IP, 0, Collections.emptyList());
@@ -629,7 +629,7 @@ public class EC2RetentionStrategyTest {
 
     @Test
     public void testRetentionIdleWithMinimumInstanceInactiveTimeRange() throws Exception {
-        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo",
+        AgentTemplate template = new AgentTemplate("ami1", EC2AbstractAgent.TEST_ZONE, null, "default", "foo",
             InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null,
             "-Xmx1g", false, "subnet 456", null, null, 2, 0, "10", null, true, true, false, "", false, "", false, false,
             true, ConnectionStrategy.PRIVATE_IP, 0, Collections.emptyList());
@@ -663,7 +663,7 @@ public class EC2RetentionStrategyTest {
 
     @Test
     public void testRetentionDespiteIdleWithMinimumInstanceActiveTimeRangeAfterMidnight() throws Exception {
-        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo",
+        AgentTemplate template = new AgentTemplate("ami1", EC2AbstractAgent.TEST_ZONE, null, "default", "foo",
             InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null,
             "-Xmx1g", false, "subnet 456", null, null, 2, 0, "10", null, true, true, false, "", false, "", false, false,
             true, ConnectionStrategy.PRIVATE_IP, 0, Collections.emptyList());
@@ -711,7 +711,7 @@ public class EC2RetentionStrategyTest {
 
     @Test
     public void testRetentionStopsAfterActiveRangeEnds() throws Exception {
-        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo",
+        AgentTemplate template = new AgentTemplate("ami1", EC2AbstractAgent.TEST_ZONE, null, "default", "foo",
             InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null,
             "-Xmx1g", false, "subnet 456", null, null, 2, 0, "10", null, true, true, false, "", false, "", false, false,
             true, ConnectionStrategy.PRIVATE_IP, 0, Collections.emptyList());
@@ -763,7 +763,7 @@ public class EC2RetentionStrategyTest {
 
     private static void checkRetentionStrategy(EC2RetentionStrategy rs, EC2Computer c) throws InterruptedException {
         rs.check(c);
-        EC2AbstractSlave node = c.getNode();
+        EC2AbstractAgent node = c.getNode();
         assertTrue(node.terminateScheduled.await(10, TimeUnit.SECONDS));
     }
 }

--- a/src/test/java/hudson/plugins/ec2/EC2SlaveMonitorTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2SlaveMonitorTest.java
@@ -16,7 +16,7 @@ import hudson.model.Node;
 import hudson.plugins.ec2.util.SSHCredentialHelper;
 import jenkins.model.Jenkins;
 
-public class EC2SlaveMonitorTest {
+public class EC2AgentMonitorTest {
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
@@ -29,7 +29,7 @@ public class EC2SlaveMonitorTest {
 
     @Test
     public void testMinimumNumberOfInstances() throws Exception {
-        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 2, null, null, true, true, false, "", false, "", false, false, true, ConnectionStrategy.PRIVATE_IP, 0);
+        AgentTemplate template = new AgentTemplate("ami1", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 2, null, null, true, true, false, "", false, "", false, false, true, ConnectionStrategy.PRIVATE_IP, 0);
         SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
         AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true, "abc", "us-east-1", null, "ghi", "3", Collections.singletonList(template), "roleArn", "roleSessionName");
         r.jenkins.clouds.add(cloud);
@@ -41,7 +41,7 @@ public class EC2SlaveMonitorTest {
     @Test
     public void testMinimumNumberOfSpareInstances() throws Exception {
         // Arguments split onto newlines matching the construtor definition to make figuring which is which easier.
-        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "defaultsecgroup", "remotefs",
+        AgentTemplate template = new AgentTemplate("ami1", EC2AbstractAgent.TEST_ZONE, null, "defaultsecgroup", "remotefs",
                                                    InstanceType.M1Large, false, "label", Node.Mode.NORMAL, "description", "init script",
                                                    "tmpdir", "userdata", "10", "remoteadmin", null, "-Xmx1g",
                                                    false, "subnet 456", null, "0", 0,

--- a/src/test/java/hudson/plugins/ec2/EC2StepTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2StepTest.java
@@ -41,15 +41,15 @@ public class EC2StepTest {
     private AmazonEC2Cloud cl;
 
     @Mock
-    private SlaveTemplate st;
+    private AgentTemplate st;
 
     @Mock
-    private EC2AbstractSlave instance;
+    private EC2AbstractAgent instance;
 
     @Before
     public void setup() throws Exception {
         r.jenkins.clouds.clear();
-        List<SlaveTemplate> templates = new ArrayList<>();
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(st);
 
         when(cl.getCloudName()).thenReturn("myCloud");
@@ -59,8 +59,8 @@ public class EC2StepTest {
         r.jenkins.clouds.add(cl);
 
         when(instance.getNodeName()).thenReturn("nodeName");
-        List<EC2AbstractSlave> slaves = Collections.singletonList(instance);
-        when(st.provision(anyInt(),any())).thenReturn(slaves);
+        List<EC2AbstractAgent> agents = Collections.singletonList(instance);
+        when(st.provision(anyInt(),any())).thenReturn(agents);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -51,7 +51,7 @@ import com.amazonaws.services.ec2.model.SecurityGroup;
 import com.amazonaws.services.ec2.model.Subnet;
 import hudson.Util;
 import hudson.model.Node;
-import hudson.plugins.ec2.SlaveTemplate.ProvisionOptions;
+import hudson.plugins.ec2.AgentTemplate.ProvisionOptions;
 import hudson.plugins.ec2.util.MinimumNumberOfInstancesTimeRangeConfig;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -76,9 +76,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Basic test to validate SlaveTemplate.
+ * Basic test to validate AgentTemplate.
  */
-public class SlaveTemplateTest {
+public class AgentTemplateTest {
 
     @Rule public JenkinsRule r = new JenkinsRule();
 
@@ -91,16 +91,16 @@ public class SlaveTemplateTest {
         List<EC2Tag> tags = new ArrayList<>();
         tags.add(tag1);
         tags.add(tag2);
-        SlaveTemplate orig = new  SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, 0, 0, null, "iamInstanceProfile", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default, EbsEncryptRootVolume.DEFAULT);
+        AgentTemplate orig = new  AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, 0, 0, null, "iamInstanceProfile", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default, EbsEncryptRootVolume.DEFAULT);
 
-        List<SlaveTemplate> templates = new ArrayList<>();
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configureClouds").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        AgentTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,javaPath,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,iamInstanceProfile,useEphemeralDevices,useDedicatedTenancy,connectionStrategy,hostKeyVerificationStrategy,tenancy,ebsEncryptRootVolume");
         // For already existing strategies, the default is this one
         assertEquals(HostKeyVerificationStrategyEnum.CHECK_NEW_SOFT, received.getHostKeyVerificationStrategy());
@@ -114,16 +114,16 @@ public class SlaveTemplateTest {
         // We check this one is set
         final HostKeyVerificationStrategyEnum STRATEGY_TO_CHECK = HostKeyVerificationStrategyEnum.OFF;
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, STRATEGY_TO_CHECK);
+        AgentTemplate orig = new AgentTemplate(ami, EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, STRATEGY_TO_CHECK);
 
-        List<SlaveTemplate> templates = new ArrayList<>();
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configureClouds").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        AgentTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,javaPath,jvmopts,stopOnTerminate,securityGroups,subnetId,useEphemeralDevices,useDedicatedTenancy,connectionStrategy,hostKeyVerificationStrategy");
         assertEquals(STRATEGY_TO_CHECK, received.getHostKeyVerificationStrategy());
     }
@@ -145,15 +145,15 @@ public class SlaveTemplateTest {
         spotConfig.setFallbackToOndemand(true);
         spotConfig.setSpotBlockReservationDuration(0);
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, true, null, "", false, false, "", false, "");
-        List<SlaveTemplate> templates = new ArrayList<>();
+        AgentTemplate orig = new AgentTemplate(ami, EC2AbstractAgent.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, true, null, "", false, false, "", false, "");
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configureClouds").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        AgentTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "ami,zone,spotConfig,description,remoteFS,type,javaPath,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
     }
 
@@ -170,15 +170,15 @@ public class SlaveTemplateTest {
 
         SpotConfiguration spotConfig = new SpotConfiguration(false);
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, true, null, "", false, false, "", false, "");
-        List<SlaveTemplate> templates = new ArrayList<>();
+        AgentTemplate orig = new AgentTemplate(ami, EC2AbstractAgent.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, true, null, "", false, false, "", false, "");
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configureClouds").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        AgentTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "ami,zone,spotConfig,description,remoteFS,type,javaPath,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
     }
 
@@ -187,16 +187,16 @@ public class SlaveTemplateTest {
         String ami = "ami1";
         String description = "foo ami";
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "rrr", new WindowsData("password", false, ""), "-Xmx1g", false, "subnet 456", null, null, false, null, "", true, false, "", false, "");
+        AgentTemplate orig = new AgentTemplate(ami, EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "rrr", new WindowsData("password", false, ""), "-Xmx1g", false, "subnet 456", null, null, false, null, "", true, false, "", false, "");
 
-        List<SlaveTemplate> templates = new ArrayList<>();
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configureClouds").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        AgentTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         assertEquals(orig.getAdminPassword(), received.getAdminPassword());
         assertEquals(orig.amiType, received.amiType);
         r.assertEqualBeans(orig, received, "amiType");
@@ -207,15 +207,15 @@ public class SlaveTemplateTest {
         String ami = "ami1";
         String description = "foo ami";
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "rrr", new UnixData("sudo", "", "", "22", ""), "-Xmx1g", false, "subnet 456", null, null, false, null, "", true, false, "", false, "");
-        List<SlaveTemplate> templates = new ArrayList<>();
+        AgentTemplate orig = new AgentTemplate(ami, EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "rrr", new UnixData("sudo", "", "", "22", ""), "-Xmx1g", false, "subnet 456", null, null, false, null, "", true, false, "", false, "");
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configureClouds").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        AgentTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "amiType");
     }
 
@@ -230,11 +230,11 @@ public class SlaveTemplateTest {
         spotConfig.setSpotMaxBidPrice("22");
         spotConfig.setFallbackToOndemand(true);
         spotConfig.setSpotBlockReservationDuration(1);
-        SlaveTemplate slaveTemplate = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 2, null, null, true, true, false, "", false, "", false, false, true, ConnectionStrategy.PRIVATE_IP, 0);
-        slaveTemplate.setMinimumNumberOfInstancesTimeRangeConfig(minimumNumberOfInstancesTimeRangeConfig);
+        AgentTemplate agentTemplate = new AgentTemplate("ami1", EC2AbstractAgent.TEST_ZONE, spotConfig, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 2, null, null, true, true, false, "", false, "", false, false, true, ConnectionStrategy.PRIVATE_IP, 0);
+        agentTemplate.setMinimumNumberOfInstancesTimeRangeConfig(minimumNumberOfInstancesTimeRangeConfig);
 
-        List<SlaveTemplate> templates = new ArrayList<>();
-        templates.add(slaveTemplate);
+        List<AgentTemplate> templates = new ArrayList<>();
+        templates.add(agentTemplate);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
@@ -258,13 +258,13 @@ public class SlaveTemplateTest {
         String securityGroups = "some security group";
         String iamInstanceProfile = "some instance profile";
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, securityGroups, "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, subnetId, null, null, false, null, iamInstanceProfile, true, false, "", associatePublicIp, "");
-        SlaveTemplate noSubnet = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, securityGroups, "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "", null, null, false, null, iamInstanceProfile, true, false, "", associatePublicIp, "");
+        AgentTemplate orig = new AgentTemplate(ami, EC2AbstractAgent.TEST_ZONE, null, securityGroups, "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, subnetId, null, null, false, null, iamInstanceProfile, true, false, "", associatePublicIp, "");
+        AgentTemplate noSubnet = new AgentTemplate(ami, EC2AbstractAgent.TEST_ZONE, null, securityGroups, "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "", null, null, false, null, iamInstanceProfile, true, false, "", associatePublicIp, "");
 
-        List<SlaveTemplate> templates = new ArrayList<>();
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(orig);
         templates.add(noSubnet);
-        for (SlaveTemplate template : templates) {
+        for (AgentTemplate template : templates) {
             AmazonEC2 mockedEC2 = setupTestForProvisioning(template);
 
             ArgumentCaptor<RunInstancesRequest> riRequestCaptor = ArgumentCaptor.forClass(RunInstancesRequest.class);
@@ -301,13 +301,13 @@ public class SlaveTemplateTest {
         tags.add(tag1);
         tags.add(tag2);
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, securityGroups, "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, subnetId, tags, null, false, null, iamInstanceProfile, true, false, "", associatePublicIp, "");
-        SlaveTemplate noSubnet = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, securityGroups, "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "", tags, null, false, null, iamInstanceProfile, true, false, "", associatePublicIp, "");
+        AgentTemplate orig = new AgentTemplate(ami, EC2AbstractAgent.TEST_ZONE, null, securityGroups, "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, subnetId, tags, null, false, null, iamInstanceProfile, true, false, "", associatePublicIp, "");
+        AgentTemplate noSubnet = new AgentTemplate(ami, EC2AbstractAgent.TEST_ZONE, null, securityGroups, "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "", tags, null, false, null, iamInstanceProfile, true, false, "", associatePublicIp, "");
 
-        List<SlaveTemplate> templates = new ArrayList<>();
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(orig);
         templates.add(noSubnet);
-        for (SlaveTemplate template : templates) {
+        for (AgentTemplate template : templates) {
             AmazonEC2 mockedEC2 = setupTestForProvisioning(template);
 
             ArgumentCaptor<RunInstancesRequest> riRequestCaptor = ArgumentCaptor.forClass(RunInstancesRequest.class);
@@ -341,7 +341,7 @@ public class SlaveTemplateTest {
         spotConfig.setFallbackToOndemand(true);
         spotConfig.setSpotBlockReservationDuration(0);
 
-        SlaveTemplate template = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, spotConfig, securityGroups, "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, subnetId, null, null, false, null, iamInstanceProfile, true, false, "", associatePublicIp, "");
+        AgentTemplate template = new AgentTemplate(ami, EC2AbstractAgent.TEST_ZONE, spotConfig, securityGroups, "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, subnetId, null, null, false, null, iamInstanceProfile, true, false, "", associatePublicIp, "");
 
         AmazonEC2 mockedEC2 = setupTestForProvisioning(template);
 
@@ -357,7 +357,7 @@ public class SlaveTemplateTest {
         verify(mockedEC2).runInstances(any(RunInstancesRequest.class));
     }
 
-    private AmazonEC2 setupTestForProvisioning(SlaveTemplate template) throws Exception {
+    private AmazonEC2 setupTestForProvisioning(AgentTemplate template) throws Exception {
         AmazonEC2Cloud mockedCloud = mock(AmazonEC2Cloud.class);
         AmazonEC2 mockedEC2 = mock(AmazonEC2.class);
         EC2PrivateKey mockedPrivateKey = mock(EC2PrivateKey.class);
@@ -414,53 +414,53 @@ public class SlaveTemplateTest {
     @Test
     public void testMacConfig() throws Exception {
         String description = "foo ami";
-        SlaveTemplate orig = new  SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.Mac1Metal, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", new MacData("sudo", null, null, "22", null), "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default);
+        AgentTemplate orig = new  AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.Mac1Metal, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", new MacData("sudo", null, null, "22", null), "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default);
 
-        List<SlaveTemplate> templates = new ArrayList<>();
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configureClouds").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
+        AgentTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "type,amiType");
     }
 
     @Issue("JENKINS-65569")
     @Test
     public void testAgentName() {
-        SlaveTemplate broken = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "broken/description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default);
-        SlaveTemplate working = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "working", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default);
-        List<SlaveTemplate> templates = new ArrayList<>();
+        AgentTemplate broken = new AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "broken/description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default);
+        AgentTemplate working = new AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "working", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default);
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(broken);
         templates.add(working);
         AmazonEC2Cloud brokenCloud = new AmazonEC2Cloud("broken/cloud", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
-        assertThat(broken.getSlaveName("test"), is("test"));
-        assertThat(working.getSlaveName("test"), is("test"));
+        assertThat(broken.getAgentName("test"), is("test"));
+        assertThat(working.getAgentName("test"), is("test"));
         AmazonEC2Cloud workingCloud = new AmazonEC2Cloud("cloud", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
-        assertThat(broken.getSlaveName("test"), is("test"));
-        assertThat(working.getSlaveName("test"), is("EC2 (cloud) - working (test)"));
+        assertThat(broken.getAgentName("test"), is("test"));
+        assertThat(working.getAgentName("test"), is("EC2 (cloud) - working (test)"));
     }
 
     @Test
     public void testMetadataV2Config() throws Exception {
-        final String slaveDescription = "foobar";
-        SlaveTemplate orig = new  SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, slaveDescription, "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", true, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, true, true, 2);
+        final String agentDescription = "foobar";
+        AgentTemplate orig = new  AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, agentDescription, "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", true, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, true, true, 2);
 
-        List<SlaveTemplate> templates = Collections.singletonList(orig);
+        List<AgentTemplate> templates = Collections.singletonList(orig);
 
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));
-        SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(slaveDescription);
+        AgentTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(agentDescription);
         r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,javaPath,jvmopts,stopOnTerminate,securityGroups,subnetId,useEphemeralDevices,connectionStrategy,hostKeyVerificationStrategy,metadataEndpointEnabled,metadataTokensRequired,metadataHopsLimit");
     }
 
     @Test
     public void provisionOnDemandSetsMetadataV1Options() throws Exception {
-        SlaveTemplate template = new  SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", true, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, true, false, 2);
+        AgentTemplate template = new  AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", true, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, true, false, 2);
 
         AmazonEC2 mockedEC2 = setupTestForProvisioning(template);
 
@@ -478,7 +478,7 @@ public class SlaveTemplateTest {
 
     @Test
     public void provisionOnDemandSetsMetadataV2Options() throws Exception {
-        SlaveTemplate template = new  SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", true, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, true, true, 2);
+        AgentTemplate template = new  AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", true, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, true, true, 2);
 
         AmazonEC2 mockedEC2 = setupTestForProvisioning(template);
 
@@ -496,7 +496,7 @@ public class SlaveTemplateTest {
 
     @Test
     public void provisionOnDemandSetsMetadataDefaultOptions() throws Exception {
-        SlaveTemplate template = new  SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", true, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, null, true, null);
+        AgentTemplate template = new  AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "java", "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "", true, false, "", false, "", true, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, HostKeyVerificationStrategyEnum.CHECK_NEW_HARD, Tenancy.Default, EbsEncryptRootVolume.DEFAULT, null, true, null);
 
         AmazonEC2 mockedEC2 = setupTestForProvisioning(template);
 

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-public class SlaveTemplateUnitTest {
+public class AgentTemplateUnitTest {
 
     private Logger logger;
     private TestHandler handler;
@@ -41,7 +41,7 @@ public class SlaveTemplateUnitTest {
     @Before
     public void setUp() throws Exception {
         handler = new TestHandler();
-        logger = Logger.getLogger(SlaveTemplate.class.getName());
+        logger = Logger.getLogger(AgentTemplate.class.getName());
         logger.addHandler(handler);
     }
 
@@ -64,7 +64,7 @@ public class SlaveTemplateUnitTest {
         tags.add(tag2);
         String instanceId = "123";
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, false, null, "", true, false, "", false, "") {
+        AgentTemplate orig = new AgentTemplate(ami, EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, false, null, "", true, false, "", false, "") {
             @Override
             protected Object readResolve() {
                 return null;
@@ -72,10 +72,10 @@ public class SlaveTemplateUnitTest {
         };
 
         ArrayList<Tag> awsTags = new ArrayList<Tag>();
-        awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "value1"));
-        awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "value2"));
+        awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_AGENT_TYPE, "value1"));
+        awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_AGENT_TYPE, "value2"));
 
-        Method updateRemoteTags = SlaveTemplate.class.getDeclaredMethod("updateRemoteTags", AmazonEC2.class, Collection.class, String.class, String[].class);
+        Method updateRemoteTags = AgentTemplate.class.getDeclaredMethod("updateRemoteTags", AmazonEC2.class, Collection.class, String.class, String[].class);
         updateRemoteTags.setAccessible(true);
         final Object params[] = {ec2, awsTags, "InvalidInstanceRequestID.NotFound", new String[]{instanceId}};
         updateRemoteTags.invoke(orig, params);
@@ -103,7 +103,7 @@ public class SlaveTemplateUnitTest {
         tags.add(tag2);
         String instanceId = "123";
 
-        SlaveTemplate orig = new SlaveTemplate(ami, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, false, null, "", true, false, "", false, "") {
+        AgentTemplate orig = new AgentTemplate(ami, EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, description, "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", tags, null, false, null, "", true, false, "", false, "") {
             @Override
             protected Object readResolve() {
                 return null;
@@ -111,10 +111,10 @@ public class SlaveTemplateUnitTest {
         };
 
         ArrayList<Tag> awsTags = new ArrayList<Tag>();
-        awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "value1"));
-        awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, "value2"));
+        awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_AGENT_TYPE, "value1"));
+        awsTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_AGENT_TYPE, "value2"));
 
-        Method updateRemoteTags = SlaveTemplate.class.getDeclaredMethod("updateRemoteTags", AmazonEC2.class, Collection.class, String.class, String[].class);
+        Method updateRemoteTags = AgentTemplate.class.getDeclaredMethod("updateRemoteTags", AmazonEC2.class, Collection.class, String.class, String[].class);
         updateRemoteTags.setAccessible(true);
         final Object params[] = {ec2, awsTags, "InvalidSpotInstanceRequestID.NotFound", new String[]{instanceId}};
         updateRemoteTags.invoke(orig, params);
@@ -127,7 +127,7 @@ public class SlaveTemplateUnitTest {
         }
     }
 
-    private void doTestMakeDescribeImagesRequest(SlaveTemplate template,
+    private void doTestMakeDescribeImagesRequest(AgentTemplate template,
                                                  String testImageId,
                                                  String testOwners,
                                                  String testUsers,
@@ -142,7 +142,7 @@ public class SlaveTemplateUnitTest {
         template.setAmiOwners(testOwners);
         template.setAmiUsers(testUsers);
         template.setAmiFilters(testFilters);
-        Method makeDescribeImagesRequest = SlaveTemplate.class.getDeclaredMethod("makeDescribeImagesRequest");
+        Method makeDescribeImagesRequest = AgentTemplate.class.getDeclaredMethod("makeDescribeImagesRequest");
         makeDescribeImagesRequest.setAccessible(true);
         if (shouldRaise) {
             assertThrows(AmazonClientException.class, () -> {
@@ -163,7 +163,7 @@ public class SlaveTemplateUnitTest {
 
     @Test
     public void testMakeDescribeImagesRequest() throws Exception {
-        SlaveTemplate template = new SlaveTemplate(null, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "", true, false, "", false, "") {
+        AgentTemplate template = new AgentTemplate(null, EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "", true, false, "", false, "") {
             @Override
             protected Object readResolve() {
                 return null;
@@ -318,7 +318,7 @@ public class SlaveTemplateUnitTest {
     }
 
     private Boolean checkEncryptedForSetupRootDevice(EbsEncryptRootVolume rootVolumeEnum) throws Exception {
-        SlaveTemplate template = new SlaveTemplate(null, EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "", true, false, "", false, "") {
+        AgentTemplate template = new AgentTemplate(null, EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "", true, false, "", false, "") {
             @Override
             protected Object readResolve() {
                 return null;
@@ -335,7 +335,7 @@ public class SlaveTemplateUnitTest {
         if (rootVolumeEnum instanceof EbsEncryptRootVolume) {
             template.ebsEncryptRootVolume = rootVolumeEnum;
         };
-        Method setupRootDevice = SlaveTemplate.class.getDeclaredMethod("setupRootDevice", Image.class, List.class);
+        Method setupRootDevice = AgentTemplate.class.getDeclaredMethod("setupRootDevice", Image.class, List.class);
         setupRootDevice.setAccessible(true);
         setupRootDevice.invoke(template, image, deviceMappings);
         return image.getBlockDeviceMappings().get(0).getEbs().getEncrypted();
@@ -367,13 +367,13 @@ public class SlaveTemplateUnitTest {
 
     @Test
     public void testNullTimeoutShouldReturnMaxInt() {
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, false, "");
+        AgentTemplate st = new AgentTemplate("", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
     @Test
     public void testUpdateAmi() {
-        SlaveTemplate st = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "0", false, "");
+        AgentTemplate st = new AgentTemplate("ami1", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "0", false, "");
         assertEquals("ami1", st.getAmi());
         st.setAmi("ami2");
         assertEquals("ami2", st.getAmi());
@@ -383,55 +383,55 @@ public class SlaveTemplateUnitTest {
 
     @Test
     public void test0TimeoutShouldReturnMaxInt() {
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "0", false, "");
+        AgentTemplate st = new AgentTemplate("", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "0", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
     @Test
     public void testNegativeTimeoutShouldReturnMaxInt() {
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "-1", false, "");
+        AgentTemplate st = new AgentTemplate("", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "-1", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
     @Test
     public void testNonNumericTimeoutShouldReturnMaxInt() {
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "NotANumber", false, "");
+        AgentTemplate st = new AgentTemplate("", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, "NotANumber", false, "");
         assertEquals(Integer.MAX_VALUE, st.getLaunchTimeout());
     }
 
     @Test
     public void testAssociatePublicIpSetting() {
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true, "");
+        AgentTemplate st = new AgentTemplate("", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true, "");
         assertEquals(true, st.getAssociatePublicIp());
     }
 
     @Test
     public void testConnectUsingPublicIpSetting() {
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, false, null, true, "", false, true);
+        AgentTemplate st = new AgentTemplate("", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, false, null, true, "", false, true);
         assertEquals(st.connectionStrategy, ConnectionStrategy.PUBLIC_IP);
     }
 
     @Test
     public void testConnectUsingPublicIpSettingWithDefaultSetting() {
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true, "");
+        AgentTemplate st = new AgentTemplate("", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, false, null, true, "");
         assertEquals(st.connectionStrategy, ConnectionStrategy.PUBLIC_IP);
     }
 
     @Test
     public void testBackwardCompatibleUnixData() {
-        SlaveTemplate st = new SlaveTemplate("", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "rrr", "sudo", null, null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, "NotANumber");
-        assertFalse(st.isWindowsSlave());
+        AgentTemplate st = new AgentTemplate("", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", "22", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "", "bar", "bbb", "aaa", "10", "rrr", "sudo", null, null, "-Xmx1g", false, "subnet 456", null, null, false, null, "iamInstanceProfile", false, "NotANumber");
+        assertFalse(st.isWindowsAgent());
         assertEquals(22, st.getSshPort());
         assertEquals("sudo", st.getRootCommandPrefix());
     }
 
     @Test
     public void testChooseSpaceDelimitedSubnetId() throws Exception {
-        SlaveTemplate slaveTemplate = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123 subnet-456", null, null, true, null, "", false, false, "", false, "");
+        AgentTemplate agentTemplate = new AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123 subnet-456", null, null, true, null, "", false, false, "", false, "");
 
-        String subnet1 = slaveTemplate.chooseSubnetId();
-        String subnet2 = slaveTemplate.chooseSubnetId();
-        String subnet3 = slaveTemplate.chooseSubnetId();
+        String subnet1 = agentTemplate.chooseSubnetId();
+        String subnet2 = agentTemplate.chooseSubnetId();
+        String subnet3 = agentTemplate.chooseSubnetId();
 
         assertEquals(subnet1, "subnet-123");
         assertEquals(subnet2, "subnet-456");
@@ -440,11 +440,11 @@ public class SlaveTemplateUnitTest {
 
     @Test
     public void testChooseCommaDelimitedSubnetId() throws Exception {
-        SlaveTemplate slaveTemplate = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123,subnet-456", null, null, true, null, "", false, false, "", false, "");
+        AgentTemplate agentTemplate = new AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123,subnet-456", null, null, true, null, "", false, false, "", false, "");
 
-        String subnet1 = slaveTemplate.chooseSubnetId();
-        String subnet2 = slaveTemplate.chooseSubnetId();
-        String subnet3 = slaveTemplate.chooseSubnetId();
+        String subnet1 = agentTemplate.chooseSubnetId();
+        String subnet2 = agentTemplate.chooseSubnetId();
+        String subnet3 = agentTemplate.chooseSubnetId();
 
         assertEquals(subnet1, "subnet-123");
         assertEquals(subnet2, "subnet-456");
@@ -453,11 +453,11 @@ public class SlaveTemplateUnitTest {
 
     @Test
     public void testChooseSemicolonDelimitedSubnetId() throws Exception {
-        SlaveTemplate slaveTemplate = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123;subnet-456", null, null, true, null, "", false, false, "", false, "");
+        AgentTemplate agentTemplate = new AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123;subnet-456", null, null, true, null, "", false, false, "", false, "");
 
-        String subnet1 = slaveTemplate.chooseSubnetId();
-        String subnet2 = slaveTemplate.chooseSubnetId();
-        String subnet3 = slaveTemplate.chooseSubnetId();
+        String subnet1 = agentTemplate.chooseSubnetId();
+        String subnet2 = agentTemplate.chooseSubnetId();
+        String subnet3 = agentTemplate.chooseSubnetId();
 
         assertEquals(subnet1, "subnet-123");
         assertEquals(subnet2, "subnet-456");
@@ -467,7 +467,7 @@ public class SlaveTemplateUnitTest {
     @Issue("JENKINS-59460")
     @Test
     public void testConnectionStrategyDeprecatedFieldsAreExported() {
-        SlaveTemplate template = new SlaveTemplate("ami1", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", Collections.singletonList(new EC2Tag("name1", "value1")), null, false, null, "", true, false, "", false, "");
+        AgentTemplate template = new AgentTemplate("ami1", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", Collections.singletonList(new EC2Tag("name1", "value1")), null, false, null, "", true, false, "", false, "");
 
         String exported = Jenkins.XSTREAM.toXML(template);
         assertThat(exported, containsString("usePrivateDnsName"));

--- a/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
+++ b/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
@@ -56,8 +56,8 @@ public class TemplateLabelsTest {
         tags.add(tag1);
         tags.add(tag2);
 
-        SlaveTemplate template = new SlaveTemplate("ami", "foo", null, "default", "zone", InstanceType.M1Large, false, label, mode, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", true, "subnet 456", tags, null, false, null, "", false, false, null, false, "");
-        List<SlaveTemplate> templates = new ArrayList<>();
+        AgentTemplate template = new AgentTemplate("ami", "foo", null, "default", "zone", InstanceType.M1Large, false, label, mode, "foo ami", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", true, "subnet 456", tags, null, false, null, "", false, false, null, false, "");
+        List<AgentTemplate> templates = new ArrayList<>();
         templates.add(template);
 
         ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);

--- a/src/test/java/hudson/plugins/ec2/ssh/verifiers/SshHostKeyVerificationStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/ssh/verifiers/SshHostKeyVerificationStrategyTest.java
@@ -6,12 +6,12 @@ import com.trilead.ssh2.Connection;
 import com.trilead.ssh2.ServerHostKeyVerifier;
 import hudson.model.Node;
 import hudson.plugins.ec2.ConnectionStrategy;
-import hudson.plugins.ec2.EC2AbstractSlave;
+import hudson.plugins.ec2.EC2AbstractAgent;
 import hudson.plugins.ec2.EC2Computer;
 import hudson.plugins.ec2.InstanceState;
-import hudson.plugins.ec2.SlaveTemplate;
+import hudson.plugins.ec2.AgentTemplate;
 import hudson.plugins.ec2.util.ConnectionRule;
-import hudson.slaves.NodeProperty;
+import hudson.agents.NodeProperty;
 import org.hamcrest.core.StringContains;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -328,16 +328,16 @@ public class SshHostKeyVerificationStrategyTest {
     private static class MockEC2Computer extends EC2Computer {
         InstanceState state = InstanceState.PENDING;
         String console = null;
-        EC2AbstractSlave slave;
+        EC2AbstractAgent agent;
         
-        public MockEC2Computer(EC2AbstractSlave slave) {
-            super(slave);
-            this.slave = slave;
+        public MockEC2Computer(EC2AbstractAgent agent) {
+            super(agent);
+            this.agent = agent;
         }
 
         // Create a computer
         private static MockEC2Computer createComputer(String suffix) throws Exception {
-            final EC2AbstractSlave slave = new EC2AbstractSlave(COMPUTER_NAME + suffix, "id" + suffix, "description" + suffix, "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "remote", "jvm", false, "idle", null, "cloud", false, Integer.MAX_VALUE, null, ConnectionStrategy.PRIVATE_IP, -1) {
+            final EC2AbstractAgent agent = new EC2AbstractAgent(COMPUTER_NAME + suffix, "id" + suffix, "description" + suffix, "fs", 1, null, "label", null, null, "init", "tmpDir", new ArrayList<NodeProperty<?>>(), "remote", "jvm", false, "idle", null, "cloud", false, Integer.MAX_VALUE, null, ConnectionStrategy.PRIVATE_IP, -1) {
                 @Override
                 public void terminate() {
                 }
@@ -348,7 +348,7 @@ public class SshHostKeyVerificationStrategyTest {
                 }
             };
 
-            return new MockEC2Computer(slave);
+            return new MockEC2Computer(agent);
         }
 
         @Override
@@ -362,13 +362,13 @@ public class SshHostKeyVerificationStrategyTest {
         }
 
         @Override
-        public EC2AbstractSlave getNode() {
-            return slave;
+        public EC2AbstractAgent getNode() {
+            return agent;
         }
 
         @Override
-        public SlaveTemplate getSlaveTemplate() {
-            return new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123 subnet-456", null, null, true, null, "", false, false, "", false, "");
+        public AgentTemplate getAgentTemplate() {
+            return new AgentTemplate("ami-123", EC2AbstractAgent.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "AMI description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet-123 subnet-456", null, null, true, null, "", false, false, "", false, "");
         }
     } 
     

--- a/src/test/java/hudson/plugins/ec2/util/ConnectionRule.java
+++ b/src/test/java/hudson/plugins/ec2/util/ConnectionRule.java
@@ -86,8 +86,8 @@ public class ConnectionRule extends ExternalResource {
     @Override
     public void before() {
         try {
-            sshContainer = new GenericContainer("jenkins/ssh-slave")
-                    .withEnv("JENKINS_SLAVE_SSH_PUBKEY", publicKey)
+            sshContainer = new GenericContainer("jenkins/ssh-agent")
+                    .withEnv("JENKINS_AGENT_SSH_PUBKEY", publicKey)
                     .withExposedPorts(SSH_PORT);
 
             sshContainer.start();

--- a/src/test/java/hudson/plugins/ec2/util/EC2AgentFactoryMockImpl.java
+++ b/src/test/java/hudson/plugins/ec2/util/EC2AgentFactoryMockImpl.java
@@ -10,27 +10,27 @@ import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.plugins.ec2.*;
-import hudson.slaves.NodeProperty;
+import hudson.agents.NodeProperty;
 
 @Extension
 public class EC2AgentFactoryMockImpl implements EC2AgentFactory {
 
     @Override
-    public EC2OndemandSlave createOnDemandAgent(EC2AgentConfig.OnDemand config)
+    public EC2OndemandAgent createOnDemandAgent(EC2AgentConfig.OnDemand config)
             throws Descriptor.FormException, IOException {
-        return new MockEC2OndemandSlave(config.name, config.instanceId, config.description, config.remoteFS, config.numExecutors, config.labelString, config.mode, config.initScript, config.tmpDir, config.nodeProperties, config.remoteAdmin, config.javaPath, config.jvmopts, config.stopOnTerminate, config.idleTerminationMinutes, config.publicDNS, config.privateDNS, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses, config.tenancy);
+        return new MockEC2OndemandAgent(config.name, config.instanceId, config.description, config.remoteFS, config.numExecutors, config.labelString, config.mode, config.initScript, config.tmpDir, config.nodeProperties, config.remoteAdmin, config.javaPath, config.jvmopts, config.stopOnTerminate, config.idleTerminationMinutes, config.publicDNS, config.privateDNS, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses, config.tenancy);
     }
 
     @Override
-    public EC2SpotSlave createSpotAgent(EC2AgentConfig.Spot config)
+    public EC2SpotAgent createSpotAgent(EC2AgentConfig.Spot config)
             throws Descriptor.FormException, IOException {
-        return new MockEC2SpotSlave(config.name, config.spotInstanceRequestId, config.description, config.remoteFS, config.numExecutors, config.mode, config.initScript, config.tmpDir, config.labelString, config.nodeProperties, config.remoteAdmin, config.javaPath, config.jvmopts, config.idleTerminationMinutes, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses);
+        return new MockEC2SpotAgent(config.name, config.spotInstanceRequestId, config.description, config.remoteFS, config.numExecutors, config.mode, config.initScript, config.tmpDir, config.labelString, config.nodeProperties, config.remoteAdmin, config.javaPath, config.jvmopts, config.idleTerminationMinutes, config.tags, config.cloudName, config.launchTimeout, config.amiType, config.connectionStrategy, config.maxTotalUses);
     }
 
-    private static class MockEC2OndemandSlave extends EC2OndemandSlave {
+    private static class MockEC2OndemandAgent extends EC2OndemandAgent {
         private static final long serialVersionUID = 1L;
 
-        private MockEC2OndemandSlave(String name, String instanceId, String description, String remoteFS,
+        private MockEC2OndemandAgent(String name, String instanceId, String description, String remoteFS,
                 int numExecutors, String labelString, Mode mode, String initScript, String tmpDir,
                 List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts,
                 boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS,
@@ -41,7 +41,7 @@ public class EC2AgentFactoryMockImpl implements EC2AgentFactory {
             this(name, instanceId, description, remoteFS, numExecutors, labelString, mode, initScript, tmpDir, nodeProperties, remoteAdmin, javaPath, jvmopts, stopOnTerminate, idleTerminationMinutes, publicDNS, privateDNS, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses,Tenancy.Default);
         }
 
-        private MockEC2OndemandSlave(String name, String instanceId, String description, String remoteFS,
+        private MockEC2OndemandAgent(String name, String instanceId, String description, String remoteFS,
                                      int numExecutors, String labelString, Mode mode, String initScript, String tmpDir,
                                      List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts,
                                      boolean stopOnTerminate, String idleTerminationMinutes, String publicDNS, String privateDNS,
@@ -58,10 +58,10 @@ public class EC2AgentFactoryMockImpl implements EC2AgentFactory {
         }
     }
 
-    private static class MockEC2SpotSlave extends EC2SpotSlave {
+    private static class MockEC2SpotAgent extends EC2SpotAgent {
         private static final long serialVersionUID = 1L;
 
-        private MockEC2SpotSlave(String name, String spotInstanceRequestId, String description, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
+        private MockEC2SpotAgent(String name, String spotInstanceRequestId, String description, String remoteFS, int numExecutors, Mode mode, String initScript, String tmpDir, String labelString, List<? extends NodeProperty<?>> nodeProperties, String remoteAdmin, String javaPath, String jvmopts, String idleTerminationMinutes, List<EC2Tag> tags, String cloudName, int launchTimeout, AMITypeData amiType, ConnectionStrategy connectionStrategy, int maxTotalUses)
                 throws Descriptor.FormException, IOException {
             super(name, spotInstanceRequestId, description, remoteFS, numExecutors, mode, initScript, tmpDir, labelString, nodeProperties, remoteAdmin, javaPath, jvmopts, idleTerminationMinutes, tags, cloudName, launchTimeout, amiType, connectionStrategy, maxTotalUses);
         }
@@ -74,8 +74,8 @@ public class EC2AgentFactoryMockImpl implements EC2AgentFactory {
 
     private static class MockEC2Computer extends EC2Computer {
 
-        private MockEC2Computer(EC2AbstractSlave slave) {
-            super(slave);
+        private MockEC2Computer(EC2AbstractAgent agent) {
+            super(agent);
         }
 
         @Override

--- a/src/test/resources/hudson/plugins/ec2/MacData.yml
+++ b/src/test/resources/hudson/plugins/ec2/MacData.yml
@@ -16,7 +16,7 @@ jenkins:
             amiType:
               macData:
                 rootCommandPrefix: "sudo"
-                slaveCommandPrefix: "sudo -u jenkins"
-                slaveCommandSuffix: "-fakeFlag"
+                agentCommandPrefix: "sudo -u jenkins"
+                agentCommandSuffix: "-fakeFlag"
                 sshPort: "22"
                 bootDelay: "180"

--- a/src/test/resources/hudson/plugins/ec2/MacDataExport.yml
+++ b/src/test/resources/hudson/plugins/ec2/MacDataExport.yml
@@ -8,8 +8,8 @@
         macData:
           bootDelay: "180"
           rootCommandPrefix: "sudo"
-          slaveCommandPrefix: "sudo -u jenkins"
-          slaveCommandSuffix: "-fakeFlag"
+          agentCommandPrefix: "sudo -u jenkins"
+          agentCommandSuffix: "-fakeFlag"
           sshPort: "22"
       associatePublicIp: false
       connectBySSHProcess: false

--- a/src/test/resources/hudson/plugins/ec2/UnixData-withAltEndpointAndJavaPath.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixData-withAltEndpointAndJavaPath.yml
@@ -23,6 +23,6 @@ jenkins:
             amiType:
               unixData:
                 rootCommandPrefix: "sudo"
-                slaveCommandPrefix: "sudo -u jenkins"
-                slaveCommandSuffix: "-fakeFlag"
+                agentCommandPrefix: "sudo -u jenkins"
+                agentCommandSuffix: "-fakeFlag"
                 sshPort: "22"

--- a/src/test/resources/hudson/plugins/ec2/UnixData.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixData.yml
@@ -21,6 +21,6 @@ jenkins:
               unixData:
                 bootDelay: "180"
                 rootCommandPrefix: "sudo"
-                slaveCommandPrefix: "sudo -u jenkins"
-                slaveCommandSuffix: "-fakeFlag"
+                agentCommandPrefix: "sudo -u jenkins"
+                agentCommandSuffix: "-fakeFlag"
                 sshPort: "22"

--- a/src/test/resources/hudson/plugins/ec2/UnixDataExport-withAltEndpointAndJavaPath.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixDataExport-withAltEndpointAndJavaPath.yml
@@ -8,8 +8,8 @@
       amiType:
         unixData:
           rootCommandPrefix: "sudo"
-          slaveCommandPrefix: "sudo -u jenkins"
-          slaveCommandSuffix: "-fakeFlag"
+          agentCommandPrefix: "sudo -u jenkins"
+          agentCommandSuffix: "-fakeFlag"
           sshPort: "22"
       associatePublicIp: false
       connectBySSHProcess: false

--- a/src/test/resources/hudson/plugins/ec2/UnixDataExport.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixDataExport.yml
@@ -8,8 +8,8 @@
         unixData:
           bootDelay: "180"
           rootCommandPrefix: "sudo"
-          slaveCommandPrefix: "sudo -u jenkins"
-          slaveCommandSuffix: "-fakeFlag"
+          agentCommandPrefix: "sudo -u jenkins"
+          agentCommandSuffix: "-fakeFlag"
           sshPort: "22"
       associatePublicIp: false
       connectBySSHProcess: false


### PR DESCRIPTION
Fix for JENKINS-63660: Slave to agent term sweep

Jenkins core has been changing the terminology from Slave to Agent and plugins should follow this flow. I create this pull request to rename all the "Slave" references on the ec2-plugin to "Agent"
Changes:

- There are no Slave references in a source code

- There are no Slave references in documentation
