### PR TITLE
[JENKINS-71737] update for dedicated cloud rename page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@ THE SOFTWARE.
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.414</jenkins.version>
+        <jenkins.version>2.423-rc34197.1024b_9eb_344b_</jenkins.version> <!-- TODO: https://github.com/jenkinsci/jenkins/pull/8310 -->
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@ THE SOFTWARE.
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.423-rc34197.1024b_9eb_344b_</jenkins.version> <!-- TODO: https://github.com/jenkinsci/jenkins/pull/8310 -->
+        <jenkins.version>2.423-rc34199.8c3d6c65b_758</jenkins.version> <!-- TODO: https://github.com/jenkinsci/jenkins/pull/8310 -->
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 

--- a/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
@@ -19,9 +19,6 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-  <f:entry title="${%Name}" field="cloudName">
-    <f:textbox />
-  </f:entry>
   <f:entry field="credentialsId" title="${%Amazon EC2 Credentials}" description="AWS IAM Access Key used to connect to EC2. If not specified, implicit authentication mechanisms are used (IAM roles...)">
     <c:select />
   </f:entry>

--- a/src/main/resources/hudson/plugins/ec2/Eucalyptus/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/Eucalyptus/config-entries.jelly
@@ -19,9 +19,6 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-  <f:entry title="${%Name}" field="name">
-    <f:textbox />
-  </f:entry>
   <f:entry title="${%Eucalyptus EC2 URL}" field="ec2EndpointUrl">
     <f:textbox />
   </f:entry>

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
@@ -73,8 +73,8 @@ public class AmazonEC2CloudTest {
 
     @Test
     public void testConfigRoundtrip() throws Exception {
-        r.submit(getConfigForm());
-        r.assertEqualBeans(cloud, r.jenkins.clouds.get(AmazonEC2Cloud.class), "cloudName,region,useInstanceProfileForCredentials,privateKey,instanceCap,roleArn,roleSessionName");
+        r.submit(getConfigForm(cloud));
+        r.assertEqualBeans(cloud, r.jenkins.clouds.get(AmazonEC2Cloud.class), "region,useInstanceProfileForCredentials,privateKey,instanceCap,roleArn,roleSessionName");
     }
 
     @Test
@@ -87,14 +87,14 @@ public class AmazonEC2CloudTest {
 
     @Test
     public void testSshKeysCredentialsIdRemainsUnchangedAfterUpdatingOtherFields() throws Exception {
-        HtmlForm form = getConfigForm();
+        HtmlForm form = getConfigForm(cloud);
         HtmlTextInput input = form.getInputByName("_.roleSessionName");
 
         input.setText("updatedSessionName");
         r.submit(form);
         AmazonEC2Cloud actual = r.jenkins.clouds.get(AmazonEC2Cloud.class);
         assertEquals("updatedSessionName", actual.getRoleSessionName());
-        r.assertEqualBeans(cloud, actual, "cloudName,region,useInstanceProfileForCredentials,sshKeysCredentialsId,instanceCap,roleArn");
+        r.assertEqualBeans(cloud, actual, "region,useInstanceProfileForCredentials,sshKeysCredentialsId,instanceCap,roleArn");
     }
 
     @Test
@@ -161,7 +161,7 @@ public class AmazonEC2CloudTest {
         assertThat(actual.resolvePrivateKey(), notNullValue());
     }
 
-    private HtmlForm getConfigForm() throws IOException, SAXException {
+    private HtmlForm getConfigForm(AmazonEC2Cloud cloud) throws IOException, SAXException {
         return r.createWebClient().goTo(cloud.getUrl() + "configure").getFormByName("config");
     }
 

--- a/src/test/java/hudson/plugins/ec2/EucalyptusTest.java
+++ b/src/test/java/hudson/plugins/ec2/EucalyptusTest.java
@@ -20,6 +20,6 @@ public class EucalyptusTest {
         HtmlPage p = wc.goTo(cloud.getUrl() + "configure");
         HtmlForm f = p.getFormByName("config");
         r.submit(f);
-        r.assertEqualBeans(cloud, r.jenkins.getCloud("test"), "name,ec2EndpointUrl,s3EndpointUrl,useInstanceProfileForCredentials,roleArn,roleSessionName,credentialsId,sshKeysCredentialsId,instanceCap,templates");
+        r.assertEqualBeans(cloud, r.jenkins.getCloud("test"), "ec2EndpointUrl,s3EndpointUrl,useInstanceProfileForCredentials,roleArn,roleSessionName,credentialsId,sshKeysCredentialsId,instanceCap,templates");
     }
 }

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -53,16 +53,13 @@ import hudson.Util;
 import hudson.model.Node;
 import hudson.plugins.ec2.SlaveTemplate.ProvisionOptions;
 import hudson.plugins.ec2.util.MinimumNumberOfInstancesTimeRangeConfig;
-import org.htmlunit.html.HtmlForm;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.ArgumentCaptor;
-import org.xml.sax.SAXException;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -110,7 +107,7 @@ public class SlaveTemplateTest {
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
-        r.submit(getConfigForm(ac));
+        r.submit(r.createWebClient().goTo(ac.getUrl() + "configure").getFormByName("config"));
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,javaPath,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,iamInstanceProfile,useEphemeralDevices,useDedicatedTenancy,connectionStrategy,hostKeyVerificationStrategy,tenancy,ebsEncryptRootVolume");
         // For already existing strategies, the default is this one
@@ -132,7 +129,7 @@ public class SlaveTemplateTest {
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
-        r.submit(getConfigForm(ac));
+        r.submit(r.createWebClient().goTo(ac.getUrl() + "configure").getFormByName("config"));
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "ami,zone,description,remoteFS,type,javaPath,jvmopts,stopOnTerminate,securityGroups,subnetId,useEphemeralDevices,useDedicatedTenancy,connectionStrategy,hostKeyVerificationStrategy");
         assertEquals(STRATEGY_TO_CHECK, received.getHostKeyVerificationStrategy());
@@ -161,7 +158,7 @@ public class SlaveTemplateTest {
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
-        r.submit(getConfigForm(ac));
+        r.submit(r.createWebClient().goTo(ac.getUrl() + "configure").getFormByName("config"));
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "ami,zone,spotConfig,description,remoteFS,type,javaPath,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
     }
@@ -185,7 +182,7 @@ public class SlaveTemplateTest {
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
-        r.submit(getConfigForm(ac));
+        r.submit(r.createWebClient().goTo(ac.getUrl() + "configure").getFormByName("config"));
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "ami,zone,spotConfig,description,remoteFS,type,javaPath,jvmopts,stopOnTerminate,securityGroups,subnetId,tags,usePrivateDnsName");
     }
@@ -202,7 +199,7 @@ public class SlaveTemplateTest {
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
-        r.submit(getConfigForm(ac));
+        r.submit(r.createWebClient().goTo(ac.getUrl() + "configure").getFormByName("config"));
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         assertEquals(orig.getAdminPassword(), received.getAdminPassword());
         assertEquals(orig.amiType, received.amiType);
@@ -220,7 +217,7 @@ public class SlaveTemplateTest {
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
-        r.submit(getConfigForm(ac));
+        r.submit(r.createWebClient().goTo(ac.getUrl() + "configure").getFormByName("config"));
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "amiType");
     }
@@ -425,7 +422,7 @@ public class SlaveTemplateTest {
         AmazonEC2Cloud ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
-        r.submit(getConfigForm(ac));
+        r.submit(r.createWebClient().goTo(ac.getUrl() + "configure").getFormByName("config"));
         SlaveTemplate received = ((EC2Cloud) r.jenkins.clouds.iterator().next()).getTemplate(description);
         r.assertEqualBeans(orig, received, "type,amiType");
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
downstream of https://github.com/jenkinsci/jenkins/pull/8310

Update config-entries to not display name fields in the configuration page

also needs #875 to be merged to pass failing tests

### Testing done
manually created a new AmazonEC2Cloud and renamed it, verified name is not showing in config page

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
