### PR TITLE
add dl2q instance type

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -425,6 +425,8 @@ public abstract class EC2AbstractSlave extends Slave {
             return 240;
         case Dl124xlarge:
             return 250;
+        case Dl2q24xlarge:
+            return 250;
          case Mac1Metal:
             return 1;
             // We don't have a suggestion, but we don't want to fail completely


### PR DESCRIPTION
Kindly requesting a review of the added support for the currently missing Amazon EC2 DL2q instance type, powered by Qualcomm AI 100 Standard accelerators (dl2q.24xlarge).

Link to similar pull request - https://github.com/jenkinsci/ec2-plugin/pull/681

Not tested, as it just adds the missing instance type.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
