### PR TITLE
JENKINS-66373: idle timeout should not fight with min spare instances setting

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -131,9 +131,14 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
         SlaveTemplate slaveTemplate = computer.getSlaveTemplate();
         if (slaveTemplate != null) {
             long numberOfCurrentInstancesForTemplate = MinimumInstanceChecker.countCurrentNumberOfAgents(slaveTemplate);
-            if (numberOfCurrentInstancesForTemplate > 0 && numberOfCurrentInstancesForTemplate <= slaveTemplate.getMinimumNumberOfInstances()) {
-                //Check if we're in an active time-range for keeping minimum number of instances
+            long numberOfCurrentSpareInstancesForTemplate = MinimumInstanceChecker.countCurrentNumberOfSpareAgents(slaveTemplate);
+            boolean atOrBelowMinInstances = numberOfCurrentInstancesForTemplate > 0 && numberOfCurrentInstancesForTemplate <= slaveTemplate.getMinimumNumberOfInstances();
+            boolean atOrBelowMinSpareInstances = numberOfCurrentSpareInstancesForTemplate > 0 && numberOfCurrentSpareInstancesForTemplate <= slaveTemplate.getMinimumNumberOfSpareInstances();
+            if (atOrBelowMinInstances || atOrBelowMinSpareInstances) {
+                // Check if we're in an active time-range for keeping minimum number of instances
                 if (MinimumInstanceChecker.minimumInstancesActive(slaveTemplate.getMinimumNumberOfInstancesTimeRangeConfig())) {
+                    // Time range is active and we are at (or below) one of the "minimum number" settings, so return here
+                    // to avoid terminating any instances seeing as MinimumInstanceChecker will immediately re-provision
                     return 1;
                 }
             }


### PR DESCRIPTION
The problem: currently if you use the "Minimum number of spare instances" setting as well as "Idle termination time", then there is a constant battle going on between:
- `MinimumInstanceChecker.checkForMinimumInstances` provisioning new agents to try and maintain the minimum number of spare instances as configured
- however the idle timeout checks in this method are killing off the 'spare' instances once they reach the idle termination time

This means that the spare instances are repeatedly killed & recreated as described on https://issues.jenkins.io/browse/JENKINS-66373 which is wasteful and means that, some percentage of the time, there are never enough spare instances because they are being booted (again).

This PR makes a simple change to the idle termination logic so that it takes account of "Minimum number of _spare_ instances" in the same way that it already accounts for the main "Minimum number of instances" setting.

### Testing done

None yet - I have found `EC2RetentionStrategyTest.java` and it would definitely make sense to add a relevant test in there for this case.

Right now I've got very limited time and wanted to first get the fix up for discussion.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
