### PR TITLE
Terminate the EC2 on receiving an exception

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -210,9 +210,9 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                 int exitStatus = waitCompletion(sess);
                 if (exitStatus != 0) {
                     logWarning(computer, listener, "init script failed: exit code=" + exitStatus);
-                    return;
+                    sess.close();
+                    throw new IOException("Init script exited with an error");
                 }
-                sess.close();
 
                 logInfo(computer, listener, "Creating ~/.hudson-run-init");
 


### PR DESCRIPTION
The EC2 node should terminate when an exception is received or exit code is not 0. The current script just ignores & continues after only logging the message but no termination action is taken.