### PR TITLE
JENKINS-72643: Fixed listing regions when using ec2 ARN role with instance profile

### DIFF
--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -185,6 +185,9 @@ public class AmazonEC2Cloud extends EC2Cloud {
         public ListBoxModel doFillRegionItems(
                 @QueryParameter String altEC2Endpoint,
                 @QueryParameter boolean useInstanceProfileForCredentials,
+                @QueryParameter String roleArn,
+                @QueryParameter String roleSessionName,
+                @QueryParameter String region,
                 @QueryParameter String credentialsId)
 
                 throws IOException, ServletException {
@@ -192,7 +195,10 @@ public class AmazonEC2Cloud extends EC2Cloud {
             if (Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 try {
                     AWSCredentialsProvider credentialsProvider = createCredentialsProvider(useInstanceProfileForCredentials,
-                            credentialsId);
+                            credentialsId,
+                            roleArn,
+                            roleSessionName,
+                            region);
                     AmazonEC2 client = AmazonEC2Factory.getInstance().connect(credentialsProvider, determineEC2EndpointURL(altEC2Endpoint));
                     DescribeRegionsResult regions = client.describeRegions();
                     List<Region> regionList = regions.getRegions();
@@ -201,6 +207,7 @@ public class AmazonEC2Cloud extends EC2Cloud {
                         model.add(name, name);
                     }
                 } catch (SdkClientException ex) {
+                    LOGGER.log(Level.INFO, "AmazonEC2Cloud.doFillRegionItems() got exception: " + ex);
                     // Ignore, as this may happen before the credentials are specified
                 }
             }


### PR DESCRIPTION
In the case where a user specified an ARN Role in the advanced section of cloud config we need to use that information when pulling the list of regions.

In my case without this ARN Role being used with credentials I would get an empty drop-down list with no errors.

I added a log message with the exception to expose a bit of information in case of failures.

### Testing done

I did test with an ARN Role in the advanced section of cloud config.

I did not (yet) test without this but will do this next. I suppose I could check if roleArn is empty/null and use a different createCredentialsProvider() signature. 

I did not see an existing test involving ec2 instance profile or listing regions so did not add one.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] (n/a) Link to relevant pull requests, esp. upstream and downstream changes
- [x] (skipped, see above comment) Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
