### PR TITLE
Added support for programmatic update of a SlaveTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,28 @@ jenkins.clouds.add(amazonEC2Cloud)
 jenkins.save()
 ```
 
+## Programmatically adding/updating CloudTemplates
+
+The plugin supports programmatic addition and update of `CloudTemplates` in an already existing `Cloud` - 
+both can be accomplished via the Jenkins script console [Jenkins script console](https://wiki.jenkins.io/display/JENKINS/Jenkins+Script+Console).
+
+Example:
+
+```java
+ // Assuming on the Jenkins instance, there exists an EC2Cloud with the name "AwsCloud"
+
+ AmazonEC2Cloud cloud = (AmazonEC2Cloud) Jenkins.get().clouds.stream().filter(cloud1 -> Objects.equals(cloud.getDisplayName(), "AwsCloud")).findFirst().get();
+ 
+ SlaveTemplate template = new SlaveTemplate(/*constructor*/); // View available constructors at https://github.com/jenkinsci/ec2-plugin/blob/master/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+ 
+ // Adding a template
+ cloud.addTemplate(template);
+    
+ SlaveTemplate template2 = new SlaveTemplate(/*constructor*/);
+ // Updating a template. Note the description of an existing SlaveTemplate needs to passed in order for there to be a successful update, otherwise an Exception is thrown
+ cloud.updateTemplate(template2, template.description);
+```
+
 # Security
 ## Securing the connection to Unix AMIs
 When you set up a template for a *Unix* instance (`Type AMI` field), you can select the strategy used to guarantee the

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -87,16 +87,7 @@ import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
@@ -223,6 +214,17 @@ public abstract class EC2Cloud extends Cloud {
                 String.format("A SlaveTemplate with description %s already exists", newTemplateDescription));
         List<SlaveTemplate> templatesHolder = new ArrayList<>(templates);
         templatesHolder.add(newTemplate);
+        templates = templatesHolder;
+    }
+
+    public void updateTemplate(SlaveTemplate newTemplate, String oldTemplateDescription) throws Exception{
+        Optional<? extends SlaveTemplate> optionalOldTemplate = templates.stream().filter(template ->
+                Objects.equals(template.description, oldTemplateDescription)).findFirst();
+        if (!optionalOldTemplate.isPresent())
+            throw new Exception(String.format("A SlaveTemplate with description %s does not exist", oldTemplateDescription));
+        int oldTemplateIndex = templates.indexOf(optionalOldTemplate.get());
+        List<SlaveTemplate> templatesHolder = new ArrayList<>(templates);
+        templatesHolder.set(oldTemplateIndex, newTemplate);
         templates = templatesHolder;
     }
 

--- a/src/test/java/hudson/plugins/ec2/EC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudTest.java
@@ -19,8 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 
@@ -35,6 +34,19 @@ public class EC2CloudTest {
         SlaveTemplate orig = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "description", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "iamInstanceProfile", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default, EbsEncryptRootVolume.DEFAULT);
         cloud.addTemplate(orig);
         assertNotNull(cloud.getTemplate(orig.description));
+    }
+
+    @Test
+    public void testSlaveTemplateUpdate() throws Exception{
+        AmazonEC2Cloud cloud = new AmazonEC2Cloud("us-east-1", true,
+                "abc", "us-east-1", null, "ghi",
+                "3", Collections.emptyList(), "roleArn", "roleSessionName");
+        SlaveTemplate oldSlaveTemplate = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "OldSlaveDescription", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "iamInstanceProfile", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default, EbsEncryptRootVolume.DEFAULT);
+        cloud.addTemplate(oldSlaveTemplate);
+        SlaveTemplate newSlaveTemplate = new SlaveTemplate("ami-456", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "NewSlaveDescription", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "iamInstanceProfile", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default, EbsEncryptRootVolume.DEFAULT);
+        cloud.updateTemplate(newSlaveTemplate, "OldSlaveDescription");
+        assertNull(cloud.getTemplate("OldSlaveDescription"));
+        assertNotNull(cloud.getTemplate("NewSlaveDescription"));
     }
 
     @Test

--- a/src/test/java/hudson/plugins/ec2/EC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudTest.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.InstanceType;
 import hudson.model.Node;
 import jenkins.model.Jenkins;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
@@ -42,11 +43,16 @@ public class EC2CloudTest {
                 "abc", "us-east-1", null, "ghi",
                 "3", Collections.emptyList(), "roleArn", "roleSessionName");
         SlaveTemplate oldSlaveTemplate = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "OldSlaveDescription", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "iamInstanceProfile", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default, EbsEncryptRootVolume.DEFAULT);
+        SlaveTemplate secondSlaveTemplate = new SlaveTemplate("ami-123", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "SecondSlaveDescription", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "iamInstanceProfile", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default, EbsEncryptRootVolume.DEFAULT);
         cloud.addTemplate(oldSlaveTemplate);
+        cloud.addTemplate(secondSlaveTemplate);
         SlaveTemplate newSlaveTemplate = new SlaveTemplate("ami-456", EC2AbstractSlave.TEST_ZONE, null, "default", "foo", InstanceType.M1Large, false, "ttt", Node.Mode.NORMAL, "NewSlaveDescription", "bar", "bbb", "aaa", "10", "fff", null, "-Xmx1g", false, "subnet 456", null, null, 0, 0, null, "iamInstanceProfile", true, false, "", false, "", false, false, false, ConnectionStrategy.PUBLIC_IP, -1, null, null, Tenancy.Default, EbsEncryptRootVolume.DEFAULT);
+        int index = cloud.getTemplates().indexOf(oldSlaveTemplate);
+
         cloud.updateTemplate(newSlaveTemplate, "OldSlaveDescription");
         assertNull(cloud.getTemplate("OldSlaveDescription"));
         assertNotNull(cloud.getTemplate("NewSlaveDescription"));
+        Assert.assertEquals(index, cloud.getTemplates().indexOf(newSlaveTemplate)); // assert order of templates is kept
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
### PR Description

Added functionallity that would allow programmatic update of SlaveTemplates, which can be done by specifying the "old" SlaveTemplate's description. In case a template with the provided description does not exist, an exception is thrown. This feature is useful when someone wants to manage the SlaveTemplates programatically via the Jenkins Script feature. 

### Testing done

[Added an Unit test for the new EC2Cloud method](https://github.com/drullar/ec2-plugin/blob/2d21ff4e9f7b7d14e3bbfd91bd34ce8bfe2d0412/src/test/java/hudson/plugins/ec2/EC2CloudTest.java#L40). Attached screenshot of local test execution 
![image](https://github.com/user-attachments/assets/9309c7ca-28c6-439c-adef-e9bf8cba4010)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
