### PR TITLE
Replace dropdown button to remove dependency on YUI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@ THE SOFTWARE.
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.414.3</jenkins.version>
+        <jenkins.version>2.452.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <hpi.compatibleSinceVersion>1626</hpi.compatibleSinceVersion>
     </properties>
@@ -201,8 +201,8 @@ THE SOFTWARE.
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.414.x</artifactId>
-                <version>2982.vdce2153031a_0</version>
+                <artifactId>bom-2.452.x</artifactId>
+                <version>3208.vb_21177d4b_cd9</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/computerSet.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/computerSet.jelly
@@ -22,28 +22,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
+         xmlns:l="/lib/layout" xmlns:dd="/lib/layout/dropdowns" xmlns:f="/lib/form">
   <j:if test="${it.hasPermission(it.PROVISION)}">
     <tr>
       <td />
       <td colspan="${monitors.size()+1}">
+        <l:overflowButton icon="symbol-add"
+                          text="${%Provision via} ${it.displayName}"
+                          tooltip="${null}"
+                          clazz="jenkins-!-margin-top-2">
+          <j:forEach var="t" items="${it.templates}">
+            <dd:custom>
+              <button class="jenkins-dropdown__item"
+                      data-type="ec2-provision"
+                      data-url="${t.description}">
+                ${t.displayName}
+              </button>
+            </dd:custom>
+          </j:forEach>
+        </l:overflowButton>
         <f:form action="${rootURL}/${it.url}/provision" method="post" name="provision">
-          <input type="submit" class="ec2-provision-button" value="${%Provision via} ${it.displayName}" />
-          <select name="template">
-            <j:forEach var="t" items="${it.templates}">
-              <option value="${t.description}">${t.displayName}</option>
-            </j:forEach>
-          </select>
-          <st:once>
-            <script>
-              Behaviour.register({
-                ".ec2-provision-button" : function (e) {
-                  new YAHOO.widget.Button(e, { type: "menu", menu: e.nextSibling });
-                }
-              });
-            </script>
-          </st:once>
+          <input name="template" type="hidden"/>
         </f:form>
+        <st:adjunct includes="hudson.plugins.ec2.EC2Cloud.provision"/>
       </td>
     </tr>
   </j:if>

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/computerSet.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/computerSet.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
          xmlns:l="/lib/layout" xmlns:dd="/lib/layout/dropdowns" xmlns:f="/lib/form">
   <j:if test="${it.hasPermission(it.PROVISION)}">
+    <j:set var="formId" value="${h.generateId()}"/>
     <tr>
       <td />
       <td colspan="${monitors.size()+2}">
@@ -36,13 +37,14 @@ THE SOFTWARE.
             <dd:custom>
               <button class="jenkins-dropdown__item"
                       data-type="ec2-provision"
+                      data-form="${formId}"
                       data-url="${t.description}">
                 ${t.displayName}
               </button>
             </dd:custom>
           </j:forEach>
         </l:overflowButton>
-        <f:form action="${rootURL}/${it.url}/provision" method="post" name="provision">
+        <f:form action="${rootURL}/${it.url}/provision" method="post" name="provision" id="${formId}">
           <input name="template" type="hidden"/>
         </f:form>
         <st:adjunct includes="hudson.plugins.ec2.EC2Cloud.provision"/>

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/computerSet.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/computerSet.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <j:if test="${it.hasPermission(it.PROVISION)}">
     <tr>
       <td />
-      <td colspan="${monitors.size()+1}">
+      <td colspan="${monitors.size()+2}">
         <l:overflowButton icon="symbol-add"
                           text="${%Provision via} ${it.displayName}"
                           tooltip="${null}"

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/provision.js
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/provision.js
@@ -1,0 +1,8 @@
+Behaviour.specify("[data-type='ec2-provision']", 'ec2-provision', -99, function(e) {
+  e.addEventListener("click", function (event) {
+    const form = document.querySelector("form[name='provision']");
+    form.querySelector("[name='template']").value = e.dataset.url;
+    buildFormTree(form);
+    form.submit();
+  });
+});

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/provision.js
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/provision.js
@@ -1,6 +1,6 @@
 Behaviour.specify("[data-type='ec2-provision']", 'ec2-provision', -99, function(e) {
   e.addEventListener("click", function (event) {
-    const form = document.querySelector("form[name='provision']");
+    const form = document.getElementById(e.dataset.form);
     form.querySelector("[name='template']").value = e.dataset.url;
     buildFormTree(form);
     form.submit();


### PR DESCRIPTION
Fixes https://issues.jenkins.io/browse/JENKINS-73541

Replace YUI button with a more modern component, analogous to https://github.com/jenkinsci/credentials-plugin/pull/551 as part of the YUI removal initiative (https://issues.jenkins.io/browse/JENKINS-73539 )

### Testing done

Manually checked that clicking the dropdown button goes to the provision page with the correct parameters.

![image](https://github.com/user-attachments/assets/2c349e63-d745-4589-aeca-93d76e80071b)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
