### PR TITLE
allow using a file based ssh credential via system property to avoid having to create a Jenkins ssh credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,25 @@ the main "Manage Jenkins" \> "Configure System" page, and scroll down
 near the bottom to the "Cloud" section. There, you click the "Add a new
 cloud" button, and select the "Amazon EC2" option. This will display the
 UI for configuring the EC2 plugin.  Then enter the Access Key and Secret
-Access Key which act like a username/password (see IAM section). Because
-of the way EC2 works, you also need to have an RSA private key that the
+Access Key which act like a username/password (see IAM section). 
+
+Because of the way EC2 works, you also need to have an RSA private key that the
 cloud has the other half for, to permit sshing into the instances that
 are started. Please use the AWS console or any other tool of your choice
-to generate the private key to interactively log in to EC2 instances.
+to generate the private key to interactively log in to EC2 instances. 
 
-Once you have put in your Access Key and Secret Access Key, select a
-region for the cloud (not shown in screenshot). You may define only one
+Once you have generated the needed private key you must either store it as
+a Jenkins `SSH Private Key` credential (and select that credential in your cloud
+config).
+
+If you do not want to create a new Jenkins credential you may alterantively store it
+in plain text on disk, indicating its file path via the Jenkins system property
+`SSH_KEY_PAIR_PRIVATE_KEY_FILE`.  If this system property has a non-empty value then
+it will override the ssh credential specified in the cloud configuration page.  This
+approach works well for `k8s` secrets that are mounted in a jenkins container for example.
+
+Once you have put in your Access Key, Secret Access Key, and configured an ssh private key
+select a region for the cloud (not shown in screenshot). You may define only one
 cloud for each region, and the regions offered in the UI will show only
 the regions that you don't already have clouds defined for them.
 

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -1655,6 +1655,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         if (keyPair == null) {
             throw new AmazonClientException("No matching keypair found on EC2. Is the EC2 private key a valid one?");
         }
+        LOGGER.fine("found matching keypair");
         return keyPair;
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
For some use cases it may not be desirable to create a Jenkins ssh credential to use for connecting to agents, as this credential may be visible to users in the ux, or you may find it easier to manage this private key as a mounted k8s secret.  

To enable this functionality simply define a new `System.property` as follows:
`SSH_KEY_PAIR_PRIVATE_KEY_FILE=/path/to/plaintext/private_key.pem`

If this system property is defined then any credential configured in the cloud config page will be ignored. 


### Testing done

- [ ]  Manually tested and works as expected in my k8s test cluster. 
- [ ] fixup 1 failing unit test
- [ ] unit test for new functionality
 
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
