### PR TITLE
[JENKINS-74945] Use Role ARN when defined

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
@@ -50,7 +50,7 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
     <f:entry title="${%Session Name}" field="roleSessionName">
-      <f:textbox />
+      <f:textbox checkDependsOn="roleArn"/>
     </f:entry>
   </f:advanced>
   <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="region,useInstanceProfileForCredentials,credentialsId,sshKeysCredentialsId,roleArn,roleSessionName" />

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-roleArn.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-roleArn.html
@@ -1,0 +1,3 @@
+<div>
+    The ARN of an IAM Role to be assumed.
+</div>

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-roleSessionName.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-roleSessionName.html
@@ -1,0 +1,3 @@
+<div>
+    A name for the session of the assumed IAM role. If empty, this defaults to 'Jenkins'.
+</div>

--- a/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
+++ b/src/test/java/hudson/plugins/ec2/AmazonEC2CloudTest.java
@@ -38,6 +38,7 @@ import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import hudson.plugins.ec2.util.TestSSHUserPrivateKey;
+import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import java.io.IOException;
 import java.util.Collections;
@@ -94,6 +95,24 @@ public class AmazonEC2CloudTest {
         AmazonEC2 connection = cloud.connect();
         Assert.assertNotNull(connection);
         Assert.assertTrue(Mockito.mockingDetails(connection).isMock());
+    }
+
+    @Test
+    public void testAmazonEC2FactoryWorksIfSessionNameMissing() throws Exception {
+        r.jenkins.clouds.replace(new AmazonEC2Cloud(
+                "us-east-1", true, "abc", "us-east-1", null, "ghi", "3", Collections.emptyList(), "roleArn", null));
+        AmazonEC2Cloud cloud = r.jenkins.clouds.get(AmazonEC2Cloud.class);
+        AmazonEC2 connection = cloud.connect();
+        Assert.assertNotNull(connection);
+        Assert.assertTrue(Mockito.mockingDetails(connection).isMock());
+    }
+
+    @Test
+    public void testSessionNameMissingWarning() {
+        AmazonEC2Cloud actual = r.jenkins.clouds.get(AmazonEC2Cloud.class);
+        AmazonEC2Cloud.DescriptorImpl descriptor = (AmazonEC2Cloud.DescriptorImpl) actual.getDescriptor();
+        assertThat(descriptor.doCheckRoleSessionName("roleArn", "").kind, is(FormValidation.Kind.WARNING));
+        assertThat(descriptor.doCheckRoleSessionName("roleArn", "roleSessionName").kind, is(FormValidation.Kind.OK));
     }
 
     @Test


### PR DESCRIPTION
[JENKINS-74945](https://issues.jenkins.io/browse/JENKINS-74945): 

The Role ARN was silently ignored if the session name was not provided:

* Role ARN is now used whenever it is not empty, if a Role Session Name is not provided "Jenkins will be used"
* Added a check and warning on Role Session Name to warn that it is recommended to set it otherwise "Jenkins" will be used if unset.
* Added help message

<img width="1358" alt="ui-warning-and-help" src="https://github.com/user-attachments/assets/7860d83d-da04-4866-9a02-9a8860232fc7">


### Testing done

* Started a Jenkins controller
* Create an EC2 Cloud
* Specify a Role Arn that can be assumed, leave Session Name empty, and hit test connection
--> It works
* Specify a Role Arn that cannot be assumed, leave Session Name empty, and hit test connection
--> it works
* leave Role Arn and Session Name empty, and hit test connection
--> it works (to make sure that STS is not used )


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue