### PR TITLE
Remove more usages of deprecated constructors in tests

### DIFF
--- a/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
@@ -117,7 +117,8 @@ public class EC2AbstractSlaveTest {
         List<SlaveTemplate> templates = new ArrayList<>();
         templates.add(orig);
         String cloudName = "us-east-1";
-        AmazonEC2Cloud ac = new AmazonEC2Cloud(cloudName, false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+        AmazonEC2Cloud ac =
+                new AmazonEC2Cloud(cloudName, false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
         r.jenkins.clouds.add(ac);
         EC2AbstractSlave slave =
                 new EC2AbstractSlave(
@@ -134,16 +135,21 @@ public class EC2AbstractSlaveTest {
                         "tmpDir",
                         new ArrayList<>(),
                         "root",
+                        EC2AbstractSlave.DEFAULT_JAVA_PATH,
                         "jvm",
                         false,
                         "idle",
                         null,
                         cloudName,
-                        false,
                         Integer.MAX_VALUE,
                         new UnixData("remote", null, null, "22", null),
                         ConnectionStrategy.PRIVATE_IP,
-                        0) {
+                        -1,
+                        Tenancy.Default,
+                        EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                        EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                        EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                        EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED) {
                     @Override
                     public void terminate() {}
 

--- a/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2OndemandSlaveTest.java
@@ -27,6 +27,7 @@ public class EC2OndemandSlaveTest {
                 "tmpDir",
                 Collections.emptyList(),
                 "remoteAdmin",
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
                 "jvmopts",
                 false,
                 "30",
@@ -34,11 +35,15 @@ public class EC2OndemandSlaveTest {
                 "privateDNS",
                 Collections.emptyList(),
                 "cloudName",
-                false,
                 0,
                 new UnixData("a", null, null, "b", null),
                 ConnectionStrategy.PRIVATE_IP,
-                -1);
+                -1,
+                Tenancy.Default,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED);
         assertEquals(Node.Mode.NORMAL, slaveNormal.getMode());
 
         EC2OndemandSlave slaveExclusive = new EC2OndemandSlave(
@@ -53,6 +58,7 @@ public class EC2OndemandSlaveTest {
                 "tmpDir",
                 Collections.emptyList(),
                 "remoteAdmin",
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
                 "jvmopts",
                 false,
                 "30",
@@ -60,11 +66,15 @@ public class EC2OndemandSlaveTest {
                 "privateDNS",
                 Collections.emptyList(),
                 "cloudName",
-                false,
                 0,
                 new UnixData("a", null, null, "b", null),
                 ConnectionStrategy.PRIVATE_IP,
-                -1);
+                -1,
+                Tenancy.Default,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED);
 
         assertEquals(Node.Mode.EXCLUSIVE, slaveExclusive.getMode());
     }

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -232,16 +232,21 @@ public class EC2RetentionStrategyTest {
                         "tmpDir",
                         new ArrayList<>(),
                         "remote",
+                        EC2AbstractSlave.DEFAULT_JAVA_PATH,
                         "jvm",
                         false,
                         "idle",
                         null,
                         "cloud",
-                        false,
                         Integer.MAX_VALUE,
                         null,
                         ConnectionStrategy.PRIVATE_IP,
-                        -1) {
+                        -1,
+                        Tenancy.Default,
+                        EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                        EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                        EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                        EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED) {
                     @Override
                     public void terminate() {}
 
@@ -372,16 +377,21 @@ public class EC2RetentionStrategyTest {
                         "tmpDir",
                         new ArrayList<>(),
                         "remote",
+                        EC2AbstractSlave.DEFAULT_JAVA_PATH,
                         "jvm",
                         false,
                         "idle",
                         null,
                         "cloud",
-                        false,
                         Integer.MAX_VALUE,
                         null,
                         ConnectionStrategy.PRIVATE_IP,
-                        -1) {
+                        -1,
+                        Tenancy.Default,
+                        EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                        EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                        EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                        EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED) {
                     @Override
                     public void terminate() {}
 
@@ -533,16 +543,21 @@ public class EC2RetentionStrategyTest {
                         "tmpDir",
                         new ArrayList<>(),
                         "remote",
+                        EC2AbstractSlave.DEFAULT_JAVA_PATH,
                         "jvm",
                         false,
                         "idle",
                         null,
                         "cloud",
-                        false,
                         Integer.MAX_VALUE,
                         null,
                         ConnectionStrategy.PRIVATE_IP,
-                        usageLimit) {
+                        usageLimit,
+                        Tenancy.Default,
+                        EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                        EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                        EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                        EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED) {
                     @Override
                     public void terminate() {
                         terminateCalled.set(true);
@@ -990,6 +1005,7 @@ public class EC2RetentionStrategyTest {
                 "abc",
                 "us-east-1",
                 PrivateKeyHelper.generate(),
+                null,
                 "3",
                 Collections.singletonList(template),
                 "roleArn",

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -153,7 +153,7 @@ public class SlaveTemplateTest {
         templates.add(orig);
 
         AmazonEC2Cloud ac =
-                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(getConfigForm(ac));
@@ -223,7 +223,7 @@ public class SlaveTemplateTest {
         templates.add(orig);
 
         AmazonEC2Cloud ac =
-                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(getConfigForm(ac));
@@ -300,7 +300,7 @@ public class SlaveTemplateTest {
         templates.add(orig);
 
         AmazonEC2Cloud ac =
-                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(getConfigForm(ac));
@@ -372,7 +372,7 @@ public class SlaveTemplateTest {
         templates.add(orig);
 
         AmazonEC2Cloud ac =
-                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(getConfigForm(ac));
@@ -403,7 +403,7 @@ public class SlaveTemplateTest {
                 "aaa",
                 "10",
                 "rrr",
-                new WindowsData("password", false, ""),
+                new WindowsData("password", false, "", false, true),
                 EC2AbstractSlave.DEFAULT_JAVA_PATH,
                 "-Xmx1g",
                 false,
@@ -437,7 +437,7 @@ public class SlaveTemplateTest {
         templates.add(orig);
 
         AmazonEC2Cloud ac =
-                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(getConfigForm(ac));
@@ -500,7 +500,7 @@ public class SlaveTemplateTest {
         templates.add(orig);
 
         AmazonEC2Cloud ac =
-                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(getConfigForm(ac));
@@ -571,7 +571,7 @@ public class SlaveTemplateTest {
         templates.add(slaveTemplate);
 
         AmazonEC2Cloud ac =
-                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.configRoundtrip();
@@ -1030,7 +1030,7 @@ public class SlaveTemplateTest {
         templates.add(orig);
 
         AmazonEC2Cloud ac =
-                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(getConfigForm(ac));
@@ -1135,11 +1135,11 @@ public class SlaveTemplateTest {
         templates.add(broken);
         templates.add(working);
         AmazonEC2Cloud brokenCloud =
-                new AmazonEC2Cloud("broken/cloud", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+                new AmazonEC2Cloud("broken/cloud", false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
         assertThat(broken.getSlaveName("test"), is("test"));
         assertThat(working.getSlaveName("test"), is("test"));
         AmazonEC2Cloud workingCloud =
-                new AmazonEC2Cloud("cloud", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+                new AmazonEC2Cloud("cloud", false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
         assertThat(broken.getSlaveName("test"), is("test"));
         assertThat(working.getSlaveName("test"), is("EC2 (cloud) - working (test)"));
     }
@@ -1196,7 +1196,7 @@ public class SlaveTemplateTest {
         List<SlaveTemplate> templates = Collections.singletonList(orig);
 
         AmazonEC2Cloud ac =
-                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+                new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
         r.jenkins.clouds.add(ac);
 
         r.submit(r.createWebClient().goTo("configure").getFormByName("config"));

--- a/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
+++ b/src/test/java/hudson/plugins/ec2/TemplateLabelsTest.java
@@ -105,7 +105,7 @@ public class TemplateLabelsTest {
         List<SlaveTemplate> templates = new ArrayList<>();
         templates.add(template);
 
-        ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", "3", templates, null, null);
+        ac = new AmazonEC2Cloud("us-east-1", false, "abc", "us-east-1", "ghi", null, "3", templates, null, null);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/ec2/ssh/verifiers/SshHostKeyVerificationStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/ssh/verifiers/SshHostKeyVerificationStrategyTest.java
@@ -369,16 +369,21 @@ public class SshHostKeyVerificationStrategyTest {
                             "tmpDir",
                             new ArrayList<>(),
                             "remote",
+                            EC2AbstractSlave.DEFAULT_JAVA_PATH,
                             "jvm",
                             false,
                             "idle",
                             null,
                             "cloud",
-                            false,
                             Integer.MAX_VALUE,
                             null,
                             ConnectionStrategy.PRIVATE_IP,
-                            -1) {
+                            -1,
+                            Tenancy.Default,
+                            EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                            EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                            EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                            EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED) {
                         @Override
                         public void terminate() {}
 

--- a/src/test/java/hudson/plugins/ec2/win/WinConnectionTest.java
+++ b/src/test/java/hudson/plugins/ec2/win/WinConnectionTest.java
@@ -17,7 +17,8 @@ public class WinConnectionTest {
         WinConnection connect = new WinConnection(
                 System.getProperty("winrm.host"),
                 System.getProperty("winrm.username", "Administrator"),
-                System.getProperty("winrm.password"));
+                System.getProperty("winrm.password"),
+                true);
         connect.setUseHTTPS(true);
         WindowsProcess process = connect.execute("dir c:\\");
         process.waitFor();


### PR DESCRIPTION
Like #1023, makes it easier to read these tests by avoiding the use of deprecated constructors.

### Testing done

`mvn clean verify`