### PR TITLE
[JENKINS-75230] Fixes the use of an init script with Windows AMI using a Linux launcher

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
@@ -23,8 +23,6 @@
  */
 package hudson.plugins.ec2.ssh;
 
-import static org.apache.sshd.client.session.ClientSession.REMOTE_COMMAND_WAIT_EVENTS;
-
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.KeyPair;
@@ -66,19 +64,15 @@ import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
 import java.security.PublicKey;
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.channel.ChannelExec;
-import org.apache.sshd.client.channel.ClientChannel;
-import org.apache.sshd.client.channel.ClientChannelEvent;
 import org.apache.sshd.client.future.ConnectFuture;
 import org.apache.sshd.client.keyverifier.ServerKeyVerifier;
 import org.apache.sshd.client.session.ClientSession;
@@ -253,67 +247,11 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
 
                         logInfo(computer, listener, "Executing init script");
                         String initCommand = buildUpCommand(computer, tmpDir + "/init.sh");
-                        try (ClientChannel channel = clientSession.createExecChannel(
-                                initCommand, StandardCharsets.US_ASCII, null, Collections.emptyMap())) {
-
-                            channel.open().await(timeout);
-
-                            OutputStream invertedIn = channel.getInvertedIn();
-                            if (invertedIn != null) {
-                                invertedIn.close(); // nothing to write here
-                            }
-
-                            Collection<ClientChannelEvent> waitMask =
-                                    channel.waitFor(REMOTE_COMMAND_WAIT_EVENTS, timeout);
-
-                            if (waitMask.contains(ClientChannelEvent.TIMEOUT)) {
-                                logWarning(computer, listener, "init script timed out");
-                                return;
-                            }
-
-                            int exitStatus = waitCompletion(channel, timeout);
-                            if (exitStatus != 0) {
-                                logWarning(computer, listener, "init script failed: exit code=" + exitStatus);
-                                return;
-                            }
-
-                            InputStream invertedErr = channel.getInvertedErr();
-                            if (invertedErr != null) {
-                                invertedErr.close(); // we are not supposed to get anything from stderr
-                            }
-                            IOUtils.copy(channel.getInvertedOut(), logger);
-                        }
+                        executeRemote(clientSession, initCommand, logger);
 
                         logInfo(computer, listener, "Creating ~/.hudson-run-init");
                         String createHudsonRunInitCommand = buildUpCommand(computer, "touch ~/.hudson-run-init");
-                        try (ClientChannel channel = clientSession.createExecChannel(
-                                createHudsonRunInitCommand, StandardCharsets.US_ASCII, null, Collections.emptyMap())) {
-                            OutputStream invertedIn = channel.getInvertedIn();
-                            if (invertedIn != null) {
-                                invertedIn.close(); // nothing to write here
-                            }
-                            channel.open().await(timeout);
-
-                            Collection<ClientChannelEvent> waitMask =
-                                    channel.waitFor(REMOTE_COMMAND_WAIT_EVENTS, timeout);
-
-                            if (waitMask.contains(ClientChannelEvent.TIMEOUT)) {
-                                logWarning(computer, listener, "init script timed out");
-                                return;
-                            }
-
-                            int exitStatus = waitCompletion(channel, timeout);
-                            if (exitStatus != 0) {
-                                logWarning(computer, listener, "init script failed: exit code=" + exitStatus);
-                                return;
-                            }
-
-                            InputStream invertedErr = channel.getInvertedErr();
-                            if (invertedErr != null) {
-                                invertedErr.close(); // we are not supposed to get anything from stderr
-                            }
-                            IOUtils.copy(channel.getInvertedOut(), logger);
-                        }
+                        executeRemote(clientSession, createHudsonRunInitCommand, logger);
                     }
 
                     try {

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
@@ -242,7 +242,16 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
                         scp.upload(
                                 initScript.getBytes(StandardCharsets.UTF_8),
                                 tmpDir + "/init.sh",
-                                List.of(PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_READ),
+                                List.of(
+                                        PosixFilePermission.OWNER_READ,
+                                        PosixFilePermission.OWNER_WRITE,
+                                        PosixFilePermission.OWNER_EXECUTE,
+                                        PosixFilePermission.GROUP_READ,
+                                        PosixFilePermission.GROUP_WRITE,
+                                        PosixFilePermission.GROUP_EXECUTE,
+                                        PosixFilePermission.OTHERS_READ,
+                                        PosixFilePermission.OTHERS_WRITE,
+                                        PosixFilePermission.OTHERS_EXECUTE),
                                 scpTimestamp);
 
                         logInfo(computer, listener, "Executing init script");
@@ -289,8 +298,11 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
                             tmpDir + "/remoting.jar",
                             List.of(
                                     PosixFilePermission.OWNER_READ,
+                                    PosixFilePermission.OWNER_WRITE,
                                     PosixFilePermission.GROUP_READ,
-                                    PosixFilePermission.OTHERS_READ),
+                                    PosixFilePermission.GROUP_WRITE,
+                                    PosixFilePermission.OTHERS_READ,
+                                    PosixFilePermission.OTHERS_WRITE),
                             scpTimestamp);
                 }
             }

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
@@ -244,13 +244,14 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
 
                     if (StringUtils.isNotBlank(initScript)
                             && !executeRemote(clientSession, "test -e ~/.hudson-run-init", logger)) {
-                        logInfo(computer, listener, "Executing init script");
+                        logInfo(computer, listener, "Upload init script");
                         scp.upload(
                                 initScript.getBytes(StandardCharsets.UTF_8),
                                 tmpDir + "/init.sh",
                                 List.of(PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_READ),
                                 scpTimestamp);
 
+                        logInfo(computer, listener, "Executing init script");
                         String initCommand = buildUpCommand(computer, tmpDir + "/init.sh");
                         try (ClientChannel channel = clientSession.createExecChannel(
                                 initCommand, StandardCharsets.US_ASCII, null, Collections.emptyMap())) {

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
@@ -245,13 +245,7 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
                                 List.of(
                                         PosixFilePermission.OWNER_READ,
                                         PosixFilePermission.OWNER_WRITE,
-                                        PosixFilePermission.OWNER_EXECUTE,
-                                        PosixFilePermission.GROUP_READ,
-                                        PosixFilePermission.GROUP_WRITE,
-                                        PosixFilePermission.GROUP_EXECUTE,
-                                        PosixFilePermission.OTHERS_READ,
-                                        PosixFilePermission.OTHERS_WRITE,
-                                        PosixFilePermission.OTHERS_EXECUTE),
+                                        PosixFilePermission.OWNER_EXECUTE),
                                 scpTimestamp);
 
                         logInfo(computer, listener, "Executing init script");
@@ -296,13 +290,7 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
                     scp.upload(
                             Jenkins.get().getJnlpJars("remoting.jar").readFully(),
                             tmpDir + "/remoting.jar",
-                            List.of(
-                                    PosixFilePermission.OWNER_READ,
-                                    PosixFilePermission.OWNER_WRITE,
-                                    PosixFilePermission.GROUP_READ,
-                                    PosixFilePermission.GROUP_WRITE,
-                                    PosixFilePermission.OTHERS_READ,
-                                    PosixFilePermission.OTHERS_WRITE),
+                            List.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
                             scpTimestamp);
                 }
             }

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -245,13 +245,14 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
 
                     if (StringUtils.isNotBlank(initScript)
                             && !executeRemote(clientSession, "test -e ~/.hudson-run-init", logger)) {
-                        logInfo(computer, listener, "Executing init script");
+                        logInfo(computer, listener, "Upload init script");
                         scp.upload(
                                 initScript.getBytes(StandardCharsets.UTF_8),
                                 tmpDir + "/init.sh",
                                 List.of(PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_READ),
                                 scpTimestamp);
 
+                        logInfo(computer, listener, "Executing init script");
                         String initCommand = buildUpCommand(computer, tmpDir + "/init.sh");
                         try (ClientChannel channel = clientSession.createExecChannel(
                                 initCommand, StandardCharsets.US_ASCII, null, Collections.emptyMap())) {

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -243,7 +243,16 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                         scp.upload(
                                 initScript.getBytes(StandardCharsets.UTF_8),
                                 tmpDir + "/init.sh",
-                                List.of(PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_READ),
+                                List.of(
+                                        PosixFilePermission.OWNER_READ,
+                                        PosixFilePermission.OWNER_WRITE,
+                                        PosixFilePermission.OWNER_EXECUTE,
+                                        PosixFilePermission.GROUP_READ,
+                                        PosixFilePermission.GROUP_WRITE,
+                                        PosixFilePermission.GROUP_EXECUTE,
+                                        PosixFilePermission.OTHERS_READ,
+                                        PosixFilePermission.OTHERS_WRITE,
+                                        PosixFilePermission.OTHERS_EXECUTE),
                                 scpTimestamp);
 
                         logInfo(computer, listener, "Executing init script");
@@ -277,8 +286,11 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                             tmpDir + "/remoting.jar",
                             List.of(
                                     PosixFilePermission.OWNER_READ,
+                                    PosixFilePermission.OWNER_WRITE,
                                     PosixFilePermission.GROUP_READ,
-                                    PosixFilePermission.OTHERS_READ),
+                                    PosixFilePermission.GROUP_WRITE,
+                                    PosixFilePermission.OTHERS_READ,
+                                    PosixFilePermission.OTHERS_WRITE),
                             scpTimestamp);
                 }
             }

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -23,8 +23,6 @@
  */
 package hudson.plugins.ec2.ssh;
 
-import static org.apache.sshd.client.session.ClientSession.REMOTE_COMMAND_WAIT_EVENTS;
-
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.KeyPair;
@@ -68,19 +66,15 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.security.PublicKey;
 import java.time.Duration;
 import java.util.Base64;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.channel.ChannelExec;
-import org.apache.sshd.client.channel.ClientChannel;
-import org.apache.sshd.client.channel.ClientChannelEvent;
 import org.apache.sshd.client.future.ConnectFuture;
 import org.apache.sshd.client.keyverifier.ServerKeyVerifier;
 import org.apache.sshd.client.session.ClientSession;
@@ -254,68 +248,11 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
 
                         logInfo(computer, listener, "Executing init script");
                         String initCommand = buildUpCommand(computer, tmpDir + "/init.sh");
-                        try (ClientChannel channel = clientSession.createExecChannel(
-                                initCommand, StandardCharsets.US_ASCII, null, Collections.emptyMap())) {
-
-                            channel.open().await(timeout);
-
-                            OutputStream invertedIn = channel.getInvertedIn();
-                            if (invertedIn != null) {
-                                invertedIn.close(); // nothing to write here
-                            }
-
-                            Collection<ClientChannelEvent> waitMask =
-                                    channel.waitFor(REMOTE_COMMAND_WAIT_EVENTS, timeout);
-
-                            if (waitMask.contains(ClientChannelEvent.TIMEOUT)) {
-                                logWarning(computer, listener, "init script timed out");
-                                return;
-                            }
-
-                            int exitStatus = waitCompletion(channel, timeout);
-                            if (exitStatus != 0) {
-                                logWarning(computer, listener, "init script failed: exit code=" + exitStatus);
-                                return;
-                            }
-
-                            InputStream invertedErr = channel.getInvertedErr();
-                            if (invertedErr != null) {
-                                invertedErr.close(); // we are not supposed to get anything from stderr
-                            }
-                            IOUtils.copy(channel.getInvertedOut(), logger);
-                        }
+                        executeRemote(clientSession, initCommand, logger);
 
                         logInfo(computer, listener, "Creating ~/.hudson-run-init");
-
                         String createHudsonRunInitCommand = buildUpCommand(computer, "touch ~/.hudson-run-init");
-                        try (ClientChannel channel = clientSession.createExecChannel(
-                                createHudsonRunInitCommand, StandardCharsets.US_ASCII, null, Collections.emptyMap())) {
-                            OutputStream invertedIn = channel.getInvertedIn();
-                            if (invertedIn != null) {
-                                invertedIn.close(); // nothing to write here
-                            }
-                            channel.open().await(timeout);
-
-                            Collection<ClientChannelEvent> waitMask =
-                                    channel.waitFor(REMOTE_COMMAND_WAIT_EVENTS, timeout);
-
-                            if (waitMask.contains(ClientChannelEvent.TIMEOUT)) {
-                                logWarning(computer, listener, "init script timed out");
-                                return;
-                            }
-
-                            int exitStatus = waitCompletion(channel, timeout);
-                            if (exitStatus != 0) {
-                                logWarning(computer, listener, "init script failed: exit code=" + exitStatus);
-                                return;
-                            }
-
-                            InputStream invertedErr = channel.getInvertedErr();
-                            if (invertedErr != null) {
-                                invertedErr.close(); // we are not supposed to get anything from stderr
-                            }
-                            IOUtils.copy(channel.getInvertedOut(), logger);
-                        }
+                        executeRemote(clientSession, createHudsonRunInitCommand, logger);
                     }
 
                     executeRemote(

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -246,13 +246,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                                 List.of(
                                         PosixFilePermission.OWNER_READ,
                                         PosixFilePermission.OWNER_WRITE,
-                                        PosixFilePermission.OWNER_EXECUTE,
-                                        PosixFilePermission.GROUP_READ,
-                                        PosixFilePermission.GROUP_WRITE,
-                                        PosixFilePermission.GROUP_EXECUTE,
-                                        PosixFilePermission.OTHERS_READ,
-                                        PosixFilePermission.OTHERS_WRITE,
-                                        PosixFilePermission.OTHERS_EXECUTE),
+                                        PosixFilePermission.OWNER_EXECUTE),
                                 scpTimestamp);
 
                         logInfo(computer, listener, "Executing init script");
@@ -284,13 +278,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
                     scp.upload(
                             Jenkins.get().getJnlpJars("remoting.jar").readFully(),
                             tmpDir + "/remoting.jar",
-                            List.of(
-                                    PosixFilePermission.OWNER_READ,
-                                    PosixFilePermission.OWNER_WRITE,
-                                    PosixFilePermission.GROUP_READ,
-                                    PosixFilePermission.GROUP_WRITE,
-                                    PosixFilePermission.OTHERS_READ,
-                                    PosixFilePermission.OTHERS_WRITE),
+                            List.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
                             scpTimestamp);
                 }
             }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fix for https://issues.jenkins.io/browse/JENKINS-75230

Previously, the `init.sh` script was uploaded without the `write` permission. On Windows, this creates a `read-only` file. This read-only file is then impossible to replace when the end user wants to reuse the same node. This read-only file causes `scp` to get stuck.

All uploaded files (the init script ant the remoting jar) now have the `write` permissions set.

# :rotating_light: Important notice :rotating_light: 

Users with version `1822.v87175d209b_b_5` or later using a Windows image and the `unix` launcher who upgrade the plugin will have to disable manually the read-only flag on the `init.sh` and `remoting.jar` located in the temporary folder of the Windows machine or, alternatively, delete the the files.

### Testing done

#### Windows AMI

A dedicated AMI was created, based on `ami-0abaed814109888a5` (Microsoft Windows Server 2025 Base). The created AMI contains: `openssh` (configured to use the RSA key), `GitBash` and `java`.

The connection was successful:

```
INFO: Connection allowed after the host key has been verified
<===[JENKINS REMOTING CAPACITY]===>Remoting version: 3248.3250.v3277a_8e88c9b_
Launcher: EC2UnixLauncher
Communication Protocol: Standard in/out
This is a Windows agent
NOTE: Relative remote path resolved to: C:\Users\Administrator
Agent successfully connected and online
```

The configured init script:
```
date >> ~/init.txt
```

The init script was properly executed:
![image](https://github.com/user-attachments/assets/211c1677-b26c-476f-a1d9-b4c36e3e7fd3)

#### Linux AMI

AMI used: `ami-08b1d20c6a69a7100` (Amazon Linux 2023 AMI)

The connection was successful:

```
<===[JENKINS REMOTING CAPACITY]===>Remoting version: 3248.3250.v3277a_8e88c9b_
Launcher: EC2UnixLauncher
Communication Protocol: Standard in/out
This is a Unix agent
NOTE: Relative remote path resolved to: /home/ec2-user
Agent successfully connected and online
```

The configured init script:
```
echo "Init script install java"
sudo yum install -y java
```

The init script was properly executed:
```
INFO: Executing init script
Init script install java
Amazon Linux 2023 repository                     41 MB/s |  31 MB     00:00    
Amazon Linux 2023 Kernel Livepatch repository    55 kB/s |  14 kB     00:00    
[...]
```

#### MacLauncher

Same configuration as the Linux AMI, but using the MacLauncher:
```
Launcher: EC2MacLauncher
Communication Protocol: Standard in/out
This is a Unix agent
NOTE: Relative remote path resolved to: /home/ec2-user
Agent successfully connected and online
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
