### PR TITLE
[JENKINS-75214] Added prioritization of SSH host key algorithms

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
@@ -45,6 +45,7 @@ import hudson.plugins.ec2.ssh.proxy.ProxyCONNECTListener;
 import hudson.plugins.ec2.ssh.verifiers.HostKey;
 import hudson.plugins.ec2.ssh.verifiers.Messages;
 import hudson.plugins.ec2.util.KeyHelper;
+import hudson.plugins.ec2.util.SSHClientHelper;
 import hudson.remoting.Channel;
 import hudson.remoting.Channel.Listener;
 import hudson.slaves.CommandLauncher;
@@ -192,7 +193,7 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
         final String javaPath = node.javaPath;
         String tmpDir = (Util.fixEmptyAndTrim(node.tmpDir) != null ? node.tmpDir : "/tmp");
 
-        try (SshClient client = SshClient.setUpDefaultClient()) {
+        try (SshClient client = SSHClientHelper.getInstance().setupSshClient(computer)) {
             boolean isBootstrapped = bootstrap(computer, listener, template);
             if (!isBootstrapped) {
                 logWarning(computer, listener, "bootstrapresult failed");
@@ -367,7 +368,7 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
             throws InterruptedException, IOException {
         logInfo(computer, listener, "Launching remoting agent (via SSH2 Connection): " + launchString);
 
-        final SshClient remotingClient = SshClient.setUpDefaultClient();
+        final SshClient remotingClient = SSHClientHelper.getInstance().setupSshClient(computer);
         final ClientSession remotingSession = connectToSsh(remotingClient, computer, listener, template);
         KeyPair key = computer.getCloud().getKeyPair();
         if (key != null) {
@@ -457,7 +458,7 @@ public class EC2MacLauncher extends EC2ComputerLauncher {
         final EC2AbstractSlave node = computer.getNode();
         final long timeout = node == null ? 0L : node.getLaunchTimeoutInMillis();
         ClientSession bootstrapSession = null;
-        try (SshClient client = SshClient.setUpDefaultClient()) {
+        try (SshClient client = SSHClientHelper.getInstance().setupSshClient(computer)) {
             int tries = bootstrapAuthTries;
             boolean isAuthenticated = false;
             logInfo(computer, listener, "Getting keypair...");

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -46,6 +46,7 @@ import hudson.plugins.ec2.ssh.verifiers.HostKey;
 import hudson.plugins.ec2.ssh.verifiers.HostKeyHelper;
 import hudson.plugins.ec2.ssh.verifiers.Messages;
 import hudson.plugins.ec2.util.KeyHelper;
+import hudson.plugins.ec2.util.SSHClientHelper;
 import hudson.remoting.Channel;
 import hudson.remoting.Channel.Listener;
 import hudson.slaves.CommandLauncher;
@@ -193,7 +194,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
         final String javaPath = node.javaPath;
         String tmpDir = (Util.fixEmptyAndTrim(node.tmpDir) != null ? node.tmpDir : "/tmp");
 
-        try (SshClient client = SshClient.setUpDefaultClient()) {
+        try (SshClient client = SSHClientHelper.getInstance().setupSshClient(computer)) {
             boolean isBootstrapped = bootstrap(computer, listener, template);
             if (!isBootstrapped) {
                 logWarning(computer, listener, "bootstrapresult failed");
@@ -354,7 +355,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
             throws InterruptedException, IOException {
         logInfo(computer, listener, "Launching remoting agent (via SSH2 Connection): " + launchString);
 
-        final SshClient remotingClient = SshClient.setUpDefaultClient();
+        final SshClient remotingClient = SSHClientHelper.getInstance().setupSshClient(computer);
         final ClientSession remotingSession = connectToSsh(remotingClient, computer, listener, template);
         KeyPair key = computer.getCloud().getKeyPair();
         if (key != null) {
@@ -481,7 +482,7 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
         final EC2AbstractSlave node = computer.getNode();
         final long timeout = node == null ? 0L : node.getLaunchTimeoutInMillis();
         ClientSession bootstrapSession = null;
-        try (SshClient client = SshClient.setUpDefaultClient()) {
+        try (SshClient client = SSHClientHelper.getInstance().setupSshClient(computer)) {
             int tries = bootstrapAuthTries;
             boolean isAuthenticated = false;
             logInfo(computer, listener, "Getting keypair...");

--- a/src/main/java/hudson/plugins/ec2/util/SSHClientHelper.java
+++ b/src/main/java/hudson/plugins/ec2/util/SSHClientHelper.java
@@ -1,0 +1,93 @@
+package hudson.plugins.ec2.util;
+
+import hudson.plugins.ec2.EC2Computer;
+import hudson.plugins.ec2.ssh.verifiers.HostKey;
+import hudson.plugins.ec2.ssh.verifiers.HostKeyHelper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.common.signature.BuiltinSignatures;
+import org.apache.sshd.common.signature.Signature;
+
+public final class SSHClientHelper {
+
+    private static final SSHClientHelper INSTANCE = new SSHClientHelper();
+
+    private SSHClientHelper() {}
+
+    public static SSHClientHelper getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Set up an SSH client configured for the given {@link EC2Computer}.
+     *
+     * @param computer the {@link EC2Computer} the created client will connect to
+     * @return an SSH client configured for this {@link EC2Computer}
+     */
+    public SshClient setupSshClient(EC2Computer computer) {
+        SshClient client = SshClient.setUpDefaultClient();
+
+        List<BuiltinSignatures> preferred = getPreferredSignatures(computer);
+        if (!preferred.isEmpty()) {
+            LinkedHashSet<NamedFactory<Signature>> signatureFactoriesSet = new LinkedHashSet<>(preferred);
+            signatureFactoriesSet.addAll(client.getSignatureFactories());
+            client.setSignatureFactories(new ArrayList<>(signatureFactoriesSet));
+        }
+
+        return client;
+    }
+
+    /**
+     * Return an ordered list of signature algorithms that should be used. Noticeably, if a {@link HostKey} already exists for this
+     * {@link EC2Computer}, the {@link HostKey} algorithm will be attempted first.
+     *
+     * @param computer return a list of signature for this computer.
+     * @return an ordered list of signature algorithms that should be used.
+     */
+    public List<BuiltinSignatures> getPreferredSignatures(EC2Computer computer) {
+        String trustedAlgorithm;
+        try {
+            HostKey trustedHostKey = HostKeyHelper.getInstance().getHostKey(computer);
+            if (trustedHostKey == null) {
+                return List.of();
+            }
+            trustedAlgorithm = trustedHostKey.getAlgorithm();
+        } catch (IOException e) {
+            return List.of();
+        }
+
+        List<BuiltinSignatures> preferred;
+        switch (trustedAlgorithm) {
+            case "ssh-rsa":
+                preferred = List.of(
+                        BuiltinSignatures.rsa,
+                        BuiltinSignatures.rsaSHA256,
+                        BuiltinSignatures.rsaSHA256_cert,
+                        BuiltinSignatures.rsaSHA512,
+                        BuiltinSignatures.rsaSHA512_cert);
+                break;
+            case "ecdsa-sha2-nistp256":
+                preferred = List.of(BuiltinSignatures.nistp256, BuiltinSignatures.nistp256_cert);
+                break;
+            case "ecdsa-sha2-nistp384":
+                preferred = List.of(BuiltinSignatures.nistp384, BuiltinSignatures.nistp384_cert);
+                break;
+            case "ecdsa-sha2-nistp521":
+                preferred = List.of(BuiltinSignatures.nistp521, BuiltinSignatures.nistp521_cert);
+                break;
+            case "ssh-ed25519":
+                preferred = List.of(
+                        BuiltinSignatures.ed25519, BuiltinSignatures.ed25519_cert, BuiltinSignatures.sk_ssh_ed25519);
+                break;
+            default:
+                return List.of();
+        }
+
+        // Keep only supported algorithms
+        return NamedFactory.setUpBuiltinFactories(true, preferred);
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/MockEC2Computer.java
+++ b/src/test/java/hudson/plugins/ec2/MockEC2Computer.java
@@ -1,0 +1,143 @@
+package hudson.plugins.ec2;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.ec2.model.InstanceType;
+import hudson.model.Node;
+import java.util.ArrayList;
+import java.util.Collections;
+
+// A mock ec2 computer returning the data we want
+public class MockEC2Computer extends EC2Computer {
+    private static final String COMPUTER_NAME = "MockInstanceForTest";
+
+    private InstanceState state = InstanceState.PENDING;
+
+    private String console = null;
+
+    private final EC2AbstractSlave slave;
+
+    public MockEC2Computer(EC2AbstractSlave slave) {
+        super(slave);
+        this.slave = slave;
+    }
+
+    // Create a computer
+    public static MockEC2Computer createComputer(String suffix) throws Exception {
+        final EC2AbstractSlave slave =
+                new EC2AbstractSlave(
+                        COMPUTER_NAME + suffix,
+                        "id" + suffix,
+                        "description" + suffix,
+                        "fs",
+                        1,
+                        null,
+                        "label",
+                        null,
+                        null,
+                        "init",
+                        "tmpDir",
+                        new ArrayList<>(),
+                        "remote",
+                        EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                        "jvm",
+                        false,
+                        "idle",
+                        null,
+                        "cloud",
+                        Integer.MAX_VALUE,
+                        null,
+                        ConnectionStrategy.PRIVATE_IP,
+                        -1,
+                        Tenancy.Default,
+                        EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                        EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                        EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                        EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED) {
+                    @Override
+                    public void terminate() {}
+
+                    @Override
+                    public String getEc2Type() {
+                        return null;
+                    }
+                };
+
+        return new MockEC2Computer(slave);
+    }
+
+    @Override
+    public String getDecodedConsoleOutput() throws AmazonClientException {
+        return getConsole();
+    }
+
+    @Override
+    public InstanceState getState() {
+        return state;
+    }
+
+    @Override
+    public EC2AbstractSlave getNode() {
+        return slave;
+    }
+
+    @Override
+    public SlaveTemplate getSlaveTemplate() {
+        return new SlaveTemplate(
+                "ami-123",
+                EC2AbstractSlave.TEST_ZONE,
+                null,
+                "default",
+                "foo",
+                InstanceType.M1Large,
+                false,
+                "ttt",
+                Node.Mode.NORMAL,
+                "AMI description",
+                "bar",
+                "bbb",
+                "aaa",
+                "10",
+                "fff",
+                null,
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "-Xmx1g",
+                false,
+                "subnet-123 subnet-456",
+                null,
+                null,
+                0,
+                0,
+                null,
+                "",
+                false,
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                false,
+                ConnectionStrategy.PRIVATE_DNS,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED);
+    }
+
+    public void setState(InstanceState state) {
+        this.state = state;
+    }
+
+    public String getConsole() {
+        return console;
+    }
+
+    public void setConsole(String console) {
+        this.console = console;
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/ssh/verifiers/SshHostKeyVerificationStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/ssh/verifiers/SshHostKeyVerificationStrategyTest.java
@@ -4,22 +4,14 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.ec2.model.InstanceType;
-import hudson.model.Node;
-import hudson.plugins.ec2.ConnectionStrategy;
-import hudson.plugins.ec2.EC2AbstractSlave;
 import hudson.plugins.ec2.EC2Computer;
-import hudson.plugins.ec2.EbsEncryptRootVolume;
 import hudson.plugins.ec2.InstanceState;
-import hudson.plugins.ec2.SlaveTemplate;
-import hudson.plugins.ec2.Tenancy;
+import hudson.plugins.ec2.MockEC2Computer;
 import hudson.plugins.ec2.util.ConnectionRule;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.security.PublicKey;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import org.apache.sshd.client.keyverifier.ServerKeyVerifier;
@@ -32,8 +24,6 @@ import org.jvnet.hudson.test.LoggerRule;
 import org.testcontainers.containers.Container;
 
 public class SshHostKeyVerificationStrategyTest {
-    private static final String COMPUTER_NAME = "MockInstanceForTest";
-
     @ClassRule
     public static ConnectionRule conRule = new ConnectionRule();
 
@@ -244,8 +234,8 @@ public class SshHostKeyVerificationStrategyTest {
             loggerRule = new LoggerRule();
             loggerRule.recordPackage(CheckNewHardStrategy.class, Level.INFO).capture(10);
 
-            computer.console = console;
-            computer.state = state;
+            computer.setConsole(console);
+            computer.setState(state);
 
             if (changeHostKey) {
                 // Regenerate all the keys in the container
@@ -334,126 +324,6 @@ public class SshHostKeyVerificationStrategyTest {
                 connectionAttempt.verifier = verifier;
                 return connectionAttempt;
             }
-        }
-    }
-
-    // A mock ec2 computer returning the data we want
-    private static class MockEC2Computer extends EC2Computer {
-        InstanceState state = InstanceState.PENDING;
-        String console = null;
-        EC2AbstractSlave slave;
-
-        public MockEC2Computer(EC2AbstractSlave slave) {
-            super(slave);
-            this.slave = slave;
-        }
-
-        // Create a computer
-        private static MockEC2Computer createComputer(String suffix) throws Exception {
-            final EC2AbstractSlave slave =
-                    new EC2AbstractSlave(
-                            COMPUTER_NAME + suffix,
-                            "id" + suffix,
-                            "description" + suffix,
-                            "fs",
-                            1,
-                            null,
-                            "label",
-                            null,
-                            null,
-                            "init",
-                            "tmpDir",
-                            new ArrayList<>(),
-                            "remote",
-                            EC2AbstractSlave.DEFAULT_JAVA_PATH,
-                            "jvm",
-                            false,
-                            "idle",
-                            null,
-                            "cloud",
-                            Integer.MAX_VALUE,
-                            null,
-                            ConnectionStrategy.PRIVATE_IP,
-                            -1,
-                            Tenancy.Default,
-                            EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
-                            EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
-                            EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
-                            EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED) {
-                        @Override
-                        public void terminate() {}
-
-                        @Override
-                        public String getEc2Type() {
-                            return null;
-                        }
-                    };
-
-            return new MockEC2Computer(slave);
-        }
-
-        @Override
-        public String getDecodedConsoleOutput() throws AmazonClientException {
-            return console;
-        }
-
-        @Override
-        public InstanceState getState() {
-            return state;
-        }
-
-        @Override
-        public EC2AbstractSlave getNode() {
-            return slave;
-        }
-
-        @Override
-        public SlaveTemplate getSlaveTemplate() {
-            return new SlaveTemplate(
-                    "ami-123",
-                    EC2AbstractSlave.TEST_ZONE,
-                    null,
-                    "default",
-                    "foo",
-                    InstanceType.M1Large,
-                    false,
-                    "ttt",
-                    Node.Mode.NORMAL,
-                    "AMI description",
-                    "bar",
-                    "bbb",
-                    "aaa",
-                    "10",
-                    "fff",
-                    null,
-                    EC2AbstractSlave.DEFAULT_JAVA_PATH,
-                    "-Xmx1g",
-                    false,
-                    "subnet-123 subnet-456",
-                    null,
-                    null,
-                    0,
-                    0,
-                    null,
-                    "",
-                    false,
-                    false,
-                    "",
-                    false,
-                    "",
-                    false,
-                    false,
-                    false,
-                    ConnectionStrategy.PRIVATE_DNS,
-                    -1,
-                    Collections.emptyList(),
-                    null,
-                    Tenancy.Default,
-                    EbsEncryptRootVolume.DEFAULT,
-                    EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
-                    EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
-                    EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
-                    EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED);
         }
     }
 

--- a/src/test/java/hudson/plugins/ec2/util/SSHClientHelperTest.java
+++ b/src/test/java/hudson/plugins/ec2/util/SSHClientHelperTest.java
@@ -1,0 +1,165 @@
+package hudson.plugins.ec2.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import hudson.plugins.ec2.MockEC2Computer;
+import hudson.plugins.ec2.ssh.verifiers.HostKeyHelper;
+import java.security.Provider;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.common.signature.BuiltinSignatures;
+import org.apache.sshd.common.signature.Signature;
+import org.apache.sshd.common.util.security.AbstractSecurityProviderRegistrar;
+import org.apache.sshd.common.util.security.SecurityUtils;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+import org.mockito.Mockito;
+
+public class SSHClientHelperTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    @LocalData
+    public void setupSshClientWithNoHostKey() throws Exception {
+        MockEC2Computer computer = MockEC2Computer.createComputer("noHostKey");
+
+        try (SshClient client = SSHClientHelper.getInstance().setupSshClient(computer);
+                SshClient defaultClient = SshClient.setUpDefaultClient()) {
+            List<NamedFactory<Signature>> signatureFactories = client.getSignatureFactories();
+            assertEquals(
+                    "No existing host key found, created client should not have customized signature factories",
+                    defaultClient.getSignatureFactories(),
+                    signatureFactories);
+        }
+    }
+
+    @Test
+    @LocalData("ecdsaSha2Nistp256")
+    public void setupSshClientWithHostKeyECDSASha2Nistp256Supported() throws Exception {
+        // don't run this if EC is not supported
+        Assume.assumeTrue(SecurityUtils.isECCSupported());
+
+        MockEC2Computer computer = MockEC2Computer.createComputer("HostKey");
+        assertNotNull("Expected an HostKey file", HostKeyHelper.getInstance().getHostKey(computer));
+
+        List<BuiltinSignatures> expected = List.of(BuiltinSignatures.nistp256, BuiltinSignatures.nistp256_cert);
+        String message =
+                "Existing host key found and EC provider exists, created client should have customized signature factories";
+
+        doTestPreferredAlgorithms(message, expected);
+    }
+
+    @Test
+    @LocalData("ecdsaSha2Nistp384")
+    public void setupSshClientWithHostKeyECDSASha2Nistp384Supported() throws Exception {
+        // don't run this if EC is not supported
+        Assume.assumeTrue(SecurityUtils.isECCSupported());
+
+        MockEC2Computer computer = MockEC2Computer.createComputer("HostKey");
+        assertNotNull("Expected an HostKey file", HostKeyHelper.getInstance().getHostKey(computer));
+
+        List<BuiltinSignatures> expected = List.of(BuiltinSignatures.nistp384, BuiltinSignatures.nistp384_cert);
+        String message =
+                "Existing host key found and EC provider exists, created client should have customized signature factories";
+
+        doTestPreferredAlgorithms(message, expected);
+    }
+
+    @Test
+    @LocalData("ecdsaSha2Nistp521")
+    public void setupSshClientWithHostKeyECDSASha2Nistp521Supported() throws Exception {
+        // don't run this if EC is not supported
+        Assume.assumeTrue(SecurityUtils.isECCSupported());
+
+        MockEC2Computer computer = MockEC2Computer.createComputer("HostKey");
+        assertNotNull("Expected an HostKey file", HostKeyHelper.getInstance().getHostKey(computer));
+
+        List<BuiltinSignatures> expected = List.of(BuiltinSignatures.nistp521, BuiltinSignatures.nistp521_cert);
+        String message =
+                "Existing host key found and EC provider exists, created client should have customized signature factories";
+
+        doTestPreferredAlgorithms(message, expected);
+    }
+
+    @Test
+    @LocalData("ed25519")
+    public void setupSshClientWithHostKeyEDDSANotSupported() throws Exception {
+        SecurityUtils.registerSecurityProvider(new MockEDDSASecurityProviderRegistrar(false));
+        // don't run this if EDDSA is supported
+        Assume.assumeFalse(SecurityUtils.isEDDSACurveSupported());
+
+        MockEC2Computer computer = MockEC2Computer.createComputer("HostKey");
+        assertNotNull("Expected an HostKey file", HostKeyHelper.getInstance().getHostKey(computer));
+
+        try (SshClient client = SSHClientHelper.getInstance().setupSshClient(computer);
+                SshClient defaultClient = SshClient.setUpDefaultClient()) {
+            List<NamedFactory<Signature>> signatureFactories = client.getSignatureFactories();
+            assertEquals(
+                    "Existing host key found but no EDDSA provider, created client should not have customized signature factories",
+                    defaultClient.getSignatureFactories(),
+                    signatureFactories);
+        }
+    }
+
+    @Test
+    @LocalData("ed25519")
+    public void setupSshClientWithHostKeyEDDSASupported() throws Exception {
+        SecurityUtils.registerSecurityProvider(new MockEDDSASecurityProviderRegistrar(true));
+        // don't run this if EDDSA is not supported
+        Assume.assumeTrue(SecurityUtils.isEDDSACurveSupported());
+
+        List<BuiltinSignatures> expected =
+                List.of(BuiltinSignatures.ed25519, BuiltinSignatures.ed25519_cert, BuiltinSignatures.sk_ssh_ed25519);
+        String message =
+                "Existing host key found and EDDSA provider exists, created client should have customized signature factories";
+
+        doTestPreferredAlgorithms(message, expected);
+    }
+
+    private static void doTestPreferredAlgorithms(String message, List<BuiltinSignatures> expected) throws Exception {
+        MockEC2Computer computer = MockEC2Computer.createComputer("HostKey");
+        assertNotNull("Expected an HostKey file", HostKeyHelper.getInstance().getHostKey(computer));
+
+        try (SshClient client = SSHClientHelper.getInstance().setupSshClient(computer)) {
+            List<NamedFactory<Signature>> signatureFactories = client.getSignatureFactories();
+            List<NamedFactory<Signature>> actual =
+                    signatureFactories.stream().limit(expected.size()).collect(Collectors.toList());
+            assertEquals(message, expected, actual);
+        }
+    }
+
+    /**
+     * This class registers a mocked security provider for EDDSA.
+     */
+    private static class MockEDDSASecurityProviderRegistrar extends AbstractSecurityProviderRegistrar {
+
+        private final boolean isSupported;
+
+        /**
+         * @param isSupported if true, EDDSA is supported
+         */
+        public MockEDDSASecurityProviderRegistrar(boolean isSupported) {
+            super(SecurityUtils.EDDSA);
+            this.isSupported = isSupported;
+        }
+
+        @Override
+        public boolean isSupported() {
+            return isSupported;
+        }
+
+        @Override
+        public Provider getSecurityProvider() {
+            Provider mock = Mockito.mock(Provider.class);
+            Mockito.when(mock.getName()).thenReturn(SecurityUtils.EDDSA);
+            return mock;
+        }
+    }
+}

--- a/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ecdsaSha2Nistp256/config.xml
+++ b/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ecdsaSha2Nistp256/config.xml
@@ -1,0 +1,20 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson>
+  <numExecutors>4</numExecutors>
+  <clouds>
+    <hudson.plugins.ec2.EC2Cloud>
+      <name>ec2-myEc2Cloud</name>
+      <useInstanceProfileForCredentials>false</useInstanceProfileForCredentials>
+      <roleArn></roleArn>
+      <roleSessionName></roleSessionName>
+      <credentialsId></credentialsId>
+      <privateKey>
+        <privateKey>myPrivateKey</privateKey>
+      </privateKey>
+      <instanceCap>2147483647</instanceCap>
+      <templates class="empty-list"/>
+      <region></region>
+      <noDelayProvisioning>false</noDelayProvisioning>
+    </hudson.plugins.ec2.EC2Cloud>
+  </clouds>
+</hudson>

--- a/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ecdsaSha2Nistp256/nodes/MockInstanceForTestHostKey/ssh-host-key.xml
+++ b/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ecdsaSha2Nistp256/nodes/MockInstanceForTestHostKey/ssh-host-key.xml
@@ -1,0 +1,5 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.plugins.ec2.ssh.verifiers.HostKey plugin="ec2@999999-SNAPSHOT">
+  <algorithm>ecdsa-sha2-nistp256</algorithm>
+  <key>AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBB1ZWbuchcMR2NMc4wu4sB2sFvnxZ45tAyijmSx9pUkQ51InNU7t1qzf2p29VhwdJ7kQSX3HdUcwBP1NfUSEoFw=</key>
+</hudson.plugins.ec2.ssh.verifiers.HostKey>

--- a/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ecdsaSha2Nistp384/config.xml
+++ b/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ecdsaSha2Nistp384/config.xml
@@ -1,0 +1,20 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson>
+  <numExecutors>4</numExecutors>
+  <clouds>
+    <hudson.plugins.ec2.EC2Cloud>
+      <name>ec2-myEc2Cloud</name>
+      <useInstanceProfileForCredentials>false</useInstanceProfileForCredentials>
+      <roleArn></roleArn>
+      <roleSessionName></roleSessionName>
+      <credentialsId></credentialsId>
+      <privateKey>
+        <privateKey>myPrivateKey</privateKey>
+      </privateKey>
+      <instanceCap>2147483647</instanceCap>
+      <templates class="empty-list"/>
+      <region></region>
+      <noDelayProvisioning>false</noDelayProvisioning>
+    </hudson.plugins.ec2.EC2Cloud>
+  </clouds>
+</hudson>

--- a/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ecdsaSha2Nistp384/nodes/MockInstanceForTestHostKey/ssh-host-key.xml
+++ b/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ecdsaSha2Nistp384/nodes/MockInstanceForTestHostKey/ssh-host-key.xml
@@ -1,0 +1,5 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.plugins.ec2.ssh.verifiers.HostKey plugin="ec2@999999-SNAPSHOT">
+  <algorithm>ecdsa-sha2-nistp384</algorithm>
+  <key>AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBEfdfV0luXJ0NJGMpeAMDZvfDjfwpC9U+YDSlgM0Gh2eCCtYCGv41G4tZd5+L1gjPEiS4Y8r+jb3JoAX6JdQfHecK6+NHpZsF0uwrn8zTfA9PT+I9nTtEyBgNWM/v/A5wQ==</key>
+</hudson.plugins.ec2.ssh.verifiers.HostKey>

--- a/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ecdsaSha2Nistp521/config.xml
+++ b/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ecdsaSha2Nistp521/config.xml
@@ -1,0 +1,20 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson>
+  <numExecutors>4</numExecutors>
+  <clouds>
+    <hudson.plugins.ec2.EC2Cloud>
+      <name>ec2-myEc2Cloud</name>
+      <useInstanceProfileForCredentials>false</useInstanceProfileForCredentials>
+      <roleArn></roleArn>
+      <roleSessionName></roleSessionName>
+      <credentialsId></credentialsId>
+      <privateKey>
+        <privateKey>myPrivateKey</privateKey>
+      </privateKey>
+      <instanceCap>2147483647</instanceCap>
+      <templates class="empty-list"/>
+      <region></region>
+      <noDelayProvisioning>false</noDelayProvisioning>
+    </hudson.plugins.ec2.EC2Cloud>
+  </clouds>
+</hudson>

--- a/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ecdsaSha2Nistp521/nodes/MockInstanceForTestHostKey/ssh-host-key.xml
+++ b/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ecdsaSha2Nistp521/nodes/MockInstanceForTestHostKey/ssh-host-key.xml
@@ -1,0 +1,5 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.plugins.ec2.ssh.verifiers.HostKey plugin="ec2@999999-SNAPSHOT">
+  <algorithm>ecdsa-sha2-nistp521</algorithm>
+  <key>AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAFrY2jC8sarrQqI13e9fDhzeUvTFt5j2krHfFfqDrP/M7L5RJzbg4jOSOly7FdOi7JhFkYaEguddhRh2DIUWKHR9ADR9/m4n9WxHR9QaVLUYUyZdQzgdtlY6KfLYJyO5PBSulMhpfDKGoycNKmr6Av1gyESAIBq+bINsgpUby+h9jkC7Q==</key>
+</hudson.plugins.ec2.ssh.verifiers.HostKey>

--- a/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ed25519/config.xml
+++ b/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ed25519/config.xml
@@ -1,0 +1,20 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson>
+  <numExecutors>4</numExecutors>
+  <clouds>
+    <hudson.plugins.ec2.EC2Cloud>
+      <name>ec2-myEc2Cloud</name>
+      <useInstanceProfileForCredentials>false</useInstanceProfileForCredentials>
+      <roleArn></roleArn>
+      <roleSessionName></roleSessionName>
+      <credentialsId></credentialsId>
+      <privateKey>
+        <privateKey>myPrivateKey</privateKey>
+      </privateKey>
+      <instanceCap>2147483647</instanceCap>
+      <templates class="empty-list"/>
+      <region></region>
+      <noDelayProvisioning>false</noDelayProvisioning>
+    </hudson.plugins.ec2.EC2Cloud>
+  </clouds>
+</hudson>

--- a/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ed25519/nodes/MockInstanceForTestHostKey/ssh-host-key.xml
+++ b/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/ed25519/nodes/MockInstanceForTestHostKey/ssh-host-key.xml
@@ -1,0 +1,5 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.plugins.ec2.ssh.verifiers.HostKey plugin="ec2@999999-SNAPSHOT">
+  <algorithm>ssh-ed25519</algorithm>
+  <key>AAAAC3NzaC1lZDI1NTE5AAAAIHp+UvRTxCZxJKZcExTuY4uOFEPj3pfX1FJGzRGIh+AC</key>
+</hudson.plugins.ec2.ssh.verifiers.HostKey>

--- a/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/setupSshClientWithNoHostKey/config.xml
+++ b/src/test/resources/hudson/plugins/ec2/util/SSHClientHelperTest/setupSshClientWithNoHostKey/config.xml
@@ -1,0 +1,20 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson>
+  <numExecutors>4</numExecutors>
+  <clouds>
+    <hudson.plugins.ec2.EC2Cloud>
+      <name>ec2-myEc2Cloud</name>
+      <useInstanceProfileForCredentials>false</useInstanceProfileForCredentials>
+      <roleArn></roleArn>
+      <roleSessionName></roleSessionName>
+      <credentialsId></credentialsId>
+      <privateKey>
+        <privateKey>myPrivateKey</privateKey>
+      </privateKey>
+      <instanceCap>2147483647</instanceCap>
+      <templates class="empty-list"/>
+      <region></region>
+      <noDelayProvisioning>false</noDelayProvisioning>
+    </hudson.plugins.ec2.EC2Cloud>
+  </clouds>
+</hudson>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fix for https://issues.jenkins.io/browse/JENKINS-75214

When a `HostKey` already exists for the `Computer`, the algorithm is used as the preferred one to initiate the connection.

# :rotating_light:  `ssh-ed25519` support

Please note that, as for now, `mina` doesn't support `ssh-ed25519` out of the box. This support will be added in a future release: https://github.com/apache/mina-sshd/issues/657.

In the meantime, it is require to install https://plugins.jenkins.io/eddsa-api/ for `ssh-ed25519` to be supported.

### Testing done

Note: I moved `MockEC2Computer` to use it in `SSHClientHelperTest`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
