### PR TITLE
[JENKINS-75589] Region is no longer being kept in the UI

### DIFF
--- a/src/test/java/hudson/plugins/ec2/EC2CloudUnitTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudUnitTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 import hudson.model.Node;
 import hudson.plugins.ec2.util.AmazonEC2FactoryMockImpl;
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,6 +48,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
 import software.amazon.awssdk.services.ec2.model.Instance;
@@ -59,6 +61,19 @@ import software.amazon.awssdk.services.ec2.model.Tag;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class EC2CloudUnitTest {
+
+    @Test
+    void testBootstrapRegion() throws Exception {
+        assertEquals(Region.US_EAST_1, EC2Cloud.getBootstrapRegion(null));
+        assertEquals(Region.US_EAST_1, EC2Cloud.getBootstrapRegion(new URI("")));
+        assertEquals(Region.US_EAST_1, EC2Cloud.getBootstrapRegion(new URI("https://ec2.amazonaws.com/")));
+        assertEquals(Region.US_EAST_1, EC2Cloud.getBootstrapRegion(new URI("https://ec2.us-east-1.amazonaws.com/")));
+        assertEquals(Region.US_WEST_1, EC2Cloud.getBootstrapRegion(new URI("https://ec2.us-west-1.amazonaws.com/")));
+        assertEquals(
+                Region.US_GOV_EAST_1, EC2Cloud.getBootstrapRegion(new URI("https://ec2.us-gov-east-1.amazonaws.com/")));
+        assertEquals(
+                Region.US_GOV_WEST_1, EC2Cloud.getBootstrapRegion(new URI("https://ec2.us-gov-west-1.amazonaws.com/")));
+    }
 
     @Test
     void testInstanceCap() {


### PR DESCRIPTION
### Problem

See [JENKINS-75589](https://issues.jenkins.io/browse/JENKINS-75589). The code that populates the regions in the UI was failing to populate the regions on some installations.

### Evaluation

The old code, prior to adoption of AWS Java SDK v2, implicitly set the region to `us-east-1` by virtue of setting the endpoint to https://ec2.amazonaws.com which triggered a deprecated code path in the AWS Java SDK v1 to eventually assume a region of `us-east-1`. The deprecated code has been removed in AWS Java SDK v2. We were not setting a region explicitly, thus triggering [this logic](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/awscore/client/builder/AwsClientBuilder.html#region(software.amazon.awssdk.regions.Region)):

> Configure the region with which the SDK should communicate.
> 
> If this is not specified, the SDK will attempt to identify the endpoint automatically using the following logic:
> 
>   -  Check the `aws.region` system property for the region.
>   - Check the `AWS_REGION` environment variable for the region.
>   -  Check the `${user.home}/.aws/credentials` and `${user.home}/.aws/config` files for the region.
>   -  If running in EC2, check the EC2 metadata service for the region.
> 
> If the region is not found in any of the locations above, an exception will be thrown at [SdkBuilder.build()](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/utils/builder/SdkBuilder.html#build()) time.

My theory is that while many installations had a region already configured in `~/.aws` or in the EC2 metadata service (e.g., if the controller was already running in EC2), many did not. Hence before they would have picked `us-east-1` to list the regions, while after the migration to SDK v2 they would have triggered the exception mentioned in the last line above.

### Solution

Restore the old behavior by setting the region based on the endpoint URL. The new v2 API does not have a convenience utility class for doing this, so I have reimplemented the logic based on the behavior of the v1 API.

### Testing done

- Added new unit tests.
- Tested interactively in [JENKINS-75589 (comment)](https://issues.jenkins.io/browse/JENKINS-75589?focusedId=454139&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-454139).

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
