### PR TITLE
Millisecond precision in `EC2RetentionStrategy`

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -203,8 +203,8 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                 }
             }
 
-            final long idleMilliseconds = this.clock.millis()
-                    - Math.max(computer.getIdleStartMilliseconds(), launchedAt.getEpochSecond() * 1000);
+            final long idleMilliseconds =
+                    this.clock.millis() - Math.max(computer.getIdleStartMilliseconds(), launchedAt.toEpochMilli());
 
             if (idleTerminationMinutes > 0) {
                 // TODO: really think about the right strategy here, see


### PR DESCRIPTION
Prior to the AWS Java SDK v2 conversion, this used millisecond precision, but now it only uses second precision. This restores the original behavior.

### Testing done

CI build

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
