### PR TITLE
[JENKINS-75840] `NullPointerException` in `CloudHelper.getInstanceWithRetry`

### DIFF
--- a/src/main/java/hudson/plugins/ec2/CloudHelper.java
+++ b/src/main/java/hudson/plugins/ec2/CloudHelper.java
@@ -28,7 +28,7 @@ final class CloudHelper {
             try {
                 return getInstance(instanceId, cloud);
             } catch (AwsServiceException e) {
-                if (e.awsErrorDetails().errorCode().equals("InvalidInstanceID.NotFound")
+                if ("InvalidInstanceID.NotFound".equals(e.awsErrorDetails().errorCode())
                         || EC2Cloud.EC2_REQUEST_EXPIRED_ERROR_CODE.equals(
                                 e.awsErrorDetails().errorCode())) {
                     // retry in 5 seconds.

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -1047,8 +1047,8 @@ public class EC2Cloud extends Cloud {
                 }
             } catch (AwsServiceException e) {
                 LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
-                if (e.awsErrorDetails().errorCode().equals("RequestExpired")
-                        || e.awsErrorDetails().errorCode().equals("ExpiredToken")) {
+                if ("RequestExpired".equals(e.awsErrorDetails().errorCode())
+                        || "ExpiredToken".equals(e.awsErrorDetails().errorCode())) {
                     // A RequestExpired or ExpiredToken error can indicate that credentials have expired so reconnect
                     LOGGER.log(Level.INFO, "Reconnecting to EC2 due to RequestExpired or ExpiredToken error");
                     try {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -2185,7 +2185,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 newInstances = new ArrayList<>(
                         ec2.runInstances(riRequestBuilder.build()).instances());
             } catch (Ec2Exception e) {
-                if (fallbackSpotToOndemand && e.awsErrorDetails().errorCode().equals("InsufficientInstanceCapacity")) {
+                if (fallbackSpotToOndemand
+                        && "InsufficientInstanceCapacity"
+                                .equals(e.awsErrorDetails().errorCode())) {
                     logProvisionInfo(
                             "There is no spot capacity available matching your request, falling back to on-demand instance.");
                     riRequestBuilder.instanceMarketOptions(instanceMarketOptionsRequestBuilder.build());
@@ -2522,7 +2524,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 reqResult = ec2.requestSpotInstances(spotRequestBuilder.build());
             } catch (Ec2Exception e) {
                 if (spotConfig.getFallbackToOndemand()
-                        && e.awsErrorDetails().errorCode().equals("MaxSpotInstanceCountExceeded")) {
+                        && "MaxSpotInstanceCountExceeded"
+                                .equals(e.awsErrorDetails().errorCode())) {
                     logProvisionInfo(
                             "There is no spot capacity available matching your request, falling back to on-demand instance.");
                     return provisionOndemand(image, number, provisionOptions);
@@ -2736,7 +2739,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @param params
      * @throws InterruptedException
      */
-    private void updateRemoteTags(Ec2Client ec2, Collection<Tag> instTags, String catchErrorCode, String... params)
+    private void updateRemoteTags(
+            Ec2Client ec2, Collection<Tag> instTags, @NonNull String catchErrorCode, String... params)
             throws InterruptedException {
         for (int i = 0; i < 5; i++) {
             try {
@@ -2746,7 +2750,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                         .build());
                 break;
             } catch (AwsServiceException e) {
-                if (e.awsErrorDetails().errorCode().equals(catchErrorCode)) {
+                if (catchErrorCode.equals(e.awsErrorDetails().errorCode())) {
                     Thread.sleep(5000);
                     continue;
                 }


### PR DESCRIPTION
I was made aware of a controller seeing this stack trace:

```
java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because the return value of "software.amazon.awssdk.awscore.exception.AwsErrorDetails.errorCode()" is null
	at PluginClassLoader for ec2//hudson.plugins.ec2.CloudHelper.getInstanceWithRetry(CloudHelper.java:31)
	at PluginClassLoader for ec2//hudson.plugins.ec2.EC2Computer.getState(EC2Computer.java:200)
	at PluginClassLoader for ec2//hudson.plugins.ec2.EC2RetentionStrategy.start(EC2RetentionStrategy.java:293)
	at PluginClassLoader for ec2//hudson.plugins.ec2.EC2RetentionStrategy.start(EC2RetentionStrategy.java:50)
	at hudson.model.AbstractCIBase.createNewComputerForNode(AbstractCIBase.java:193)
	at hudson.model.AbstractCIBase.updateComputer(AbstractCIBase.java:154)
	at hudson.model.AbstractCIBase.lambda$updateComputerList$2(AbstractCIBase.java:256)
	at hudson.model.Queue._withLock(Queue.java:1411)
	at hudson.model.Queue.withLock(Queue.java:1285)
	at hudson.model.AbstractCIBase.updateComputerList(AbstractCIBase.java:241)
	at jenkins.model.Jenkins.updateComputerList(Jenkins.java:1606)
	at jenkins.model.Nodes$4.run(Nodes.java:369)
	at hudson.model.Queue._withLock(Queue.java:1411)
	at hudson.model.Queue.withLock(Queue.java:1285)
	at jenkins.model.Nodes.load(Nodes.java:357)
	at jenkins.model.Jenkins$13.run(Jenkins.java:3486)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:175)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:304)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1149)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:221)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:120)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

Without knowing the root cause of the problem or how to reproduce it, this PR should at least chase away the NPE by inverting the string comparison.

While I was here, I searched for all instances of `errorCode` to make sure we don't have this bug in other places. Two of them were already using the correct order of string comparison to avoid an NPE, but 5 other places weren't. I made them all consistent with each other and with the fix in this PR.

### Testing done

None; I don't know what the actual scenario is or how to reproduce this. I did run `mvn clean verify`.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
