### PR TITLE
[JENKINS-75870] Fix issue resolving instance types while checking for current spot pricing

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
+++ b/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
@@ -188,7 +188,7 @@ public final class SpotConfiguration extends AbstractDescribableImpl<SpotConfigu
                      * If the type string cannot be matched with an instance type, throw a Form error
                      */
                     InstanceType ec2Type = InstanceType.fromValue(type);
-                    if( ec2Type == null || ec2Type == InstanceType.UNKNOWN_TO_SDK_VERSION) {
+                    if (ec2Type == null || ec2Type == InstanceType.UNKNOWN_TO_SDK_VERSION) {
                         return FormValidation.error("Could not resolve instance type: " + type);
                     }
 

--- a/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
+++ b/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
@@ -185,20 +185,10 @@ public final class SpotConfiguration extends AbstractDescribableImpl<SpotConfigu
                      * This is necessary because the AWS API needs the instance type string formatted a particular way
                      * to retrieve prices and the form gives us the strings in a different format. For example "T1Micro"
                      * vs "t1.micro".
-                     */
-                    InstanceType ec2Type = null;
-
-                    for (InstanceType it : InstanceType.values()) {
-                        if (it.name().equals(type)) {
-                            ec2Type = it;
-                            break;
-                        }
-                    }
-
-                    /*
                      * If the type string cannot be matched with an instance type, throw a Form error
                      */
-                    if (ec2Type == null) {
+                    InstanceType ec2Type = InstanceType.fromValue(type);
+                    if( ec2Type == null || ec2Type == InstanceType.UNKNOWN_TO_SDK_VERSION) {
                         return FormValidation.error("Could not resolve instance type: " + type);
                     }
 

--- a/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
+++ b/src/main/java/hudson/plugins/ec2/SpotConfiguration.java
@@ -181,10 +181,6 @@ public final class SpotConfiguration extends AbstractDescribableImpl<SpotConfigu
                     }
 
                     /*
-                     * Iterate through the AWS instance types to see if can find a match for the databound String type.
-                     * This is necessary because the AWS API needs the instance type string formatted a particular way
-                     * to retrieve prices and the form gives us the strings in a different format. For example "T1Micro"
-                     * vs "t1.micro".
                      * If the type string cannot be matched with an instance type, throw a Form error
                      */
                     InstanceType ec2Type = InstanceType.fromValue(type);


### PR DESCRIPTION
Value string was comparted to enum name of SDKs InstanceType which never matches.
Fixed the issue by using AWS SDK internal method to get enumeration from string.

Relates to:  https://issues.jenkins.io/browse/JENKINS-75870.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
