### PR TITLE
[JENKINS-75910] Unable to connect to Windows SSH instance using OpenSSH version greater than 9.5.0.0

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2WindowsSSHLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2WindowsSSHLauncher.java
@@ -147,9 +147,10 @@ public class EC2WindowsSSHLauncher extends EC2SSHLauncher {
                                     "IF NOT EXIST %USERPROFILE%\\.hudson-run-init EXIT /B 999",
                                     logger)) {
                         logInfo(computer, listener, "Upload init script");
+                        String scriptPath = tmpDir + "init.bat";
                         scp.upload(
                                 initScript.getBytes(StandardCharsets.UTF_8),
-                                tmpDir + "init.bat",
+                                scriptPath.replace('\\', '/'),
                                 List.of(
                                         PosixFilePermission.OWNER_READ,
                                         PosixFilePermission.OWNER_WRITE,
@@ -157,7 +158,7 @@ public class EC2WindowsSSHLauncher extends EC2SSHLauncher {
                                 scpTimestamp);
 
                         logInfo(computer, listener, "Executing init script");
-                        String initCommand = buildUpCommand(computer, tmpDir + "init.bat");
+                        String initCommand = buildUpCommand(computer, scriptPath);
                         if (executeRemote(clientSession, initCommand, logger)) {
                             log(
                                     Level.FINE,
@@ -184,9 +185,10 @@ public class EC2WindowsSSHLauncher extends EC2SSHLauncher {
 
                     // Always copy so we get the most recent remoting.jar
                     logInfo(computer, listener, "Copying remoting.jar to: " + tmpDir);
+                    String remotingPath = tmpDir + "remoting.jar";
                     scp.upload(
                             Jenkins.get().getJnlpJars("remoting.jar").readFully(),
-                            tmpDir + "remoting.jar",
+                            remotingPath.replace('\\', '/'),
                             List.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
                             scpTimestamp);
                 }


### PR DESCRIPTION
The "scp.exe" binary included in versions of OpenSSH greater than 9.5.0.0 do not accept paths using backslashes. 

`
validateCommandStatusCode(ScpHelper[ClientSessionImpl[Administrator@/X.X.X.X:22]])[scp -p -t -- C:\Windows\Temp\init.bat] advisory ACK=1: scp: error: unexpected filename: C:\Windows\Temp\init.bat for command=C0700 16 C:\Windows\Temp\init.bat 
`

Replacing the backslashes with forward slashes fixes the issue and also works with versions 9.5.0.0 and lower

### Testing done

Tested on Jenkins controller 2.519

Tested with agents:

Windows Server 2019, OpenSSH 8.9.1.0
Windows Server 2019, OpenSSH 9.5.0.0
Windows Server 2019, OpenSSH 9.5.4.1
Windows Server 2019, OpenSSH 9.8.3.0
Windows Server 2025, OpenSSH 9.5.4.1

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
