### PR TITLE
Fix JENKINS-75199: Support Amazon Linux 2023 by detecting package man…

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -209,7 +209,10 @@ public class EC2UnixLauncher extends EC2SSHLauncher {
                             computer,
                             clientSession,
                             javaPath + " -fullversion",
-                            "sudo amazon-linux-extras install java-openjdk11 -y; sudo yum install -y fontconfig java-11-openjdk",
+                            "(command -v amazon-linux-extras >/dev/null 2>&1 && " +
+                            "sudo amazon-linux-extras install java-openjdk11 -y && " +
+                            "sudo yum install -y fontconfig java-11-openjdk) || " +
+                            "sudo dnf install -y java-11-amazon-corretto-devel fontconfig",
                             logger,
                             listener);
                     executeRemote(


### PR DESCRIPTION
Fix JENKINS-75199: Support Amazon Linux 2023 by detecting package manager

The EC2 plugin was failing to provision AL2023 instances because amazon-linux-extras command doesn't exist on AL2023. This change:

- Detects if amazon-linux-extras is available before using it
- Falls back to dnf for AL2023 which uses java-11-amazon-corretto-devel
- Maintains backward compatibility with AL2 and older AMIs
- Installs the same dependencies (Java 11 and fontconfig) on both paths

This allows the plugin to work with both Amazon Linux 2 and Amazon Linux 2023 without breaking existing functionality.

Fixes: https://issues.jenkins.io/browse/JENKINS-75199

### Testing done

Manual testing was performed to verify the fix:
- The modified command was tested on both AL2 and AL2023 instances to ensure proper package detection
- On AL2: `command -v amazon-linux-extras` returns 0, so it uses the existing installation method
- On AL2023: `command -v amazon-linux-extras` returns non-zero, triggering the dnf fallback
- Both paths successfully install Java 11 and fontconfig as required

The change uses shell command chaining with `||` operator to ensure backward compatibility - if the first command succeeds (AL2), the second is not executed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->