### PR TITLE
Discard idle instances during shutdown

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -757,7 +758,7 @@ public abstract class EC2AbstractSlave extends Slave {
     /**
      * Terminates the instance in EC2.
      */
-    public abstract void terminate();
+    public abstract Future<?> terminate();
 
     void stop() {
         try {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -202,6 +202,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     private final int minimumNumberOfSpareInstances;
 
+    private boolean terminateSpareInstances;
+
     public final boolean stopOnTerminate;
 
     private final List<EC2Tag> tags;
@@ -1703,6 +1705,15 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public int getMinimumNumberOfSpareInstances() {
         return minimumNumberOfSpareInstances;
+    }
+
+    public boolean getTerminateSpareInstances() {
+        return terminateSpareInstances;
+    }
+
+    @DataBoundSetter
+    public void setTerminateSpareInstances(boolean terminateSpareInstances) {
+        this.terminateSpareInstances = terminateSpareInstances;
     }
 
     public MinimumNumberOfInstancesTimeRangeConfig getMinimumNumberOfInstancesTimeRangeConfig() {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -186,6 +186,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public final String idleTerminationMinutes;
 
+    private boolean terminateIdleDuringShutdown;
+
     public final String iamInstanceProfile;
 
     public final boolean deleteRootOnTermination;
@@ -201,8 +203,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     private MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig;
 
     private final int minimumNumberOfSpareInstances;
-
-    private boolean terminateSpareInstances;
 
     public final boolean stopOnTerminate;
 
@@ -1676,6 +1676,15 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return idleTerminationMinutes;
     }
 
+    public boolean getTerminateIdleDuringShutdown() {
+        return terminateIdleDuringShutdown;
+    }
+
+    @DataBoundSetter
+    public void setTerminateIdleDuringShutdown(boolean terminateIdleDuringShutdown) {
+        this.terminateIdleDuringShutdown = terminateIdleDuringShutdown;
+    }
+
     public Set<LabelAtom> getLabelSet() {
         if (labelSet == null) {
             labelSet = Label.parse(labels);
@@ -1705,15 +1714,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public int getMinimumNumberOfSpareInstances() {
         return minimumNumberOfSpareInstances;
-    }
-
-    public boolean getTerminateSpareInstances() {
-        return terminateSpareInstances;
-    }
-
-    @DataBoundSetter
-    public void setTerminateSpareInstances(boolean terminateSpareInstances) {
-        this.terminateSpareInstances = terminateSpareInstances;
     }
 
     public MinimumNumberOfInstancesTimeRangeConfig getMinimumNumberOfInstancesTimeRangeConfig() {

--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -2,17 +2,24 @@ package hudson.plugins.ec2.util;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.init.Terminator;
 import hudson.model.Computer;
 import hudson.model.Label;
 import hudson.model.Queue;
+import hudson.plugins.ec2.EC2AbstractSlave;
 import hudson.plugins.ec2.EC2Cloud;
 import hudson.plugins.ec2.EC2Computer;
 import hudson.plugins.ec2.SlaveTemplate;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
@@ -21,14 +28,17 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class)
 public class MinimumInstanceChecker {
 
+    private static final Logger LOGGER = Logger.getLogger(MinimumInstanceChecker.class.getName());
+
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Needs to be overridden from tests")
     public static Clock clock = Clock.systemDefaultZone();
 
-    private static Stream<Computer> agentsForTemplate(@NonNull SlaveTemplate agentTemplate) {
+    private static Stream<EC2Computer> agentsForTemplate(@NonNull SlaveTemplate agentTemplate) {
         return Arrays.stream(Jenkins.get().getComputers())
                 .filter(EC2Computer.class::isInstance)
+                .map(EC2Computer.class::cast)
                 .filter(computer -> {
-                    SlaveTemplate computerTemplate = ((EC2Computer) computer).getSlaveTemplate();
+                    SlaveTemplate computerTemplate = computer.getSlaveTemplate();
                     return computerTemplate != null
                             && Objects.equals(computerTemplate.description, agentTemplate.description);
                 });
@@ -38,11 +48,14 @@ public class MinimumInstanceChecker {
         return (int) agentsForTemplate(agentTemplate).count();
     }
 
-    public static int countCurrentNumberOfSpareAgents(@NonNull SlaveTemplate agentTemplate) {
-        return (int) agentsForTemplate(agentTemplate)
+    private static Stream<EC2Computer> spareAgents(@NonNull SlaveTemplate agentTemplate) {
+        return agentsForTemplate(agentTemplate)
                 .filter(computer -> computer.countBusy() == 0)
-                .filter(Computer::isOnline)
-                .count();
+                .filter(Computer::isOnline);
+    }
+
+    public static int countCurrentNumberOfSpareAgents(@NonNull SlaveTemplate agentTemplate) {
+        return (int) spareAgents(agentTemplate).count();
     }
 
     public static int countCurrentNumberOfProvisioningAgents(@NonNull SlaveTemplate agentTemplate) {
@@ -141,5 +154,27 @@ public class MinimumInstanceChecker {
             }
         }
         return false;
+    }
+
+    @Terminator
+    public static void discardSpareInstances() throws Exception {
+        LOGGER.fine("Looking for spare instances to discard");
+        List<Future<?>> futures = new ArrayList<>();
+        Jenkins.get().clouds.stream()
+                .filter(EC2Cloud.class::isInstance)
+                .map(EC2Cloud.class::cast)
+                .forEach(cloud -> cloud.getTemplates().forEach(agentTemplate -> spareAgents(agentTemplate)
+                        .limit(agentTemplate.getMinimumNumberOfSpareInstances())
+                        .forEach(computer -> {
+                            EC2AbstractSlave agent = computer.getNode();
+                            if (agent != null) {
+                                LOGGER.info(() -> "discarding spare instance " + agent.getInstanceId());
+                                futures.add(agent.terminate());
+                            }
+                        })));
+        // Must wait; otherwise task could run too late during shutdown, leading to NoClassDefFoundError.
+        for (Future<?> future : futures) {
+            future.get(5, TimeUnit.SECONDS);
+        }
     }
 }

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -106,6 +106,10 @@ THE SOFTWARE.
     <f:textbox default="30" />
   </f:entry>
 
+    <f:entry title="${%Terminate idle agents during shutdown}" field="terminateIdleDuringShutdown">
+      <f:checkbox />
+    </f:entry>
+
   <f:entry title="${%Init script}" field="initScript">
     <f:textarea />
   </f:entry>
@@ -152,10 +156,6 @@ THE SOFTWARE.
 
     <f:entry title="${%Minimum number of spare instances}" field="minimumNumberOfSpareInstances">
       <f:textbox />
-    </f:entry>
-
-    <f:entry title="${%Terminate spare instances}" field="terminateSpareInstances">
-      <f:checkbox />
     </f:entry>
 
     <f:optionalBlock name="minimumNumberOfInstancesTimeRangeConfig"

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -154,6 +154,10 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
 
+    <f:entry title="${%Terminate spare instances}" field="terminateSpareInstances">
+      <f:checkbox />
+    </f:entry>
+
     <f:optionalBlock name="minimumNumberOfInstancesTimeRangeConfig"
                      title="${%Only apply minimum number of instances during specific time range}" checked="${instance.minimumNumberOfInstancesTimeRangeConfig != null}"
         help="/descriptor/hudson.plugins.ec2.SlaveTemplate/help/minimumNumberOfInstancesTimeRangeConfig" >

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-terminateIdleDuringShutdown.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-terminateIdleDuringShutdown.html
@@ -1,0 +1,5 @@
+<div>
+    Delete any idle agents and terminate their instances when the controller stops.
+    This is especially useful in conjunction with the <b>Minimum number of instances</b> or <b>Minimum number of spare instances</b> options,
+    when setting <b>Idle termination time</b> to zero.
+</div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-terminateSpareInstances.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-terminateSpareInstances.html
@@ -1,0 +1,5 @@
+<div>
+    If <b>Minimum number of spare instances</b> is configured, instances may be launched when the controller starts.
+    With this option, up to that same number of spare instances will be terminated when the controller stops,
+    according to how many idle agents are connected at the time.
+</div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-terminateSpareInstances.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-terminateSpareInstances.html
@@ -1,5 +1,0 @@
-<div>
-    If <b>Minimum number of spare instances</b> is configured, instances may be launched when the controller starts.
-    With this option, up to that same number of spare instances will be terminated when the controller stops,
-    according to how many idle agents are connected at the time.
-</div>

--- a/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2AbstractSlaveTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import hudson.model.Node;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -58,9 +60,8 @@ class EC2AbstractSlaveTest {
                         EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED) {
 
                     @Override
-                    public void terminate() {
-                        // To change body of implemented methods use File | Settings |
-                        // File Templates.
+                    public Future<?> terminate() {
+                        return CompletableFuture.completedFuture(null);
                     }
 
                     @Override
@@ -159,7 +160,9 @@ class EC2AbstractSlaveTest {
                         EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
                         EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED) {
                     @Override
-                    public void terminate() {}
+                    public Future<?> terminate() {
+                        return CompletableFuture.completedFuture(null);
+                    }
 
                     @Override
                     public String getEc2Type() {

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -251,7 +253,9 @@ class EC2RetentionStrategyTest {
                         EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
                         EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED) {
                     @Override
-                    public void terminate() {}
+                    public Future<?> terminate() {
+                        return CompletableFuture.completedFuture(null);
+                    }
 
                     @Override
                     public String getEc2Type() {
@@ -396,7 +400,9 @@ class EC2RetentionStrategyTest {
                         EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
                         EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED) {
                     @Override
-                    public void terminate() {}
+                    public Future<?> terminate() {
+                        return CompletableFuture.completedFuture(null);
+                    }
 
                     @Override
                     public String getEc2Type() {
@@ -562,8 +568,9 @@ class EC2RetentionStrategyTest {
                         EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
                         EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED) {
                     @Override
-                    public void terminate() {
+                    public Future<?> terminate() {
                         terminateCalled.set(true);
+                        return CompletableFuture.completedFuture(null);
                     }
 
                     @Override

--- a/src/test/java/hudson/plugins/ec2/MockEC2Computer.java
+++ b/src/test/java/hudson/plugins/ec2/MockEC2Computer.java
@@ -3,6 +3,8 @@ package hudson.plugins.ec2;
 import hudson.model.Node;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.ec2.model.InstanceType;
 
@@ -55,7 +57,9 @@ public class MockEC2Computer extends EC2Computer {
                         EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
                         EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED) {
                     @Override
-                    public void terminate() {}
+                    public Future<?> terminate() {
+                        return CompletableFuture.completedFuture(null);
+                    }
 
                     @Override
                     public String getEc2Type() {

--- a/src/test/java/hudson/plugins/ec2/ssh/InitScriptExecutionTest.java
+++ b/src/test/java/hudson/plugins/ec2/ssh/InitScriptExecutionTest.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import org.apache.sshd.client.SshClient;
@@ -223,7 +225,9 @@ class InitScriptExecutionTest {
                 EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
                 EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED) {
             @Override
-            public void terminate() {}
+            public Future<?> terminate() {
+                return CompletableFuture.completedFuture(null);
+            }
 
             @Override
             public String getEc2Type() {


### PR DESCRIPTION
Extracted from #1121.

While testing the spare instances feature I noticed that while the controller launches a pool of spare instances when it starts, it does not terminate them when it shuts down. If the controller is immediately restarted, this is not a big deal since they will be connected again, but it can leave a mess in a CloudBees CI HA controller where each replica has its own set of spare instances. #1115 will clean them up but it could take hours. With this patch, the spares are neatly cleaned up.

I needed to introduce a `Future` into the internal API to make sure that the termination request is processed before the web app is unloaded and class loading from plugins becomes impossible; otherwise the termination is unreliable and mostly does not work at all. This does clash a bit with #1015.
