### PR TITLE
Fail `getEC2HostAddress` for a terminated instance

### DIFF
--- a/src/test/java/hudson/plugins/ec2/ssh/InitScriptExecutionTest.java
+++ b/src/test/java/hudson/plugins/ec2/ssh/InitScriptExecutionTest.java
@@ -35,6 +35,8 @@ import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.mockito.MockedStatic;
 import software.amazon.awssdk.services.ec2.model.Instance;
+import software.amazon.awssdk.services.ec2.model.InstanceState;
+import software.amazon.awssdk.services.ec2.model.InstanceStateName;
 import software.amazon.awssdk.services.ec2.model.KeyPairInfo;
 
 @WithJenkins
@@ -248,6 +250,11 @@ class InitScriptExecutionTest {
         mockTemplate.connectionStrategy = ConnectionStrategy.PUBLIC_DNS;
         when(mockEC2Computer.updateInstanceDescription()).thenReturn(mockInstance);
         when(mockInstance.publicDnsName()).thenReturn(mockHost);
+        when(mockInstance.state())
+                .thenReturn(InstanceState.builder()
+                        .code(16)
+                        .name(InstanceStateName.RUNNING)
+                        .build());
         mockStaticScpClientCreator.when(ScpClientCreator::instance).thenReturn(mockScpClientCreator);
         when(mockScpClientCreator.createScpClient(mockClientSession)).thenReturn(mockScpClient);
         mockStaticScpClientCreator


### PR DESCRIPTION
Extracted from #1121.

While testing without #1125, as I recall (not sure exactly how to reproduce), I ran into some cases where the metadata inside the Jenkins controller was apparently out of date and there was an EC2 agent definition that corresponded to an instance which had already been terminated. This was not handled gracefully: the launch log went into a loop whereby it would claim that the hostname was not yet ready and it was going to sleep and try again in a few seconds. Clearly at this point the agent cannot be launched because the instance is gone, so it should fail early and clearly. With this patch, the agent definition gets deleted automatically.
