### PR TITLE
Simplification to `SSHCredentialHelper`

### DIFF
--- a/src/test/java/hudson/plugins/ec2/util/SSHCredentialHelper.java
+++ b/src/test/java/hudson/plugins/ec2/util/SSHCredentialHelper.java
@@ -7,10 +7,7 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 import jenkins.model.Jenkins;
 
 public class SSHCredentialHelper {
@@ -20,13 +17,7 @@ public class SSHCredentialHelper {
                 CredentialsScope.SYSTEM,
                 id,
                 "key",
-                new BasicSSHUserPrivateKey.PrivateKeySource() {
-                    @NonNull
-                    @Override
-                    public List<String> getPrivateKeys() {
-                        return Collections.singletonList(PrivateKeyHelper.generate());
-                    }
-                },
+                new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(PrivateKeyHelper.generate()),
                 "",
                 "EC2 Testing Cloud Private Key");
 


### PR DESCRIPTION
Amending #498. `PrivateKeySource` is only even an interface you can implement for historical reasons: all implementations besides `DirectEntryPrivateKeySource` are deprecated. Noticed because of a warning in test output

```
WARNING	o.j.r.u.AnonymousClassWarnings#warn: Attempt to (de-)serialize anonymous class hudson.plugins.ec2.util.SSHCredentialHelper$1 in file:/…/ec2-plugin/target/test-classes/; see: https://jenkins.io/redirect/serialization-of-anonymous-classes/
```
