### PR TITLE
[JENKINS-76021] Fix non proxy hosts support

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -87,6 +87,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
+import java.util.regex.Pattern;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.apache.commons.lang.StringUtils;
@@ -1328,6 +1329,10 @@ public class EC2Cloud extends Cloud {
             if (proxy.getUserName() != null) {
                 proxyConfiguration.username(proxy.getUserName());
                 proxyConfiguration.password(Secret.toString(proxy.getSecretPassword()));
+            }
+            List<Pattern> patterns = proxy.getNoProxyHostPatterns();
+            if (patterns != null && !patterns.isEmpty()) {
+                patterns.stream().map(Pattern::pattern).forEach(proxyConfiguration::addNonProxyHost);
             }
             builder.proxyConfiguration(proxyConfiguration.build());
         }


### PR DESCRIPTION
Since migration to AWS SDK 2 and https://github.com/jenkinsci/ec2-plugin/pull/1021, theHttpclient proxy is always configured if Jenkins proxy is defined. Regardless of the list of Non proxy Hosts. Which is a regression.

This fixes the proxy support so that the list of non proxy hosts from the Jenkins Proxy configuration are properly used.

### Testing done

* Setup a squid proxy with deny to `*.amazonaws.com`
* In Jenkins, configure Jenkins Proxy and add `*.amazonaws.com` and `169.254.169.254` to the list of non proxy hosts
* Configure EC2 Cloud
* Use the Test Connection button

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
