### PR TITLE
fix(JENKINS-76057): Fix broken "Configure" UI (slave templates failing to load)

### DIFF
--- a/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.ec2;
 
+import hudson.Extension;
 import java.util.List;
 
 /**
@@ -74,5 +75,13 @@ public class AmazonEC2Cloud extends EC2Cloud {
                 templates,
                 roleArn,
                 roleSessionName);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends EC2Cloud.DescriptorImpl {
+        @Override
+        public String getDisplayName() {
+            return "Amazon EC2 (Deprecated - use EC2 instead)";
+        }
     }
 }

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -322,6 +322,10 @@ public class EC2Cloud extends Cloud {
         return name;
     }
 
+    public String getName() {
+        return name;
+    }
+
     public String getRegion() {
         if (region == null) {
             region = DEFAULT_EC2_HOST; // Backward compatibility

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -1554,7 +1554,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
     }
 
-    String getZone() {
+    public String getZone() {
         return zone;
     }
 
@@ -1822,6 +1822,106 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.avoidUsingOrphanedNodes = avoidUsingOrphanedNodes;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getRemoteFS() {
+        return remoteFS;
+    }
+
+    public SpotConfiguration getSpotConfig() {
+        return spotConfig;
+    }
+
+    public String getSecurityGroups() {
+        return securityGroups;
+    }
+
+    public String getJavaPath() {
+        return javaPath;
+    }
+
+    public String getJvmopts() {
+        return jvmopts;
+    }
+
+    public boolean getStopOnTerminate() {
+        return stopOnTerminate;
+    }
+
+    public String getIdleTerminationMinutes() {
+        return idleTerminationMinutes;
+    }
+
+    public String getInitScript() {
+        return initScript;
+    }
+
+    public String getTmpDir() {
+        return tmpDir;
+    }
+
+    public String getUserData() {
+        return userData;
+    }
+
+    public boolean getConnectBySSHProcess() {
+        return connectBySSHProcess;
+    }
+
+    public boolean getConnectUsingPublicIp() {
+        return connectUsingPublicIp;
+    }
+
+    public boolean getDeleteRootOnTermination() {
+        return deleteRootOnTermination;
+    }
+
+    public boolean getUseEphemeralDevices() {
+        return useEphemeralDevices;
+    }
+
+    public boolean getEbsOptimized() {
+        return ebsOptimized;
+    }
+
+    public boolean getMonitoring() {
+        return monitoring;
+    }
+
+    public boolean getT2Unlimited() {
+        return t2Unlimited;
+    }
+
+    public EbsEncryptRootVolume getEbsEncryptRootVolume() {
+        return ebsEncryptRootVolume;
+    }
+
+    public String getCustomDeviceMapping() {
+        return customDeviceMapping;
+    }
+
+    public Tenancy getTenancy() {
+        return tenancy;
+    }
+
+    public ConnectionStrategy getConnectionStrategy() {
+        return connectionStrategy;
+    }
+
+    public boolean getUseDedicatedTenancy() {
+        return useDedicatedTenancy;
+    }
+
+    public int getNextSubnet() {
+        return nextSubnet;
+    }
+
     @Override
     public String toString() {
         return "SlaveTemplate{" + "description='" + description + '\'' + ", labels='" + labels + '\'' + '}';
@@ -1832,6 +1932,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     public boolean isAvoidUsingOrphanedNodes() {
+        return avoidUsingOrphanedNodes;
+    }
+
+    public boolean getAvoidUsingOrphanedNodes() {
         return avoidUsingOrphanedNodes;
     }
 


### PR DESCRIPTION
This PR resolves this ticketed bug:
https://issues.jenkins.io/browse/JENKINS-76057

### Description

The EC2 plugin's SlaveTemplate configuration UI was failing to render correctly due to missing JavaBean getter methods and descriptor registration.  Users were unable to configure or edit EC2 slave templates through the Jenkins web interface.

### Root Causes

1. Missing JavaBean Getters: Jelly templates require getFieldName() methods to bind form fields, but many were missing
2. Field Binding Failures: Specific fields like avoidUsingOrphanedNodes had no corresponding getter methods
3. Missing Descriptor Registration: Jenkins couldn't find AmazonEC2Cloud$DescriptorImpl when loading existing configurations

### Changes Made

**SlaveTemplate.java**
* Added 26 JavaBean-compliant getter methods for all public fields referenced in config.jelly:

**AmazonEC2Cloud.java**
* Added @Extension DescriptorImpl that extends EC2Cloud.DescriptorImpl
* Added proper descriptor registration to fix Jenkins configuration loading
* Clear deprecation messaging in display name

**EC2Cloud.java**
* Added getName() method for JavaBean compliance

### Technical Details

*Descriptor Pattern*: Follows the established Jenkins pattern where concrete classes need their own @Extension DescriptorImpl, even deprecated ones. The AmazonEC2Cloud.DescriptorImpl extends the parent descriptor to inherit all functionality while providing the necessary registration point for Jenkins' extension system.

*JavaBean Compliance*: All getter methods follow standard JavaBean naming conventions (getFieldName() for fields, isFieldName() or getFieldName() for booleans) to ensure proper Jelly template binding.

### Testing Done

* Updated code with fixes in this PR
* Executed `mvn clean package`
* All tests passed
* Deployed HPI artifact to Jenkins server
* Verified "Configure" UI now works as expected (see screenshots)

### Screenshots

Before the change:

<img width="3160" height="1851" alt="CleanShot 2025-09-01 at 12 50 30@2x" src="https://github.com/user-attachments/assets/b87e7916-2baa-44fa-8037-6ebea9c6cac5" />

After the change:

<img width="3160" height="1849" alt="CleanShot 2025-09-01 at 15 26 00@2x" src="https://github.com/user-attachments/assets/df2bfd3e-aabc-481f-b30b-765b3e613cd7" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
