### PR TITLE
Revert "[JENKINS-75002] Removed associatePublicIp check for building the NW interface obj"

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -2058,7 +2058,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         netBuilder.associatePublicIpAddress(getAssociatePublicIp());
         netBuilder.deviceIndex(0);
 
-        riRequestBuilder.networkInterfaces(netBuilder.build());
+        if (getAssociatePublicIp()) {
+            riRequestBuilder.networkInterfaces(netBuilder.build());
+        }
 
         HashSet<Tag> instTags = buildTags(EC2Cloud.EC2_SLAVE_TYPE_DEMAND);
         for (Tag tag : instTags) {

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -708,7 +708,7 @@ class SlaveTemplateTest {
             RunInstancesRequest actualRequest = riRequestCaptor.getValue();
             List<InstanceNetworkInterfaceSpecification> actualNets = actualRequest.networkInterfaces();
 
-            assertEquals(1, actualNets.size());
+            assertEquals(0, actualNets.size());
             String templateSubnet = Util.fixEmpty(template.getSubnetId());
             assertEquals(actualRequest.subnetId(), templateSubnet);
             if (templateSubnet != null) {
@@ -1654,35 +1654,5 @@ class SlaveTemplateTest {
 
     private HtmlForm getConfigForm(EC2Cloud ac) throws IOException, SAXException {
         return r.createWebClient().goTo(ac.getUrl() + "configure").getFormByName("config");
-    }
-
-    @Test
-    void testNetworkInterfaceAssociatePublicIpTrue() throws Exception {
-        SlaveTemplate template = mock(SlaveTemplate.class);
-        when(template.getAssociatePublicIp()).thenReturn(true);
-        InstanceNetworkInterfaceSpecification.Builder netBuilder = InstanceNetworkInterfaceSpecification.builder();
-        netBuilder.associatePublicIpAddress(true);
-        netBuilder.deviceIndex(0);
-        RunInstancesRequest.Builder riRequestBuilder = RunInstancesRequest.builder();
-        riRequestBuilder.networkInterfaces(netBuilder.build());
-        RunInstancesRequest req = riRequestBuilder.build();
-        List<InstanceNetworkInterfaceSpecification> interfaces = req.networkInterfaces();
-        assertEquals(1, interfaces.size());
-        assertTrue(interfaces.get(0).associatePublicIpAddress());
-    }
-
-    @Test
-    void testNetworkInterfaceAssociatePublicIpFalse() throws Exception {
-        SlaveTemplate template = mock(SlaveTemplate.class);
-        when(template.getAssociatePublicIp()).thenReturn(false);
-        InstanceNetworkInterfaceSpecification.Builder netBuilder = InstanceNetworkInterfaceSpecification.builder();
-        netBuilder.associatePublicIpAddress(false);
-        netBuilder.deviceIndex(0);
-        RunInstancesRequest.Builder riRequestBuilder = RunInstancesRequest.builder();
-        riRequestBuilder.networkInterfaces(netBuilder.build());
-        RunInstancesRequest req = riRequestBuilder.build();
-        List<InstanceNetworkInterfaceSpecification> interfaces = req.networkInterfaces();
-        assertEquals(1, interfaces.size());
-        assertFalse(interfaces.get(0).associatePublicIpAddress());
     }
 }


### PR DESCRIPTION
Reverts jenkinsci/ec2-plugin#1138

Reverting the changes as its causing the regression
https://issues.jenkins.io/browse/JENKINS-76068