### PR TITLE
Ban JUnit 4 imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@ THE SOFTWARE.
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <hpi.compatibleSinceVersion>1885</hpi.compatibleSinceVersion>
     <spotless.check.skip>false</spotless.check.skip>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <dependencyManagement>

--- a/src/test/java/hudson/plugins/ec2/ssh/EC2SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/ec2/ssh/EC2SSHLauncherTest.java
@@ -1,5 +1,7 @@
 package hudson.plugins.ec2.ssh;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import hudson.model.TaskListener;
 import hudson.plugins.ec2.HostKeyVerificationStrategyEnum;
 import hudson.plugins.ec2.MockEC2Computer;
@@ -7,18 +9,23 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.apache.sshd.common.config.keys.PublicKeyEntry;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class EC2SSHLauncherTest {
+@WithJenkins
+class EC2SSHLauncherTest {
 
-    @Rule
-    public JenkinsRule r = new JenkinsRule();
+    private JenkinsRule r;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        r = rule;
+    }
 
     @Test
-    public void testServerKeyVerifier() throws Exception {
+    void testServerKeyVerifier() throws Exception {
         for (String publicKeyFile : List.of(
                 "ssh_host_dss_1024.pub",
                 "ssh_host_rsa_1024.pub",
@@ -41,13 +48,13 @@ public class EC2SSHLauncherTest {
             r.jenkins.addNode(computer.getNode());
 
             computer.getSlaveTemplate().setHostKeyVerificationStrategy(HostKeyVerificationStrategyEnum.OFF);
-            Assert.assertTrue(new EC2SSHLauncher.ServerKeyVerifierImpl(computer, TaskListener.NULL)
+            assertTrue(new EC2SSHLauncher.ServerKeyVerifierImpl(computer, TaskListener.NULL)
                     .verifyServerKey(
                             null,
                             null,
                             PublicKeyEntry.parsePublicKeyEntry(sshHostKeyPath).resolvePublicKey(null, null, null)));
             computer.getSlaveTemplate().setHostKeyVerificationStrategy(HostKeyVerificationStrategyEnum.ACCEPT_NEW);
-            Assert.assertTrue(new EC2SSHLauncher.ServerKeyVerifierImpl(computer, TaskListener.NULL)
+            assertTrue(new EC2SSHLauncher.ServerKeyVerifierImpl(computer, TaskListener.NULL)
                     .verifyServerKey(
                             null,
                             null,

--- a/src/test/java/hudson/plugins/ec2/win/winrm/WinRMClientWithFIPSTest.java
+++ b/src/test/java/hudson/plugins/ec2/win/winrm/WinRMClientWithFIPSTest.java
@@ -1,7 +1,6 @@
 package hudson.plugins.ec2.win.winrm;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -71,25 +70,18 @@ class WinRMClientWithFIPSTest {
      * It should not be allowed to disable useHTTPS only when a password is used, an {@link IllegalArgumentException} is expected
      */
     @Test
-    void testSetUseHTTPSFalseWithPassword() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> new WinRMClient(new URL("https://localhost"), "username", "password", false).setUseHTTPS(false));
+    void testSetUseHTTPSFalseWithPassword() throws MalformedURLException {
+        WinRMClient winRM = new WinRMClient(new URL("https://localhost"), "username", "password", false);
+        assertThrows(IllegalArgumentException.class, () -> winRM.setUseHTTPS(false));
     }
 
     /**
      * Password leak prevention when setUseHTTPS is not called
      */
     @Test
-    void testBuildWinRMClientWithoutTLS() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            try {
-                WinRMClient winRM = new WinRMClient(new URL("https://localhost"), "username", "password", false);
-                // do not call winRM.setUseHTTPS(false); to avoid trigger the check
-                winRM.openShell();
-            } catch (WinRMConnectException e) {
-                fail("The client should not attempt to connect");
-            }
-        });
+    void testBuildWinRMClientWithoutTLS() throws MalformedURLException {
+        WinRMClient winRM = new WinRMClient(new URL("https://localhost"), "username", "password", false);
+        // do not call winRM.setUseHTTPS(false); to avoid trigger the check
+        assertThrows(IllegalArgumentException.class, winRM::openShell, "The client should not attempt to connect");
     }
 }


### PR DESCRIPTION
### Ban JUnit 4 imports

To prevent regressions when adding new tests, https://github.com/jenkinsci/plugin-pom/pull/1178 introduced a new flag that enables a Maven Enforcer rule banning `org.junit.*` imports while allowing `org.junit.jupiter.*`.

With this change, the build will fail if any `org.junit.*` imports are introduced.

### Testing done

None. Rely on `ci.jenkins.io`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed