### PR TITLE
Deprecate boolean `associatePublicIp` and add `AssociateIpStrategy` enum for IP assignment control 

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ def sshPortToConnectWith = '22'
 // store parameters
 def slaveTemplateUsEast1Parameters = [
   ami:                           'ami-AAAAAAAA',
-  associatePublicIp:             false,
+  associateIpStrategy:           AssociateIpStrategy.valueOf('PRIVATE_IP'),
   spotConfig:                    null,
   connectBySSHProcess:           false,
   connectUsingPublicIp:          false,
@@ -445,7 +445,7 @@ SlaveTemplate slaveTemplateUsEast1 = new SlaveTemplate(
   slaveTemplateUsEast1Parameters.deleteRootOnTermination,
   slaveTemplateUsEast1Parameters.useEphemeralDevices,
   slaveTemplateUsEast1Parameters.launchTimeoutStr,
-  slaveTemplateUsEast1Parameters.associatePublicIp,
+  slaveTemplateUsEast1Parameters.associateIpStrategy,
   slaveTemplateUsEast1Parameters.customDeviceMapping,
   slaveTemplateUsEast1Parameters.connectBySSHProcess,
   slaveTemplateUsEast1Parameters.monitoring,

--- a/src/main/java/hudson/plugins/ec2/AssociateIPStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/AssociateIPStrategy.java
@@ -1,0 +1,34 @@
+package hudson.plugins.ec2;
+
+/**
+ *
+ * Strategy for associating a public IPv4 address with the instance’s primary network interface at launch.
+ *
+ * {@link https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceNetworkInterfaceSpecification.html}
+ * {@link https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Subnet.html}
+ * */
+public enum AssociateIPStrategy {
+    SUBNET("Inherit from Subnet"),
+    PUBLIC_IP("Public IP"),
+    PRIVATE_IP("Private IP"),
+    DEFAULT("Default");
+
+    private final String displayText;
+
+    AssociateIPStrategy(String displayText) {
+        this.displayText = displayText;
+    }
+
+    public String getDisplayText() {
+        return this.displayText;
+    }
+
+    /**
+     * For backwards compatibility.
+     * @param associatePublicIp whether or not to use a public ip to establish a connection.
+     * @return an {@link AssociateIPStrategy} based on provided parameters that keeps {@code associatePublicIp} behavior.
+     */
+    public static AssociateIPStrategy backwardsCompatible(boolean associatePublicIp) {
+        return associatePublicIp ? PUBLIC_IP : DEFAULT;
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -217,7 +217,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public HostKeyVerificationStrategyEnum hostKeyVerificationStrategy;
 
-    public final boolean associatePublicIp;
+    public AssociateIPStrategy associateIPStrategy;
+
+    @Deprecated
+    public transient boolean associatePublicIp;
 
     protected transient EC2Cloud parent;
 
@@ -325,7 +328,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             boolean deleteRootOnTermination,
             boolean useEphemeralDevices,
             String launchTimeoutStr,
-            boolean associatePublicIp,
+            AssociateIPStrategy associateIPStrategy,
             String customDeviceMapping,
             boolean connectBySSHProcess,
             boolean monitoring,
@@ -382,7 +385,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.subnetId = subnetId;
         this.tags = tags;
         this.idleTerminationMinutes = idleTerminationMinutes;
-        this.associatePublicIp = associatePublicIp;
         this.connectionStrategy = connectionStrategy == null ? ConnectionStrategy.PRIVATE_IP : connectionStrategy;
         this.useDedicatedTenancy = tenancy == Tenancy.Dedicated;
         this.connectBySSHProcess = connectBySSHProcess;
@@ -431,7 +433,104 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.metadataHopsLimit =
                 metadataHopsLimit != null ? metadataHopsLimit : EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT;
         this.enclaveEnabled = enclaveEnabled != null ? enclaveEnabled : EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED;
+        this.associateIPStrategy = associateIPStrategy != null ? associateIPStrategy : AssociateIPStrategy.DEFAULT;
+
         readResolve(); // initialize
+    }
+
+    @Deprecated
+    public SlaveTemplate(
+            String ami,
+            String zone,
+            SpotConfiguration spotConfig,
+            String securityGroups,
+            String remoteFS,
+            String type,
+            boolean ebsOptimized,
+            String labelString,
+            Node.Mode mode,
+            String description,
+            String initScript,
+            String tmpDir,
+            String userData,
+            String numExecutors,
+            String remoteAdmin,
+            AMITypeData amiType,
+            String javaPath,
+            String jvmopts,
+            boolean stopOnTerminate,
+            String subnetId,
+            List<EC2Tag> tags,
+            String idleTerminationMinutes,
+            int minimumNumberOfInstances,
+            int minimumNumberOfSpareInstances,
+            String instanceCapStr,
+            String iamInstanceProfile,
+            boolean deleteRootOnTermination,
+            boolean useEphemeralDevices,
+            String launchTimeoutStr,
+            boolean associatePublicIp,
+            String customDeviceMapping,
+            boolean connectBySSHProcess,
+            boolean monitoring,
+            boolean t2Unlimited,
+            ConnectionStrategy connectionStrategy,
+            int maxTotalUses,
+            List<? extends NodeProperty<?>> nodeProperties,
+            HostKeyVerificationStrategyEnum hostKeyVerificationStrategy,
+            Tenancy tenancy,
+            EbsEncryptRootVolume ebsEncryptRootVolume,
+            Boolean metadataEndpointEnabled,
+            Boolean metadataTokensRequired,
+            Integer metadataHopsLimit,
+            Boolean metadataSupported,
+            Boolean enclaveEnabled) {
+        this(
+                ami,
+                zone,
+                spotConfig,
+                securityGroups,
+                remoteFS,
+                InstanceType.fromValue(type.toString()).toString(),
+                ebsOptimized,
+                labelString,
+                mode,
+                description,
+                initScript,
+                tmpDir,
+                userData,
+                numExecutors,
+                remoteAdmin,
+                amiType,
+                javaPath,
+                jvmopts,
+                stopOnTerminate,
+                subnetId,
+                tags,
+                idleTerminationMinutes,
+                minimumNumberOfInstances,
+                minimumNumberOfSpareInstances,
+                instanceCapStr,
+                iamInstanceProfile,
+                deleteRootOnTermination,
+                useEphemeralDevices,
+                launchTimeoutStr,
+                AssociateIPStrategy.backwardsCompatible(associatePublicIp),
+                customDeviceMapping,
+                connectBySSHProcess,
+                monitoring,
+                t2Unlimited,
+                connectionStrategy,
+                maxTotalUses,
+                nodeProperties,
+                hostKeyVerificationStrategy,
+                tenancy,
+                ebsEncryptRootVolume,
+                metadataEndpointEnabled,
+                metadataTokensRequired,
+                metadataHopsLimit,
+                metadataSupported,
+                enclaveEnabled);
     }
 
     @Deprecated
@@ -1640,8 +1739,13 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return currentSubnetId;
     }
 
+    @Deprecated
     public boolean getAssociatePublicIp() {
-        return associatePublicIp;
+        return AssociateIPStrategy.PUBLIC_IP == associateIPStrategy;
+    }
+
+    public AssociateIPStrategy getAssociateIPStrategy() {
+        return associateIPStrategy;
     }
 
     @Deprecated
@@ -1649,7 +1753,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public void setConnectUsingPublicIp(boolean connectUsingPublicIp) {
         this.connectUsingPublicIp = connectUsingPublicIp;
         this.connectionStrategy = ConnectionStrategy.backwardsCompatible(
-                this.usePrivateDnsName, this.connectUsingPublicIp, this.associatePublicIp);
+                this.usePrivateDnsName, this.connectUsingPublicIp, getAssociatePublicIp());
     }
 
     @Deprecated
@@ -1657,7 +1761,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public void setUsePrivateDnsName(boolean usePrivateDnsName) {
         this.usePrivateDnsName = usePrivateDnsName;
         this.connectionStrategy = ConnectionStrategy.backwardsCompatible(
-                this.usePrivateDnsName, this.connectUsingPublicIp, this.associatePublicIp);
+                this.usePrivateDnsName, this.connectUsingPublicIp, getAssociatePublicIp());
     }
 
     @Deprecated
@@ -2011,11 +2115,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         InstanceNetworkInterfaceSpecification.Builder netBuilder = InstanceNetworkInterfaceSpecification.builder();
         if (StringUtils.isNotBlank(subnetId)) {
-            if (getAssociatePublicIp()) {
-                netBuilder.subnetId(subnetId);
-            } else {
-                riRequestBuilder.subnetId(subnetId);
-            }
+            netBuilder.subnetId(subnetId);
 
             diFilters.add(Filter.builder().name("subnet-id").values(subnetId).build());
 
@@ -2026,11 +2126,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 List<String> groupIds = getEc2SecurityGroups(ec2);
 
                 if (!groupIds.isEmpty()) {
-                    if (getAssociatePublicIp()) {
-                        netBuilder.groups(groupIds);
-                    } else {
-                        riRequestBuilder.securityGroupIds(groupIds);
-                    }
+                    netBuilder.groups(groupIds);
 
                     diFilters.add(Filter.builder()
                             .name("instance.group-id")
@@ -2042,11 +2138,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             List<String> groupIds = getSecurityGroupsBy("group-name", securityGroupSet, ec2).securityGroups().stream()
                     .map(SecurityGroup::groupId)
                     .collect(Collectors.toList());
-            if (getAssociatePublicIp()) {
-                netBuilder.groups(groupIds);
-            } else {
-                riRequestBuilder.securityGroups(securityGroupSet);
-            }
+            netBuilder.groups(groupIds);
+
             if (!groupIds.isEmpty()) {
                 diFilters.add(Filter.builder()
                         .name("instance.group-id")
@@ -2055,12 +2148,20 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             }
         }
 
-        netBuilder.associatePublicIpAddress(getAssociatePublicIp());
-        netBuilder.deviceIndex(0);
-
-        if (getAssociatePublicIp()) {
-            riRequestBuilder.networkInterfaces(netBuilder.build());
+        switch (getAssociateIPStrategy()) {
+            case PUBLIC_IP:
+                netBuilder.associatePublicIpAddress(true);
+                break;
+            case PRIVATE_IP:
+                netBuilder.associatePublicIpAddress(false);
+                break;
+            case SUBNET:
+            case DEFAULT:
+                break;
         }
+
+        netBuilder.deviceIndex(0);
+        riRequestBuilder.networkInterfaces(netBuilder.build());
 
         HashSet<Tag> instTags = buildTags(EC2Cloud.EC2_SLAVE_TYPE_DEMAND);
         for (Tag tag : instTags) {
@@ -2505,7 +2606,18 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             launchSpecificationBuilder.keyName(keyPair.getKeyPairInfo().keyName());
             launchSpecificationBuilder.instanceType(type);
 
-            netBuilder.associatePublicIpAddress(getAssociatePublicIp());
+            switch (getAssociateIPStrategy()) {
+                case PUBLIC_IP:
+                    netBuilder.associatePublicIpAddress(true);
+                    break;
+                case PRIVATE_IP:
+                case DEFAULT:
+                    netBuilder.associatePublicIpAddress(false);
+                    break;
+                case SUBNET:
+                    break;
+            }
+
             netBuilder.deviceIndex(0);
             launchSpecificationBuilder.networkInterfaces(netBuilder.build());
 
@@ -2889,10 +3001,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             type = InstanceTypeCompat.of(type).toString();
         }
 
+        if (associateIPStrategy == null) {
+            associateIPStrategy = AssociateIPStrategy.backwardsCompatible(associatePublicIp);
+        }
+
         // 1.43 new parameters
         if (connectionStrategy == null) {
-            connectionStrategy =
-                    ConnectionStrategy.backwardsCompatible(usePrivateDnsName, connectUsingPublicIp, associatePublicIp);
+            connectionStrategy = ConnectionStrategy.backwardsCompatible(
+                    usePrivateDnsName, connectUsingPublicIp, AssociateIPStrategy.PUBLIC_IP == associateIPStrategy);
         }
 
         if (maxTotalUses == 0) {
@@ -3382,6 +3498,32 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                     .findFirst()
                     .map(s -> FormValidation.ok())
                     .orElse(FormValidation.error("Could not find selected connection strategy"));
+        }
+
+        @POST
+        public ListBoxModel doFillAssociateIPStrategyItems(@QueryParameter String associateIPStrategy) {
+            return Stream.of(AssociateIPStrategy.values())
+                    .map(v -> {
+                        if (v.name().equals(associateIPStrategy)) {
+                            return new ListBoxModel.Option(v.getDisplayText(), v.name(), true);
+                        } else {
+                            return new ListBoxModel.Option(v.getDisplayText(), v.name(), false);
+                        }
+                    })
+                    .collect(Collectors.toCollection(ListBoxModel::new));
+        }
+
+        @POST
+        public FormValidation doCheckAssociateIPStrategy(@QueryParameter String associateIPStrategy) {
+            return Stream.of(AssociateIPStrategy.values())
+                    .filter(v -> v.name().equals(associateIPStrategy))
+                    .findFirst()
+                    .map(s -> FormValidation.ok())
+                    .orElse(FormValidation.error("Could not find selected associate IP strategy"));
+        }
+
+        public String getDefaultAssociateIPStrategy() {
+            return AssociateIPStrategy.DEFAULT.name();
         }
 
         public String getDefaultHostKeyVerificationStrategy() {

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -205,8 +205,8 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
 
-    <f:entry title="${%Associate Public IP}" field="associatePublicIp">
-      <f:checkbox />
+    <f:entry title="${%Associate IP}" field="associateIPStrategy">
+      <f:select default="${descriptor.getDefaultAssociateIPStrategy()}"/>
     </f:entry>
 
     <f:entry title="${%Tenancy}" field="tenancy">

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-associateIPStrategy.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-associateIPStrategy.html
@@ -1,0 +1,10 @@
+<div>
+	Strategy for associating a public IPv4 address with the instance’s primary network interface at launch.
+	<ul>
+		<li><strong>Public IP</strong>: Explicitly request a public IPv4 address.</li>
+		<li><strong>Private IP</strong>: Explicitly prevent association of a public IPv4 address.</li>
+		<li><strong>Inherit from Subnet</strong>: Choose this to delegate the decision to subnet configuration. 
+ 		Inherit the subnet’s behavior, allowing the subnet’s 'MapPublicIpOnLaunch' setting to decide whether a public IPv4 address is associated.</li>
+		<li><strong>Default</strong>: Existing behavior is preserved: Spot instances use 'Private IP' (explicitly false), while on‑demand instances use 'Inherit from Subnet' (omit the field and use subnet setting).</li>
+	</ul>
+</div>

--- a/src/test/java/hudson/plugins/ec2/ConfigurationAsCodeTest.java
+++ b/src/test/java/hudson/plugins/ec2/ConfigurationAsCodeTest.java
@@ -133,6 +133,58 @@ class ConfigurationAsCodeTest {
     }
 
     @Test
+    @ConfiguredWithCode("BackwardsCompatibleAssignIPStrategyUsePublicIp.yml")
+    void testBackwardsCompatibleAssociateIPStrategy(JenkinsConfiguredWithCodeRule j) {
+        final EC2Cloud ec2Cloud = (EC2Cloud) Jenkins.get().getCloud("us-east-1");
+        assertNotNull(ec2Cloud);
+
+        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        assertEquals(1, templates.size());
+        final SlaveTemplate slaveTemplate = templates.get(0);
+        assertNull(slaveTemplate.spotConfig);
+        assertEquals(AssociateIPStrategy.PUBLIC_IP, slaveTemplate.associateIPStrategy);
+    }
+
+    @Test
+    @ConfiguredWithCode("BackwardsCompatibleAssignIPStrategyUsePublicIpSpot.yml")
+    void testBackwardsCompatibleAssociateIPStrategySpot(JenkinsConfiguredWithCodeRule j) {
+        final EC2Cloud ec2Cloud = (EC2Cloud) Jenkins.get().getCloud("us-east-1");
+        assertNotNull(ec2Cloud);
+
+        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        assertEquals(1, templates.size());
+        final SlaveTemplate slaveTemplate = templates.get(0);
+        assertNotNull(slaveTemplate.spotConfig);
+        assertEquals(AssociateIPStrategy.PUBLIC_IP, slaveTemplate.associateIPStrategy);
+    }
+
+    @Test
+    @ConfiguredWithCode("BackwardsCompatibleAssignIPStrategyUsePublicIpFalse.yml")
+    void testBackwardsCompatibleAssociateIPStrategyFalse(JenkinsConfiguredWithCodeRule j) {
+        final EC2Cloud ec2Cloud = (EC2Cloud) Jenkins.get().getCloud("us-east-1");
+        assertNotNull(ec2Cloud);
+
+        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        assertEquals(1, templates.size());
+        final SlaveTemplate slaveTemplate = templates.get(0);
+        assertNull(slaveTemplate.spotConfig);
+        assertEquals(AssociateIPStrategy.SUBNET, slaveTemplate.associateIPStrategy);
+    }
+
+    @Test
+    @ConfiguredWithCode("BackwardsCompatibleAssignIPStrategyUsePublicIpFalseSpot.yml")
+    void testBackwardsCompatibleAssociateIPStrategyFalseSpot(JenkinsConfiguredWithCodeRule j) {
+        final EC2Cloud ec2Cloud = (EC2Cloud) Jenkins.get().getCloud("us-east-1");
+        assertNotNull(ec2Cloud);
+
+        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        assertEquals(1, templates.size());
+        final SlaveTemplate slaveTemplate = templates.get(0);
+        assertNotNull(slaveTemplate.spotConfig);
+        assertEquals(AssociateIPStrategy.PRIVATE_IP, slaveTemplate.associateIPStrategy);
+    }
+
+    @Test
     @ConfiguredWithCode("UnixData.yml")
     void testConfigAsCodeExport(JenkinsConfiguredWithCodeRule j) throws Exception {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();

--- a/src/test/java/hudson/plugins/ec2/EC2CloudMigrationTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudMigrationTest.java
@@ -44,4 +44,17 @@ class EC2CloudMigrationTest {
 
         assertTrue(keyCredential.isPresent());
     }
+
+    // config.xml file contains an ec2-cloud configuration from a version using associatePublicIp boolean attribute
+    @Test
+    @LocalData
+    void testAssociatePublicIpMigration() {
+        assertEquals(1, r.jenkins.clouds.size());
+        EC2Cloud cloud = (EC2Cloud) Jenkins.get().getCloud("ec2-myEc2Cloud");
+        assertEquals(3, cloud.getTemplates().size());
+
+        assertEquals(cloud.getTemplate("PublicIpTrue").getAssociateIPStrategy(), AssociateIPStrategy.PUBLIC_IP);
+        assertEquals(cloud.getTemplate("PublicIpFalse").getAssociateIPStrategy(), AssociateIPStrategy.DEFAULT);
+        assertEquals(cloud.getTemplate("PublicIpNotPresent").getAssociateIPStrategy(), AssociateIPStrategy.DEFAULT);
+    }
 }

--- a/src/test/resources/hudson/plugins/ec2/BackwardsCompatibleAssignIPStrategyUsePublicIp.yml
+++ b/src/test/resources/hudson/plugins/ec2/BackwardsCompatibleAssignIPStrategyUsePublicIp.yml
@@ -1,0 +1,9 @@
+---
+configuration-as-code:
+jenkins:
+  clouds:
+    - amazonEC2:
+        name: "staging"
+        privateKey: "${PRIVATE_KEY}"
+        templates:
+        - associatePublicIp: true

--- a/src/test/resources/hudson/plugins/ec2/BackwardsCompatibleAssignIPStrategyUsePublicIpFalse.yml
+++ b/src/test/resources/hudson/plugins/ec2/BackwardsCompatibleAssignIPStrategyUsePublicIpFalse.yml
@@ -1,0 +1,9 @@
+---
+configuration-as-code:
+jenkins:
+  clouds:
+    - amazonEC2:
+        name: "staging"
+        privateKey: "${PRIVATE_KEY}"
+        templates:
+        - associatePublicIp: false

--- a/src/test/resources/hudson/plugins/ec2/BackwardsCompatibleAssignIPStrategyUsePublicIpFalseSpot.yml
+++ b/src/test/resources/hudson/plugins/ec2/BackwardsCompatibleAssignIPStrategyUsePublicIpFalseSpot.yml
@@ -1,0 +1,11 @@
+---
+configuration-as-code:
+jenkins:
+  clouds:
+    - amazonEC2:
+        name: "staging"
+        privateKey: "${PRIVATE_KEY}"
+        templates:
+        - associatePublicIp: false
+          spotConfig:
+            useBidPrice: true

--- a/src/test/resources/hudson/plugins/ec2/BackwardsCompatibleAssignIPStrategyUsePublicIpSpot.yml
+++ b/src/test/resources/hudson/plugins/ec2/BackwardsCompatibleAssignIPStrategyUsePublicIpSpot.yml
@@ -1,0 +1,11 @@
+---
+configuration-as-code:
+jenkins:
+  clouds:
+    - amazonEC2:
+        name: "staging"
+        privateKey: "${PRIVATE_KEY}"
+        templates:
+        - associatePublicIp: true
+          spotConfig:
+            useBidPrice: true

--- a/src/test/resources/hudson/plugins/ec2/EC2CloudMigrationTest/testAssociatePublicIpMigration/config.xml
+++ b/src/test/resources/hudson/plugins/ec2/EC2CloudMigrationTest/testAssociatePublicIpMigration/config.xml
@@ -1,0 +1,22 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson>
+	<numExecutors>4</numExecutors>
+	<clouds>
+		<hudson.plugins.ec2.EC2Cloud>
+			<name>ec2-myEc2Cloud</name>
+			<templates>
+				<hudson.plugins.ec2.SlaveTemplate>
+					<description>PublicIpTrue</description>
+					<associatePublicIp>true</associatePublicIp>
+				</hudson.plugins.ec2.SlaveTemplate>
+				<hudson.plugins.ec2.SlaveTemplate>
+					<description>PublicIpFalse</description>
+					<associatePublicIp>false</associatePublicIp>
+				</hudson.plugins.ec2.SlaveTemplate>
+				<hudson.plugins.ec2.SlaveTemplate>
+					<description>PublicIpNotPresent</description>
+				</hudson.plugins.ec2.SlaveTemplate>
+			</templates>
+		</hudson.plugins.ec2.EC2Cloud>
+	</clouds>
+</hudson>

--- a/src/test/resources/hudson/plugins/ec2/MacDataExport.yml
+++ b/src/test/resources/hudson/plugins/ec2/MacDataExport.yml
@@ -11,7 +11,7 @@
           slaveCommandPrefix: "sudo -u jenkins"
           slaveCommandSuffix: "-fakeFlag"
           sshPort: "22"
-      associatePublicIp: false
+      associateIPStrategy: DEFAULT
       connectBySSHProcess: false
       connectionStrategy: PRIVATE_IP
       deleteRootOnTermination: false

--- a/src/test/resources/hudson/plugins/ec2/UnixDataExport-withAltEndpointAndJavaPath.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixDataExport-withAltEndpointAndJavaPath.yml
@@ -11,7 +11,7 @@
           slaveCommandPrefix: "sudo -u jenkins"
           slaveCommandSuffix: "-fakeFlag"
           sshPort: "22"
-      associatePublicIp: false
+      associateIPStrategy: DEFAULT
       connectBySSHProcess: false
       connectionStrategy: PRIVATE_IP
       deleteRootOnTermination: false

--- a/src/test/resources/hudson/plugins/ec2/UnixDataExport.yml
+++ b/src/test/resources/hudson/plugins/ec2/UnixDataExport.yml
@@ -11,7 +11,7 @@
           slaveCommandPrefix: "sudo -u jenkins"
           slaveCommandSuffix: "-fakeFlag"
           sshPort: "22"
-      associatePublicIp: false
+      associateIPStrategy: DEFAULT
       connectBySSHProcess: false
       connectionStrategy: PRIVATE_IP
       deleteRootOnTermination: false

--- a/src/test/resources/hudson/plugins/ec2/WindowsSSHDataExport-withAltEndpointAndJavaPath.yml
+++ b/src/test/resources/hudson/plugins/ec2/WindowsSSHDataExport-withAltEndpointAndJavaPath.yml
@@ -11,7 +11,7 @@
           slaveCommandPrefix: "CMD /C"
           slaveCommandSuffix: "-fakeFlag"
           sshPort: "22"
-      associatePublicIp: false
+      associateIPStrategy: DEFAULT
       connectBySSHProcess: false
       connectionStrategy: PRIVATE_IP
       deleteRootOnTermination: false

--- a/src/test/resources/hudson/plugins/ec2/WindowsSSHDataExport.yml
+++ b/src/test/resources/hudson/plugins/ec2/WindowsSSHDataExport.yml
@@ -11,7 +11,7 @@
           slaveCommandPrefix: "CMD /C"
           slaveCommandSuffix: "-fakeFlag"
           sshPort: "22"
-      associatePublicIp: false
+      associateIPStrategy: DEFAULT
       connectBySSHProcess: false
       connectionStrategy: PRIVATE_IP
       deleteRootOnTermination: false


### PR DESCRIPTION
[JENKINS-75002 - Allow blocking EC2 public IP](https://issues.jenkins.io/browse/JENKINS-75002)

Currently, public IP assignment behavior is inconsistent:

- `associatePublicIp=true`:
  - Creates a `NetworkInterface`
  - Sets `associatePublicIpAddress(true)`
  - Configures subnet and security groups on the interface

- `associatePublicIp=false`:
  - **On-demand**:
    - Does *not* use a `NetworkInterface`
    - Configures subnet/security groups at the RunInstance level
    - Public IP assignment depends on the subnet's `MapPublicIpOnLaunch` setting (inherited)
  - **Spot**:
    - Uses a `NetworkInterface`
    - Sets `associatePublicIpAddress(false)`, enforcing *no* public IP (does *not* inherit)

This prevents reliable enforcement of "no public IP" via AWS Service Control Policies. The current logic follows [PR 447](https://github.com/jenkinsci/ec2-plugin/pull/447), which reverted [JENKINS-58578](https://issues.jenkins.io/browse/JENKINS-58578), losing the ability of `associatePublicIp=false` to always disable public IP assignment.


### Proposal

- **Always create** the primary `NetworkInterface`.
- Replace the boolean `associatePublicIp` with the `AssociateIpStrategy` enum:
    - `PUBLIC_IP`: Always assign a public IP (`associatePublicIpAddress=true`)
    - `PRIVATE_IP`: Never assign a public IP (`associatePublicIpAddress=false`)
    - `SUBNET`: Inherit the subnet's `MapPublicIpOnLaunch` (leave unset)
    - `DEFAULT`: Matches current behavior: `PRIVATE_IP` for spot, `SUBNET` for on-demand

:speaking_head:  The `DEFAULT` option aims to easy backward compatibility and is used as the UI default.

<!-- Please describe your pull request here. -->

### Testing done

* :construction:  work in progress
* 
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
