### PR TITLE
Ignore Spotless reformatting for blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# https://github.com/jenkinsci/ec2-plugin/pull/1011 Spotless
+98fc9a96b65375210d2dd3f9285d924d91582f3f


### PR DESCRIPTION
Forgotten after https://github.com/jenkinsci/ec2-plugin/pull/1011 (which conventionally should have been squash-merged BTW, though I guess it does not matter much).