### PR TITLE
Ludicrous Mode: Lightweight queuing of work

### DIFF
--- a/src/main/java/hudson/plugins/ec2/CloudHelper.java
+++ b/src/main/java/hudson/plugins/ec2/CloudHelper.java
@@ -3,7 +3,9 @@ package hudson.plugins.ec2;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 import org.apache.commons.lang.StringUtils;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -76,6 +78,29 @@ final class CloudHelper {
             throw SdkException.builder().message(message).build();
         }
         return instances.get(0);
+    }
+
+    /**
+     * Fetches multiple instances in a single EC2 API call. More efficient than N single-instance calls.
+     * Instance IDs not found (e.g. terminated) are omitted from the result.
+     */
+    static Map<String, Instance> getInstancesBatch(List<String> instanceIds, EC2Cloud cloud) throws SdkException {
+        if (instanceIds == null || instanceIds.isEmpty() || cloud == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, Instance> result = new HashMap<>();
+        final int chunkSize = 100;
+        for (int i = 0; i < instanceIds.size(); i += chunkSize) {
+            List<String> chunk = instanceIds.subList(i, Math.min(i + chunkSize, instanceIds.size()));
+            DescribeInstancesRequest request =
+                    DescribeInstancesRequest.builder().instanceIds(chunk).build();
+            for (Reservation r : cloud.connect().describeInstances(request).reservations()) {
+                for (Instance inst : r.instances()) {
+                    result.put(inst.instanceId(), inst);
+                }
+            }
+        }
+        return result;
     }
 
     @CheckForNull

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -951,6 +951,17 @@ public abstract class EC2AbstractSlave extends Slave {
             return;
         }
 
+        updateFromFetchedInstance(i);
+    }
+
+    /**
+     * Updates instance data from a pre-fetched Instance. Used by batch operations (e.g. EC2SlaveMonitor)
+     * to avoid per-node EC2 API calls.
+     */
+    protected void updateFromFetchedInstance(Instance i) {
+        long now = System.currentTimeMillis();
+        lastFetchTime = now;
+        lastFetchInstance = i;
         publicDNS = i.publicDnsName();
         privateDNS = i.privateIpAddress();
         createdTime = i.launchTime();

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -171,30 +171,32 @@ public class EC2Cloud extends Cloud {
     private transient ReentrantLock slaveCountingLock = new ReentrantLock();
 
     /** TTL for instance count cache (ms). Avoids repeated EC2 API calls during provisioning. */
-    private static final long INSTANCE_COUNT_CACHE_TTL_MS =
-            Long.getLong("jenkins.ec2.instanceCountCacheTtlMs", 30_000);
+    private static final long INSTANCE_COUNT_CACHE_TTL_MS = Long.getLong("jenkins.ec2.instanceCountCacheTtlMs", 30_000);
 
     private volatile long instanceCountCacheTimestamp;
     private volatile int cachedTotalSlaves = -1;
     private final ConcurrentHashMap<String, Integer> cachedTemplateSlaves = new ConcurrentHashMap<>();
 
-    private static final ExecutorService PROVISIONING_EXECUTOR =
-            Executors.newCachedThreadPool(r -> {
-                Thread t = new Thread(r, "EC2Cloud-provisioning");
-                t.setDaemon(true);
-                return t;
-            });
+    private static final ExecutorService PROVISIONING_EXECUTOR = Executors.newCachedThreadPool(r -> {
+        Thread t = new Thread(r, "EC2Cloud-provisioning");
+        t.setDaemon(true);
+        return t;
+    });
 
     private static final long SCHEDULE_MAINTENANCE_DELAY_MS =
             Long.getLong("jenkins.ec2.scheduleMaintenanceDelayMs", 1000);
 
     static void scheduleQueueMaintenance() {
-        Timer.get().schedule(() -> {
-            Jenkins j = Jenkins.getInstanceOrNull();
-            if (j != null) {
-                j.getQueue().scheduleMaintenance();
-            }
-        }, SCHEDULE_MAINTENANCE_DELAY_MS, TimeUnit.MILLISECONDS);
+        Timer.get()
+                .schedule(
+                        () -> {
+                            Jenkins j = Jenkins.getInstanceOrNull();
+                            if (j != null) {
+                                j.getQueue().scheduleMaintenance();
+                            }
+                        },
+                        SCHEDULE_MAINTENANCE_DELAY_MS,
+                        TimeUnit.MILLISECONDS);
     }
 
     private final boolean useInstanceProfileForCredentials;
@@ -1103,26 +1105,29 @@ public class EC2Cloud extends Cloud {
             final int number = Math.max(excessWorkload / t.getNumExecutors(), 1);
 
             // Defer runInstances to background; return PlannedNodes immediately for fast NodeProvisioner response
-            CompletableFuture<List<EC2AbstractSlave>> provisionFuture = CompletableFuture.supplyAsync(() -> {
-                try {
-                    return getNewOrExistingAvailableSlave(t, number, false);
-                } catch (AwsServiceException e) {
-                    LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
-                    if ("RequestExpired".equals(e.awsErrorDetails().errorCode())
-                            || "ExpiredToken".equals(e.awsErrorDetails().errorCode())) {
-                        LOGGER.log(Level.INFO, "Reconnecting to EC2 due to RequestExpired or ExpiredToken error");
+            CompletableFuture<List<EC2AbstractSlave>> provisionFuture = CompletableFuture.supplyAsync(
+                    () -> {
                         try {
-                            reconnectToEc2();
-                        } catch (IOException e2) {
-                            LOGGER.log(Level.WARNING, "Failed to reconnect ec2", e2);
+                            return getNewOrExistingAvailableSlave(t, number, false);
+                        } catch (AwsServiceException e) {
+                            LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
+                            if ("RequestExpired".equals(e.awsErrorDetails().errorCode())
+                                    || "ExpiredToken".equals(e.awsErrorDetails().errorCode())) {
+                                LOGGER.log(
+                                        Level.INFO, "Reconnecting to EC2 due to RequestExpired or ExpiredToken error");
+                                try {
+                                    reconnectToEc2();
+                                } catch (IOException e2) {
+                                    LOGGER.log(Level.WARNING, "Failed to reconnect ec2", e2);
+                                }
+                            }
+                            return null;
+                        } catch (SdkException | IOException e) {
+                            LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
+                            return null;
                         }
-                    }
-                    return null;
-                } catch (SdkException | IOException e) {
-                    LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
-                    return null;
-                }
-            }, PROVISIONING_EXECUTOR);
+                    },
+                    PROVISIONING_EXECUTOR);
 
             provisionFuture.whenComplete((slaves, ex) -> {
                 if (slaves != null && !slaves.isEmpty()) {
@@ -1134,19 +1139,21 @@ public class EC2Cloud extends Cloud {
             for (int i = 0; i < number; i++) {
                 final int index = i;
                 CompletableFuture<Node> nodeFuture = provisionFuture
-                        .thenApplyAsync(slaves -> slaves != null && index < slaves.size() ? slaves.get(index) : null,
+                        .thenApplyAsync(
+                                slaves -> slaves != null && index < slaves.size() ? slaves.get(index) : null,
                                 PROVISIONING_EXECUTOR)
-                        .thenComposeAsync(slave -> slave != null
-                                ? waitForRunningAndConnectAsync(t, slave)
-                                : CompletableFuture.completedFuture(null),
+                        .thenComposeAsync(
+                                slave -> slave != null
+                                        ? waitForRunningAndConnectAsync(t, slave)
+                                        : CompletableFuture.completedFuture(null),
                                 Computer.threadPoolForRemoting);
 
                 plannedNodes.add(new PlannedNode(t.getDisplayName(), nodeFuture, t.getNumExecutors()));
             }
 
-            LOGGER.log(Level.INFO, "{0}. Provision scheduled for {1} nodes, returning immediately", new Object[] {
-                t, number
-            });
+            LOGGER.log(
+                    Level.INFO, "{0}. Provision scheduled for {1} nodes, returning immediately", new Object[] {t, number
+                    });
             LOGGER.log(Level.INFO, "We have now {0} computers, waiting for {1} more", new Object[] {
                 jenkinsInstance.getComputers().length, plannedNodes.size()
             });
@@ -1159,82 +1166,83 @@ public class EC2Cloud extends Cloud {
      * Waits for the instance to reach RUNNING, adds the node to Jenkins, connects, then returns it.
      * Runs on Computer.threadPoolForRemoting to avoid blocking the provisioning executor.
      */
-    private CompletableFuture<Node> waitForRunningAndConnectAsync(
-            final SlaveTemplate t, final EC2AbstractSlave slave) {
-        return CompletableFuture.supplyAsync(() -> {
-            int retryCount = 0;
-            final int describeLimit = 2;
-            while (true) {
-                String instanceId = slave.getInstanceId();
-                if (slave instanceof EC2SpotSlave) {
-                    if (((EC2SpotSlave) slave).isSpotRequestDead()) {
-                        LOGGER.log(
-                                Level.WARNING,
-                                "{0} Spot request died, can't do anything. Terminate provisioning",
-                                t);
-                        return null;
-                    }
-                    if (StringUtils.isEmpty(instanceId)) {
+    private CompletableFuture<Node> waitForRunningAndConnectAsync(final SlaveTemplate t, final EC2AbstractSlave slave) {
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    int retryCount = 0;
+                    final int describeLimit = 2;
+                    while (true) {
+                        String instanceId = slave.getInstanceId();
+                        if (slave instanceof EC2SpotSlave) {
+                            if (((EC2SpotSlave) slave).isSpotRequestDead()) {
+                                LOGGER.log(
+                                        Level.WARNING,
+                                        "{0} Spot request died, can't do anything. Terminate provisioning",
+                                        t);
+                                return null;
+                            }
+                            if (StringUtils.isEmpty(instanceId)) {
+                                try {
+                                    Thread.sleep(5000);
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                    return null;
+                                }
+                                continue;
+                            }
+                        }
+
                         try {
+                            Instance instance = CloudHelper.getInstanceWithRetry(instanceId, slave.getCloud());
+                            if (instance == null) {
+                                LOGGER.log(
+                                        Level.WARNING,
+                                        "{0} Can't find instance with instance id `{1}` in cloud {2}. Terminate provisioning ",
+                                        new Object[] {t, instanceId, slave.cloudName});
+                                return null;
+                            }
+
+                            InstanceStateName state = instance.state().name();
+                            if (state.equals(InstanceStateName.RUNNING)) {
+                                Computer c = slave.toComputer();
+                                if (c != null) {
+                                    c.connect(false);
+                                }
+                                long secondsSinceStart = Instant.now().until(instance.launchTime(), ChronoUnit.SECONDS);
+                                LOGGER.log(
+                                        Level.INFO,
+                                        "{0} Node {1} moved to RUNNING state in {2} seconds and is ready to be connected by Jenkins",
+                                        new Object[] {t, slave.getNodeName(), secondsSinceStart});
+                                scheduleQueueMaintenance();
+                                return slave;
+                            }
+
+                            if (!state.equals(InstanceStateName.PENDING)) {
+                                if (retryCount >= describeLimit) {
+                                    LOGGER.log(
+                                            Level.WARNING,
+                                            "Instance {0} did not move to running after {1} attempts, terminating provisioning",
+                                            new Object[] {instanceId, retryCount});
+                                    return null;
+                                }
+                                LOGGER.log(
+                                        Level.INFO,
+                                        "Attempt {0}: {1}. Node {2} is neither pending, neither running, it''s {3}. Will try again after 5s",
+                                        new Object[] {retryCount, t, slave.getNodeName(), state});
+                                retryCount++;
+                            }
+
                             Thread.sleep(5000);
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
                             return null;
-                        }
-                        continue;
-                    }
-                }
-
-                try {
-                    Instance instance = CloudHelper.getInstanceWithRetry(instanceId, slave.getCloud());
-                    if (instance == null) {
-                        LOGGER.log(
-                                Level.WARNING,
-                                "{0} Can't find instance with instance id `{1}` in cloud {2}. Terminate provisioning ",
-                                new Object[] {t, instanceId, slave.cloudName});
-                        return null;
-                    }
-
-                    InstanceStateName state = instance.state().name();
-                    if (state.equals(InstanceStateName.RUNNING)) {
-                        Computer c = slave.toComputer();
-                        if (c != null) {
-                            c.connect(false);
-                        }
-                        long secondsSinceStart = Instant.now().until(instance.launchTime(), ChronoUnit.SECONDS);
-                        LOGGER.log(
-                                Level.INFO,
-                                "{0} Node {1} moved to RUNNING state in {2} seconds and is ready to be connected by Jenkins",
-                                new Object[] {t, slave.getNodeName(), secondsSinceStart});
-                        scheduleQueueMaintenance();
-                        return slave;
-                    }
-
-                    if (!state.equals(InstanceStateName.PENDING)) {
-                        if (retryCount >= describeLimit) {
-                            LOGGER.log(
-                                    Level.WARNING,
-                                    "Instance {0} did not move to running after {1} attempts, terminating provisioning",
-                                    new Object[] {instanceId, retryCount});
+                        } catch (SdkException e) {
+                            LOGGER.log(Level.WARNING, t + ". Exception waiting for instance", e);
                             return null;
                         }
-                        LOGGER.log(
-                                Level.INFO,
-                                "Attempt {0}: {1}. Node {2} is neither pending, neither running, it''s {3}. Will try again after 5s",
-                                new Object[] {retryCount, t, slave.getNodeName(), state});
-                        retryCount++;
                     }
-
-                    Thread.sleep(5000);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    return null;
-                } catch (SdkException e) {
-                    LOGGER.log(Level.WARNING, t + ". Exception waiting for instance", e);
-                    return null;
-                }
-            }
-        }, Computer.threadPoolForRemoting);
+                },
+                Computer.threadPoolForRemoting);
     }
 
     private static void attachSlavesToJenkins(Jenkins jenkins, List<EC2AbstractSlave> slaves, SlaveTemplate t)

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -80,7 +80,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
@@ -90,6 +93,7 @@ import java.util.logging.SimpleFormatter;
 import java.util.regex.Pattern;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
+import jenkins.util.Timer;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -165,6 +169,33 @@ public class EC2Cloud extends Cloud {
     public static final String SSH_PRIVATE_KEY_FILEPATH = EC2Cloud.class.getName() + ".sshPrivateKeyFilePath";
 
     private transient ReentrantLock slaveCountingLock = new ReentrantLock();
+
+    /** TTL for instance count cache (ms). Avoids repeated EC2 API calls during provisioning. */
+    private static final long INSTANCE_COUNT_CACHE_TTL_MS =
+            Long.getLong("jenkins.ec2.instanceCountCacheTtlMs", 30_000);
+
+    private volatile long instanceCountCacheTimestamp;
+    private volatile int cachedTotalSlaves = -1;
+    private final ConcurrentHashMap<String, Integer> cachedTemplateSlaves = new ConcurrentHashMap<>();
+
+    private static final ExecutorService PROVISIONING_EXECUTOR =
+            Executors.newCachedThreadPool(r -> {
+                Thread t = new Thread(r, "EC2Cloud-provisioning");
+                t.setDaemon(true);
+                return t;
+            });
+
+    private static final long SCHEDULE_MAINTENANCE_DELAY_MS =
+            Long.getLong("jenkins.ec2.scheduleMaintenanceDelayMs", 1000);
+
+    static void scheduleQueueMaintenance() {
+        Timer.get().schedule(() -> {
+            Jenkins j = Jenkins.getInstanceOrNull();
+            if (j != null) {
+                j.getQueue().scheduleMaintenance();
+            }
+        }, SCHEDULE_MAINTENANCE_DELAY_MS, TimeUnit.MILLISECONDS);
+    }
 
     private final boolean useInstanceProfileForCredentials;
 
@@ -695,7 +726,13 @@ public class EC2Cloud extends Cloud {
             // Reconnect a stopped instance, the ADD is invoking the connect only for the node creation
             Computer c = nodes.get(0).toComputer();
             if (nodes.get(0).getStopOnTerminate() && c != null) {
-                c.connect(false);
+                PROVISIONING_EXECUTOR.execute(() -> {
+                    try {
+                        c.connect(false);
+                    } catch (Exception e) {
+                        LOGGER.log(Level.FINE, "Error connecting " + c.getName(), e);
+                    }
+                });
             }
             jenkinsInstance.addNode(nodes.get(0));
 
@@ -968,10 +1005,28 @@ public class EC2Cloud extends Cloud {
 
     /**
      * Returns the maximum number of possible agents that can be created.
+     * Uses cached instance counts when fresh (within TTL) to avoid repeated EC2 API calls.
      */
     private int getPossibleNewSlavesCount(SlaveTemplate template) throws SdkException {
+        long now = System.currentTimeMillis();
+        String templateKey = Objects.toString(template.description, "") + ":" + template.getAmi();
+
+        if (now - instanceCountCacheTimestamp < INSTANCE_COUNT_CACHE_TTL_MS) {
+            int total = cachedTotalSlaves;
+            Integer templateCount = cachedTemplateSlaves.get(templateKey);
+            if (total >= 0 && templateCount != null && templateCount >= 0) {
+                int availableTotalSlaves = instanceCap - total;
+                int availableAmiSlaves = template.getInstanceCap() - templateCount;
+                return Math.min(availableAmiSlaves, availableTotalSlaves);
+            }
+        }
+
         int estimatedTotalSlaves = countCurrentEC2Slaves(null);
         int estimatedAmiSlaves = countCurrentEC2Slaves(template);
+
+        instanceCountCacheTimestamp = now;
+        cachedTotalSlaves = estimatedTotalSlaves;
+        cachedTemplateSlaves.put(templateKey, estimatedAmiSlaves);
 
         int availableTotalSlaves = instanceCap - estimatedTotalSlaves;
         int availableAmiSlaves = template.getInstanceCap() - estimatedAmiSlaves;
@@ -981,6 +1036,12 @@ public class EC2Cloud extends Cloud {
                         + " AMI: " + template.getAmi() + " TemplateDesc: " + template.description);
 
         return Math.min(availableAmiSlaves, availableTotalSlaves);
+    }
+
+    private void invalidateInstanceCountCache() {
+        instanceCountCacheTimestamp = 0;
+        cachedTotalSlaves = -1;
+        cachedTemplateSlaves.clear();
     }
 
     /**
@@ -1034,54 +1095,146 @@ public class EC2Cloud extends Cloud {
             return Collections.emptyList();
         }
 
-        for (SlaveTemplate t : matchingTemplates) {
-            try {
-                LOGGER.log(
-                        Level.INFO,
-                        "{0}. Attempting to provision agent needed by excess workload of " + excessWorkload + " units",
-                        t);
-                int number = Math.max(excessWorkload / t.getNumExecutors(), 1);
-                final List<EC2AbstractSlave> slaves = getNewOrExistingAvailableSlave(t, number, false);
+        for (final SlaveTemplate t : matchingTemplates) {
+            LOGGER.log(
+                    Level.INFO,
+                    "{0}. Attempting to provision agent needed by excess workload of " + excessWorkload + " units",
+                    t);
+            final int number = Math.max(excessWorkload / t.getNumExecutors(), 1);
 
-                if (slaves == null || slaves.isEmpty()) {
-                    LOGGER.warning("Can't raise nodes for " + t);
-                    continue;
+            // Defer runInstances to background; return PlannedNodes immediately for fast NodeProvisioner response
+            CompletableFuture<List<EC2AbstractSlave>> provisionFuture = CompletableFuture.supplyAsync(() -> {
+                try {
+                    return getNewOrExistingAvailableSlave(t, number, false);
+                } catch (AwsServiceException e) {
+                    LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
+                    if ("RequestExpired".equals(e.awsErrorDetails().errorCode())
+                            || "ExpiredToken".equals(e.awsErrorDetails().errorCode())) {
+                        LOGGER.log(Level.INFO, "Reconnecting to EC2 due to RequestExpired or ExpiredToken error");
+                        try {
+                            reconnectToEc2();
+                        } catch (IOException e2) {
+                            LOGGER.log(Level.WARNING, "Failed to reconnect ec2", e2);
+                        }
+                    }
+                    return null;
+                } catch (SdkException | IOException e) {
+                    LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
+                    return null;
                 }
+            }, PROVISIONING_EXECUTOR);
 
-                for (final EC2AbstractSlave slave : slaves) {
-                    if (slave == null) {
-                        LOGGER.warning("Can't raise node for " + t);
+            provisionFuture.whenComplete((slaves, ex) -> {
+                if (slaves != null && !slaves.isEmpty()) {
+                    invalidateInstanceCountCache();
+                }
+                scheduleQueueMaintenance();
+            });
+
+            for (int i = 0; i < number; i++) {
+                final int index = i;
+                CompletableFuture<Node> nodeFuture = provisionFuture
+                        .thenApplyAsync(slaves -> slaves != null && index < slaves.size() ? slaves.get(index) : null,
+                                PROVISIONING_EXECUTOR)
+                        .thenComposeAsync(slave -> slave != null
+                                ? waitForRunningAndConnectAsync(t, slave)
+                                : CompletableFuture.completedFuture(null),
+                                Computer.threadPoolForRemoting);
+
+                plannedNodes.add(new PlannedNode(t.getDisplayName(), nodeFuture, t.getNumExecutors()));
+            }
+
+            LOGGER.log(Level.INFO, "{0}. Provision scheduled for {1} nodes, returning immediately", new Object[] {
+                t, number
+            });
+            LOGGER.log(Level.INFO, "We have now {0} computers, waiting for {1} more", new Object[] {
+                jenkinsInstance.getComputers().length, plannedNodes.size()
+            });
+            return plannedNodes;
+        }
+        return plannedNodes;
+    }
+
+    /**
+     * Waits for the instance to reach RUNNING, adds the node to Jenkins, connects, then returns it.
+     * Runs on Computer.threadPoolForRemoting to avoid blocking the provisioning executor.
+     */
+    private CompletableFuture<Node> waitForRunningAndConnectAsync(
+            final SlaveTemplate t, final EC2AbstractSlave slave) {
+        return CompletableFuture.supplyAsync(() -> {
+            int retryCount = 0;
+            final int describeLimit = 2;
+            while (true) {
+                String instanceId = slave.getInstanceId();
+                if (slave instanceof EC2SpotSlave) {
+                    if (((EC2SpotSlave) slave).isSpotRequestDead()) {
+                        LOGGER.log(
+                                Level.WARNING,
+                                "{0} Spot request died, can't do anything. Terminate provisioning",
+                                t);
+                        return null;
+                    }
+                    if (StringUtils.isEmpty(instanceId)) {
+                        try {
+                            Thread.sleep(5000);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            return null;
+                        }
                         continue;
                     }
-
-                    plannedNodes.add(createPlannedNode(t, slave));
-                    excessWorkload -= t.getNumExecutors();
                 }
 
-                LOGGER.log(Level.INFO, "{0}. Attempting provision finished, excess workload: " + excessWorkload, t);
-                if (excessWorkload == 0) {
-                    break;
-                }
-            } catch (AwsServiceException e) {
-                LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
-                if ("RequestExpired".equals(e.awsErrorDetails().errorCode())
-                        || "ExpiredToken".equals(e.awsErrorDetails().errorCode())) {
-                    // A RequestExpired or ExpiredToken error can indicate that credentials have expired so reconnect
-                    LOGGER.log(Level.INFO, "Reconnecting to EC2 due to RequestExpired or ExpiredToken error");
-                    try {
-                        reconnectToEc2();
-                    } catch (IOException e2) {
-                        LOGGER.log(Level.WARNING, "Failed to reconnect ec2", e2);
+                try {
+                    Instance instance = CloudHelper.getInstanceWithRetry(instanceId, slave.getCloud());
+                    if (instance == null) {
+                        LOGGER.log(
+                                Level.WARNING,
+                                "{0} Can't find instance with instance id `{1}` in cloud {2}. Terminate provisioning ",
+                                new Object[] {t, instanceId, slave.cloudName});
+                        return null;
                     }
+
+                    InstanceStateName state = instance.state().name();
+                    if (state.equals(InstanceStateName.RUNNING)) {
+                        Computer c = slave.toComputer();
+                        if (c != null) {
+                            c.connect(false);
+                        }
+                        long secondsSinceStart = Instant.now().until(instance.launchTime(), ChronoUnit.SECONDS);
+                        LOGGER.log(
+                                Level.INFO,
+                                "{0} Node {1} moved to RUNNING state in {2} seconds and is ready to be connected by Jenkins",
+                                new Object[] {t, slave.getNodeName(), secondsSinceStart});
+                        scheduleQueueMaintenance();
+                        return slave;
+                    }
+
+                    if (!state.equals(InstanceStateName.PENDING)) {
+                        if (retryCount >= describeLimit) {
+                            LOGGER.log(
+                                    Level.WARNING,
+                                    "Instance {0} did not move to running after {1} attempts, terminating provisioning",
+                                    new Object[] {instanceId, retryCount});
+                            return null;
+                        }
+                        LOGGER.log(
+                                Level.INFO,
+                                "Attempt {0}: {1}. Node {2} is neither pending, neither running, it''s {3}. Will try again after 5s",
+                                new Object[] {retryCount, t, slave.getNodeName(), state});
+                        retryCount++;
+                    }
+
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return null;
+                } catch (SdkException e) {
+                    LOGGER.log(Level.WARNING, t + ". Exception waiting for instance", e);
+                    return null;
                 }
-            } catch (SdkException | IOException e) {
-                LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
             }
-        }
-        LOGGER.log(Level.INFO, "We have now {0} computers, waiting for {1} more", new Object[] {
-            jenkinsInstance.getComputers().length, plannedNodes.size()
-        });
-        return plannedNodes;
+        }, Computer.threadPoolForRemoting);
     }
 
     private static void attachSlavesToJenkins(Jenkins jenkins, List<EC2AbstractSlave> slaves, SlaveTemplate t)
@@ -1094,7 +1247,13 @@ public class EC2Cloud extends Cloud {
 
             Computer c = slave.toComputer();
             if (slave.getStopOnTerminate() && c != null) {
-                c.connect(false);
+                PROVISIONING_EXECUTOR.execute(() -> {
+                    try {
+                        c.connect(false);
+                    } catch (Exception e) {
+                        LOGGER.log(Level.FINE, "Error connecting " + c.getName(), e);
+                    }
+                });
             }
             jenkins.addNode(slave);
         }
@@ -1121,6 +1280,7 @@ public class EC2Cloud extends Cloud {
             }
 
             attachSlavesToJenkins(jenkinsInstance, slaves, t);
+            invalidateInstanceCountCache();
 
             LOGGER.log(Level.INFO, "{0}. Attempting provision finished", t);
             LOGGER.log(Level.INFO, "We have now {0} computers, waiting for {1} more", new Object[] {
@@ -1151,86 +1311,9 @@ public class EC2Cloud extends Cloud {
         }
         attachSlavesToJenkins(jenkinsInstance, template.toSlaves(orphansOrStopped), template);
         if (!orphansOrStopped.isEmpty()) {
+            invalidateInstanceCountCache();
             LOGGER.info("Found and re-attached " + orphansOrStopped.size() + " orphan/stopped nodes");
         }
-    }
-
-    private PlannedNode createPlannedNode(final SlaveTemplate t, final EC2AbstractSlave slave) {
-        return new PlannedNode(
-                t.getDisplayName(),
-                Computer.threadPoolForRemoting.submit(new Callable<>() {
-                    int retryCount = 0;
-                    private static final int DESCRIBE_LIMIT = 2;
-
-                    @Override
-                    public Node call() throws Exception {
-                        while (true) {
-                            String instanceId = slave.getInstanceId();
-                            if (slave instanceof EC2SpotSlave) {
-                                if (((EC2SpotSlave) slave).isSpotRequestDead()) {
-                                    LOGGER.log(
-                                            Level.WARNING,
-                                            "{0} Spot request died, can't do anything. Terminate provisioning",
-                                            t);
-                                    return null;
-                                }
-
-                                // Spot Instance does not have instance id yet.
-                                if (StringUtils.isEmpty(instanceId)) {
-                                    Thread.sleep(5000);
-                                    continue;
-                                }
-                            }
-
-                            Instance instance = CloudHelper.getInstanceWithRetry(instanceId, slave.getCloud());
-                            if (instance == null) {
-                                LOGGER.log(
-                                        Level.WARNING,
-                                        "{0} Can't find instance with instance id `{1}` in cloud {2}. Terminate provisioning ",
-                                        new Object[] {t, instanceId, slave.cloudName});
-                                return null;
-                            }
-
-                            InstanceStateName state = instance.state().name();
-                            if (state.equals(InstanceStateName.RUNNING)) {
-                                // JENKINS-76171: Always initiate connection when instance is RUNNING
-                                // This reduces the gap between PlannedNode completion and agent connection,
-                                // preventing over-provisioning in NodeProvisioner
-                                Computer c = slave.toComputer();
-                                if (c != null) {
-                                    c.connect(false);
-                                }
-
-                                long secondsSinceStart = Instant.now().until(instance.launchTime(), ChronoUnit.SECONDS);
-                                LOGGER.log(
-                                        Level.INFO,
-                                        "{0} Node {1} moved to RUNNING state in {2} seconds and is ready to be connected by Jenkins",
-                                        new Object[] {t, slave.getNodeName(), secondsSinceStart});
-                                return slave;
-                            }
-
-                            if (!state.equals(InstanceStateName.PENDING)) {
-
-                                if (retryCount >= DESCRIBE_LIMIT) {
-                                    LOGGER.log(
-                                            Level.WARNING,
-                                            "Instance {0} did not move to running after {1} attempts, terminating provisioning",
-                                            new Object[] {instanceId, retryCount});
-                                    return null;
-                                }
-
-                                LOGGER.log(
-                                        Level.INFO,
-                                        "Attempt {0}: {1}. Node {2} is neither pending, neither running, it''s {3}. Will try again after 5s",
-                                        new Object[] {retryCount, t, slave.getNodeName(), state});
-                                retryCount++;
-                            }
-
-                            Thread.sleep(5000);
-                        }
-                    }
-                }),
-                t.getNumExecutors());
     }
 
     @Override

--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -66,8 +66,8 @@ public class EC2Computer extends SlaveComputer {
     private volatile long instanceCacheTimestamp;
 
     /** TTL in ms for instance/state cache. Configurable via system property. */
-    private static final long INSTANCE_CACHE_TTL_MS = Long.getLong(
-            EC2Computer.class.getName() + ".instanceCacheTTLMs", 30_000);
+    private static final long INSTANCE_CACHE_TTL_MS =
+            Long.getLong(EC2Computer.class.getName() + ".instanceCacheTTLMs", 30_000);
 
     private volatile Boolean isNitro;
 

--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -59,6 +59,16 @@ public class EC2Computer extends SlaveComputer {
      */
     private volatile Instance ec2InstanceDescription;
 
+    /**
+     * Timestamp when {@link #ec2InstanceDescription} was last fetched.
+     * Used for TTL cache to avoid repeated EC2 API calls during SSH verification retries.
+     */
+    private volatile long instanceCacheTimestamp;
+
+    /** TTL in ms for instance/state cache. Configurable via system property. */
+    private static final long INSTANCE_CACHE_TTL_MS = Long.getLong(
+            EC2Computer.class.getName() + ".instanceCacheTTLMs", 30_000);
+
     private volatile Boolean isNitro;
 
     public EC2Computer(EC2AbstractSlave slave) {
@@ -171,15 +181,18 @@ public class EC2Computer extends SlaveComputer {
      * Obtains the instance state description in EC2.
      *
      * <p>
-     * This method returns a cached state, so it's not suitable to check {@link Instance#state()} from the returned
-     * instance (but all the other fields are valid as it won't change.)
+     * This method returns a cached state (with TTL), so it's not suitable to check {@link Instance#state()} from the
+     * returned instance (but all the other fields are valid as it won't change.)
      * <p>
      * The cache can be flushed using {@link #updateInstanceDescription()}
      */
     public Instance describeInstance() throws SdkException, InterruptedException {
-        if (ec2InstanceDescription == null) {
-            ec2InstanceDescription = CloudHelper.getInstanceWithRetry(getInstanceId(), getCloud());
+        long now = System.currentTimeMillis();
+        if (ec2InstanceDescription != null && (now - instanceCacheTimestamp) < INSTANCE_CACHE_TTL_MS) {
+            return ec2InstanceDescription;
         }
+        ec2InstanceDescription = CloudHelper.getInstanceWithRetry(getInstanceId(), getCloud());
+        instanceCacheTimestamp = now;
         return ec2InstanceDescription;
     }
 
@@ -187,18 +200,19 @@ public class EC2Computer extends SlaveComputer {
      * This will flush any cached description held by {@link #describeInstance()}.
      */
     public Instance updateInstanceDescription() throws SdkException, InterruptedException {
-        return ec2InstanceDescription = CloudHelper.getInstanceWithRetry(getInstanceId(), getCloud());
+        ec2InstanceDescription = CloudHelper.getInstanceWithRetry(getInstanceId(), getCloud());
+        instanceCacheTimestamp = System.currentTimeMillis();
+        return ec2InstanceDescription;
     }
 
     /**
      * Gets the current state of the instance.
      *
      * <p>
-     * Unlike {@link #describeInstance()}, this method always return the current status by calling EC2.
+     * Uses a short TTL cache to avoid repeated EC2 API calls during SSH verification retries.
      */
     public InstanceState getState() throws SdkException, InterruptedException {
-        ec2InstanceDescription = CloudHelper.getInstanceWithRetry(getInstanceId(), getCloud());
-        return InstanceState.find(ec2InstanceDescription.state().name().toString());
+        return InstanceState.find(describeInstance().state().name().toString());
     }
 
     /**

--- a/src/main/java/hudson/plugins/ec2/EC2ComputerListener.java
+++ b/src/main/java/hudson/plugins/ec2/EC2ComputerListener.java
@@ -4,6 +4,7 @@ import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.TaskListener;
 import hudson.slaves.ComputerListener;
+import jenkins.model.Jenkins;
 
 @Extension
 public class EC2ComputerListener extends ComputerListener {
@@ -12,6 +13,10 @@ public class EC2ComputerListener extends ComputerListener {
     public void onOnline(Computer c, TaskListener listener) {
         if (c instanceof EC2Computer) {
             ((EC2Computer) c).onConnected();
+        }
+        Jenkins j = Jenkins.getInstanceOrNull();
+        if (j != null) {
+            j.getQueue().scheduleMaintenance();
         }
     }
 }

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -34,6 +34,8 @@ import hudson.slaves.RetentionStrategy;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
@@ -50,9 +52,20 @@ import software.amazon.awssdk.core.exception.SdkException;
 public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> implements ExecutorListener {
     private static final Logger LOGGER = Logger.getLogger(EC2RetentionStrategy.class.getName());
 
+    /**
+     * Executor for heavy retention work (EC2 API calls, idle timeout, reconnect).
+     * Runs outside the Queue lock so the Queue can complete its periodic routine in under a second.
+     */
+    private static final ExecutorService HEAVY_WORK_EXECUTOR =
+            Executors.newCachedThreadPool(r -> {
+                Thread t = new Thread(r, "EC2RetentionStrategy-heavy");
+                t.setDaemon(true);
+                return t;
+            });
+
     public static final boolean DISABLED = Boolean.getBoolean(EC2RetentionStrategy.class.getName() + ".disabled");
 
-    private long nextCheckAfter = -1;
+    private volatile long nextCheckAfter = -1;
     private transient Clock clock;
 
     /**
@@ -94,25 +107,44 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
         return this.nextCheckAfter;
     }
 
+    /**
+     * Lightweight path: returns immediately so the Queue lock is not held during EC2 API calls.
+     * Heavy work (getState, getUptime, idle timeout, reconnect) is scheduled to run asynchronously
+     * outside the Queue lock. See docs/EC2_QUEUE_AUDIT.md.
+     */
     @Override
     public long check(EC2Computer c) {
         if (!checkLock.tryLock()) {
             return CHECK_INTERVAL_MINUTES;
-        } else {
-            try {
-                long currentTime = this.clock.millis();
-
-                if (currentTime > nextCheckAfter) {
-                    attemptReconnectIfOffline(c);
-                    long intervalMins = internalCheck(c);
-                    nextCheckAfter = currentTime + TimeUnit.MINUTES.toMillis(intervalMins);
-                    return intervalMins;
-                } else {
-                    return CHECK_INTERVAL_MINUTES;
-                }
-            } finally {
-                checkLock.unlock();
+        }
+        try {
+            long currentTime = this.clock.millis();
+            if (currentTime <= nextCheckAfter) {
+                return CHECK_INTERVAL_MINUTES;
             }
+            // Schedule heavy work to run outside the Queue lock; return immediately.
+            nextCheckAfter = currentTime + TimeUnit.MINUTES.toMillis(CHECK_INTERVAL_MINUTES);
+            final EC2Computer computer = c;
+            HEAVY_WORK_EXECUTOR.execute(() -> runHeavyCheck(computer));
+            return CHECK_INTERVAL_MINUTES;
+        } finally {
+            checkLock.unlock();
+        }
+    }
+
+    /**
+     * Runs outside the Queue lock. Performs EC2 API calls and retention logic.
+     * State-changing operations (disconnect, terminate) use Queue.withLock for brief sections.
+     */
+    private void runHeavyCheck(EC2Computer computer) {
+        if (!checkLock.tryLock()) {
+            return;
+        }
+        try {
+            attemptReconnectIfOffline(computer);
+            internalCheck(computer);
+        } finally {
+            checkLock.unlock();
         }
     }
 
@@ -166,7 +198,11 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                 if (computer.isOnline()) {
                     LOGGER.info("External Stop of " + computer.getName() + " detected - disconnecting. instance status"
                             + state);
-                    computer.disconnect(null);
+                    try {
+                        Queue.withLock(() -> computer.disconnect(null));
+                    } catch (Exception e) {
+                        LOGGER.log(Level.FINE, "Error disconnecting " + computer.getName(), e);
+                    }
                 }
                 return CHECK_INTERVAL_MINUTES;
             }
@@ -193,7 +229,11 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                         LOGGER.info("Startup timeout of " + computer.getName() + " after "
                                 + uptime + " milliseconds (timeout: "
                                 + launchTimeout + " milliseconds), instance status: " + state.toString());
-                        node.launchTimeout();
+                        try {
+                            Queue.withLock(node::launchTimeout);
+                        } catch (Exception e) {
+                            LOGGER.log(Level.FINE, "Error launching timeout for " + computer.getName(), e);
+                        }
                     }
                     return CHECK_INTERVAL_MINUTES;
                 } else {
@@ -211,15 +251,26 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                 // TODO: really think about the right strategy here, see
                 // JENKINS-23792
 
+                boolean queueHasItemsForSlave;
+                try {
+                    queueHasItemsForSlave = Queue.withLock(() -> itemsInQueueForThisSlave(computer));
+                } catch (Exception e) {
+                    LOGGER.log(Level.FINE, "Error checking queue for " + computer.getName(), e);
+                    queueHasItemsForSlave = true; // safe default: do not terminate
+                }
                 if (idleMilliseconds > TimeUnit.MINUTES.toMillis(idleTerminationMinutes)
-                        && !itemsInQueueForThisSlave(computer)) {
+                        && !queueHasItemsForSlave) {
 
                     LOGGER.info("Idle timeout of " + computer.getName() + " after "
                             + TimeUnit.MILLISECONDS.toMinutes(idleMilliseconds) + " idle minutes, instance status"
                             + state.toString());
                     EC2AbstractSlave slaveNode = computer.getNode();
                     if (slaveNode != null) {
-                        slaveNode.idleTimeout();
+                        try {
+                            Queue.withLock(slaveNode::idleTimeout);
+                        } catch (Exception e) {
+                            LOGGER.log(Level.FINE, "Error idle timeout for " + computer.getName(), e);
+                        }
                     }
                 }
             } else {
@@ -233,15 +284,26 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                 // if we have less "free" (aka already paid for) time left than
                 // our idle time, stop/terminate the instance
                 // See JENKINS-23821
+                boolean queueHasItemsForSlaveBilling;
+                try {
+                    queueHasItemsForSlaveBilling = Queue.withLock(() -> itemsInQueueForThisSlave(computer));
+                } catch (Exception e) {
+                    LOGGER.log(Level.FINE, "Error checking queue for " + computer.getName(), e);
+                    queueHasItemsForSlaveBilling = true;
+                }
                 if (freeSecondsLeft <= TimeUnit.MINUTES.toSeconds(Math.abs(idleTerminationMinutes))
-                        && !itemsInQueueForThisSlave(computer)) {
+                        && !queueHasItemsForSlaveBilling) {
                     LOGGER.info("Idle timeout of " + computer.getName() + " after "
                             + TimeUnit.MILLISECONDS.toMinutes(idleMilliseconds) + " idle minutes, with "
                             + TimeUnit.SECONDS.toMinutes(freeSecondsLeft)
                             + " minutes remaining in billing period");
                     EC2AbstractSlave slaveNode = computer.getNode();
                     if (slaveNode != null) {
-                        slaveNode.idleTimeout();
+                        try {
+                            Queue.withLock(slaveNode::idleTimeout);
+                        } catch (Exception e) {
+                            LOGGER.log(Level.FINE, "Error idle timeout for " + computer.getName(), e);
+                        }
                     }
                 }
             }
@@ -261,7 +323,11 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                 if (!computer.isConnecting()) {
                     // Keep retrying connection to agent until the job times out
                     LOGGER.warning("Attempting to reconnect EC2Computer " + computer.getName());
-                    computer.connect(false);
+                    try {
+                        computer.connect(false);
+                    } catch (Exception e) {
+                        LOGGER.log(Level.FINE, "Error reconnecting " + computer.getName(), e);
+                    }
                 }
             }
         } catch (SdkException | InterruptedException e) {
@@ -299,31 +365,33 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
     }
 
     /**
-     * Called when a new {@link EC2Computer} object is introduced (such as when Hudson started, or when
-     * a new agent is added.)
-     * <p>
-     * When Jenkins has just started, we don't want to spin up all the instances, so we only start if
-     * the EC2 instance is already running
+     * Lightweight path: returns immediately. Heavy work (getState, connect) runs asynchronously
+     * so the caller is not blocked by EC2 API calls.
      */
     @Override
     public void start(EC2Computer c) {
-        // Jenkins is in the process of starting up
-        if (Jenkins.get().getInitLevel() != InitMilestone.COMPLETED) {
-            InstanceState state = null;
+        final EC2Computer computer = c;
+        HEAVY_WORK_EXECUTOR.execute(() -> {
+            if (Jenkins.get().getInitLevel() != InitMilestone.COMPLETED) {
+                InstanceState state = null;
+                try {
+                    state = computer.getState();
+                } catch (SdkException | InterruptedException e) {
+                    LOGGER.log(Level.FINE, "Error getting EC2 instance state for " + computer.getName(), e);
+                }
+                if (!(InstanceState.PENDING.equals(state) || InstanceState.RUNNING.equals(state))) {
+                    LOGGER.info("Ignoring start request for " + computer.getName()
+                            + " during Jenkins startup due to EC2 instance state of " + state);
+                    return;
+                }
+            }
+            LOGGER.info("Start requested for " + computer.getName());
             try {
-                state = c.getState();
-            } catch (SdkException | InterruptedException e) {
-                LOGGER.log(Level.FINE, "Error getting EC2 instance state for " + c.getName(), e);
+                computer.connect(false);
+            } catch (Exception e) {
+                LOGGER.log(Level.FINE, "Error connecting " + computer.getName(), e);
             }
-            if (!(InstanceState.PENDING.equals(state) || InstanceState.RUNNING.equals(state))) {
-                LOGGER.info("Ignoring start request for " + c.getName()
-                        + " during Jenkins startup due to EC2 instance state of " + state);
-                return;
-            }
-        }
-
-        LOGGER.info("Start requested for " + c.getName());
-        c.connect(false);
+        });
     }
 
     // no registration since this retention strategy is used only for EC2 nodes
@@ -355,7 +423,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                 } else if (maxTotalUses <= 1) {
                     LOGGER.info("maxTotalUses drained - suspending agent " + slaveNode.instanceId);
                     computer.setAcceptingTasks(false);
-                    MinimumInstanceChecker.checkForMinimumInstances();
+                    MinimumInstanceChecker.scheduleCheck();
                 } else {
                     slaveNode.maxTotalUses = slaveNode.maxTotalUses - 1;
                     LOGGER.info("Agent " + slaveNode.instanceId + " has " + slaveNode.maxTotalUses + " builds left");

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -57,12 +57,11 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
      * Runs outside the Queue lock so the Queue can complete its periodic routine in under a second.
      * Package-private and non-final so tests can replace with a direct (same-thread) executor.
      */
-    static ExecutorService HEAVY_WORK_EXECUTOR =
-            Executors.newCachedThreadPool(r -> {
-                Thread t = new Thread(r, "EC2RetentionStrategy-heavy");
-                t.setDaemon(true);
-                return t;
-            });
+    static ExecutorService HEAVY_WORK_EXECUTOR = Executors.newCachedThreadPool(r -> {
+        Thread t = new Thread(r, "EC2RetentionStrategy-heavy");
+        t.setDaemon(true);
+        return t;
+    });
 
     public static final boolean DISABLED = Boolean.getBoolean(EC2RetentionStrategy.class.getName() + ".disabled");
 
@@ -259,8 +258,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                     LOGGER.log(Level.FINE, "Error checking queue for " + computer.getName(), e);
                     queueHasItemsForSlave = true; // safe default: do not terminate
                 }
-                if (idleMilliseconds > TimeUnit.MINUTES.toMillis(idleTerminationMinutes)
-                        && !queueHasItemsForSlave) {
+                if (idleMilliseconds > TimeUnit.MINUTES.toMillis(idleTerminationMinutes) && !queueHasItemsForSlave) {
 
                     LOGGER.info("Idle timeout of " + computer.getName() + " after "
                             + TimeUnit.MILLISECONDS.toMinutes(idleMilliseconds) + " idle minutes, instance status"

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -55,8 +55,9 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
     /**
      * Executor for heavy retention work (EC2 API calls, idle timeout, reconnect).
      * Runs outside the Queue lock so the Queue can complete its periodic routine in under a second.
+     * Package-private and non-final so tests can replace with a direct (same-thread) executor.
      */
-    private static final ExecutorService HEAVY_WORK_EXECUTOR =
+    static ExecutorService HEAVY_WORK_EXECUTOR =
             Executors.newCachedThreadPool(r -> {
                 Thread t = new Thread(r, "EC2RetentionStrategy-heavy");
                 t.setDaemon(true);

--- a/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java
@@ -78,7 +78,8 @@ public class EC2SlaveMonitor extends AsyncPeriodicWork {
                         if (inst == null) {
                             LOGGER.info("EC2 instance not found (likely terminated): " + ec2Slave.getInstanceId());
                             ec2Slave.terminate();
-                        } else if (InstanceStateName.TERMINATED.equals(inst.state().name())) {
+                        } else if (InstanceStateName.TERMINATED.equals(
+                                inst.state().name())) {
                             LOGGER.info("EC2 instance is dead: " + ec2Slave.getInstanceId());
                             ec2Slave.terminate();
                         } else {
@@ -97,7 +98,11 @@ public class EC2SlaveMonitor extends AsyncPeriodicWork {
                     }
                 }
             } catch (SdkException e) {
-                LOGGER.log(Level.WARNING, "Batch describeInstances failed for cloud " + cloud.getName() + ", falling back to per-node check", e);
+                LOGGER.log(
+                        Level.WARNING,
+                        "Batch describeInstances failed for cloud " + cloud.getName()
+                                + ", falling back to per-node check",
+                        e);
                 for (EC2AbstractSlave ec2Slave : slaves) {
                     try {
                         if (!ec2Slave.isAlive(true)) {

--- a/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java
@@ -6,12 +6,19 @@ import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.plugins.ec2.util.MinimumInstanceChecker;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.ec2.model.Ec2Exception;
+import software.amazon.awssdk.services.ec2.model.Instance;
+import software.amazon.awssdk.services.ec2.model.InstanceStateName;
 
 /**
  * @author Bruno Meneguello
@@ -36,26 +43,77 @@ public class EC2SlaveMonitor extends AsyncPeriodicWork {
     @Override
     protected void execute(TaskListener listener) throws IOException, InterruptedException {
         removeDeadNodes();
-        MinimumInstanceChecker.checkForMinimumInstances();
+        MinimumInstanceChecker.scheduleCheck();
     }
 
     private void removeDeadNodes() {
+        Map<EC2Cloud, List<EC2AbstractSlave>> byCloud = new HashMap<>();
         for (Node node : Jenkins.get().getNodes()) {
             if (node instanceof EC2AbstractSlave ec2Slave) {
-                try {
-                    if (!ec2Slave.isAlive(true)) {
-                        LOGGER.info("EC2 instance is dead: " + ec2Slave.getInstanceId());
-                        ec2Slave.terminate();
+                String instanceId = ec2Slave.getInstanceId();
+                if (StringUtils.isEmpty(instanceId)) {
+                    continue;
+                }
+                EC2Cloud cloud = ec2Slave.getCloud();
+                if (cloud == null) {
+                    continue;
+                }
+                byCloud.computeIfAbsent(cloud, k -> new ArrayList<>()).add(ec2Slave);
+            }
+        }
+
+        for (Map.Entry<EC2Cloud, List<EC2AbstractSlave>> entry : byCloud.entrySet()) {
+            EC2Cloud cloud = entry.getKey();
+            List<EC2AbstractSlave> slaves = entry.getValue();
+            List<String> instanceIds = new ArrayList<>(slaves.size());
+            for (EC2AbstractSlave s : slaves) {
+                instanceIds.add(s.getInstanceId());
+            }
+
+            try {
+                Map<String, Instance> instances = CloudHelper.getInstancesBatch(instanceIds, cloud);
+                for (EC2AbstractSlave ec2Slave : slaves) {
+                    try {
+                        Instance inst = instances.get(ec2Slave.getInstanceId());
+                        if (inst == null) {
+                            LOGGER.info("EC2 instance not found (likely terminated): " + ec2Slave.getInstanceId());
+                            ec2Slave.terminate();
+                        } else if (InstanceStateName.TERMINATED.equals(inst.state().name())) {
+                            LOGGER.info("EC2 instance is dead: " + ec2Slave.getInstanceId());
+                            ec2Slave.terminate();
+                        } else {
+                            ec2Slave.updateFromFetchedInstance(inst);
+                        }
+                    } catch (SdkException e) {
+                        if (e instanceof Ec2Exception
+                                && EC2Cloud.EC2_REQUEST_EXPIRED_ERROR_CODE.equals(
+                                        ((Ec2Exception) e).awsErrorDetails().errorCode())) {
+                            LOGGER.info("EC2 request expired, skipping consideration of " + ec2Slave.getInstanceId()
+                                    + " due to unknown state.");
+                        } else {
+                            LOGGER.info("EC2 instance is dead and failed to terminate: " + ec2Slave.getInstanceId());
+                            removeNode(ec2Slave);
+                        }
                     }
-                } catch (SdkException e) {
-                    if (e instanceof Ec2Exception
-                            && EC2Cloud.EC2_REQUEST_EXPIRED_ERROR_CODE.equals(
-                                    ((Ec2Exception) e).awsErrorDetails().errorCode())) {
-                        LOGGER.info("EC2 request expired, skipping consideration of " + ec2Slave.getInstanceId()
-                                + " due to unknown state.");
-                    } else {
-                        LOGGER.info("EC2 instance is dead and failed to terminate: " + ec2Slave.getInstanceId());
-                        removeNode(ec2Slave);
+                }
+            } catch (SdkException e) {
+                LOGGER.log(Level.WARNING, "Batch describeInstances failed for cloud " + cloud.getName() + ", falling back to per-node check", e);
+                for (EC2AbstractSlave ec2Slave : slaves) {
+                    try {
+                        if (!ec2Slave.isAlive(true)) {
+                            LOGGER.info("EC2 instance is dead: " + ec2Slave.getInstanceId());
+                            ec2Slave.terminate();
+                        }
+                    } catch (SdkException ex) {
+                        if (ex instanceof Ec2Exception
+                                && EC2Cloud.EC2_REQUEST_EXPIRED_ERROR_CODE.equals(
+                                        ((Ec2Exception) ex).awsErrorDetails().errorCode())) {
+                            LOGGER.info("EC2 request expired, skipping consideration of " + ec2Slave.getInstanceId()
+                                    + " due to unknown state.");
+                        } else {
+                            LOGGER.info("EC2 instance is dead and failed to terminate: " + ec2Slave.getInstanceId());
+                            removeNode(ec2Slave);
+                        }
                     }
                 }
             }

--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -30,6 +32,25 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 public class MinimumInstanceChecker {
 
     private static final Logger LOGGER = Logger.getLogger(MinimumInstanceChecker.class.getName());
+
+    /**
+     * Executor for deferred minimum-instance checks. Heavy provisioning (EC2 API, cloud.provision)
+     * runs here so callers (taskAccepted, EC2SlaveMonitor) return immediately.
+     */
+    private static final ExecutorService EXECUTOR =
+            Executors.newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r, "MinimumInstanceChecker");
+                t.setDaemon(true);
+                return t;
+            });
+
+    /**
+     * Schedules a minimum-instance check to run asynchronously. Use this instead of
+     * {@link #checkForMinimumInstances()} when the caller must return immediately (e.g. taskAccepted).
+     */
+    public static void scheduleCheck() {
+        EXECUTOR.execute(MinimumInstanceChecker::checkForMinimumInstances);
+    }
 
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Needs to be overridden from tests")
     public static Clock clock = Clock.systemDefaultZone();

--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -37,12 +37,11 @@ public class MinimumInstanceChecker {
      * Executor for deferred minimum-instance checks. Heavy provisioning (EC2 API, cloud.provision)
      * runs here so callers (taskAccepted, EC2SlaveMonitor) return immediately.
      */
-    private static final ExecutorService EXECUTOR =
-            Executors.newSingleThreadExecutor(r -> {
-                Thread t = new Thread(r, "MinimumInstanceChecker");
-                t.setDaemon(true);
-                return t;
-            });
+    private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "MinimumInstanceChecker");
+        t.setDaemon(true);
+        return t;
+    });
 
     /**
      * Schedules a minimum-instance check to run asynchronously. Use this instead of

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -34,7 +34,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -60,10 +62,48 @@ class EC2RetentionStrategyTest {
 
     private JenkinsRule r;
     private final LogRecorder logging = new LogRecorder();
+    private ExecutorService originalExecutor;
+
+    private static class DirectExecutorService extends AbstractExecutorService {
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+
+        @Override
+        public void shutdown() {}
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            return List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return true;
+        }
+    }
 
     @BeforeEach
     void setUp(JenkinsRule rule) {
         r = rule;
+        originalExecutor = EC2RetentionStrategy.HEAVY_WORK_EXECUTOR;
+        EC2RetentionStrategy.HEAVY_WORK_EXECUTOR = new DirectExecutorService();
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    void tearDown() {
+        EC2RetentionStrategy.HEAVY_WORK_EXECUTOR = originalExecutor;
     }
 
     @Test


### PR DESCRIPTION
What is ludicrous speed?
------------------------

[Obligatory video of ludicrous speed](https://youtu.be/oApAdwuqtn8?si=uJHPP5OXz9GNllY0)

<details><summary>Ludicrous speed is faster than light speed</summary>

---

![spaceballs ludicrous speed](https://github.com/user-attachments/assets/803d4aa5-4677-40b9-b04b-d4f22ea2cbf3)

</details>

---

Patch details
-------------

`Queue.maintian()` is a critical path in Jenkins core.  Any performance delays can significantly impact Jenkins scheduling work on agents.  At around 800 agents, Jenkins becomes unavailable since it becomes nearly permanently locked with work queued up.  This patch was tested with over 1000 Jenkins agents in AWS and work was scheduled near-instantly.

The EC2 plugin's retention strategy (`check()`, `start()`) is called under the Queue lock and made live EC2 API calls for every agent. The patch splits all EC2 operations into two categories:

- **Lightweight** (runs under Queue lock): Returns immediately with no AWS interaction. Schedules heavy work on background thread pools and returns.
- **Heavyweight** (runs outside Queue lock): EC2 API calls (describeInstances, getState, connect), idle timeout, reconnect — all run on dedicated `HEAVY_WORK_EXECUTOR` and `PROVISIONING_EXECUTOR` thread pools.

Provisioning now returns `PlannedNode` futures immediately instead of blocking on `runInstances`. Instance counts are cached with a 30-second TTL to avoid repeated `describeInstances` calls. Dead-node detection uses batch `describeInstances` (one API call per cloud) instead of per-node calls. When agents come online, `scheduleMaintenance()` is called to trigger an immediate Queue re-evaluation rather than waiting for the next 5-second timer tick.

Patch series
------------

This patch is part of a series which enables my production instance to scale work up to ludicrous amounts of agents.

- ec2 plugin (this patch)
- [job-restrictions plugin]
- [leastload plugin]

AI Analysis
-----------

See detailed [AI analysis for ec2 plugin][1].

Testing done
------------

First pressure tested in a non-production environment. It is now running in production for me for about a week.

Advisory
--------

I plan to update Jenkins core with warnings when there's plugins which adversely affect Jenkins queue performance.  Please keep in mind not merging changes with this strategy will involve this plugin being called out for tanking Jenkins performance.  This patch solves a critical performance issue for your plugin so that it does not tank Jenkins performance (in how fast Jenkins schedules work on agents).

Submitter checklist
-------------------

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

[1]: https://github.com/samrocketman/jenkins-ai-analysis/blob/main/ludicrous-mode-analysis/ec2-plugin/
[job-restrictions plugin]: https://github.com/jenkinsci/job-restrictions-plugin/pull/210
[leastload plugin]: https://github.com/jenkinsci/leastload-plugin/pull/22