### PR TITLE
Fill in gaps for NPE fix

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -505,6 +505,9 @@ public class EC2Cloud extends Cloud {
 
     protected Object readResolve() {
         this.slaveCountingLock = new ReentrantLock();
+        if (this.cachedTemplateSlaves == null) {
+            this.cachedTemplateSlaves = new ConcurrentHashMap<>();
+        }
 
         for (SlaveTemplate t : templates) {
             t.parent = this;
@@ -557,10 +560,6 @@ public class EC2Cloud extends Cloud {
                     Level.WARNING,
                     "EC2 Plugin could not migrate credentials to the Jenkins Global Credentials Store, EC2 Plugin for cloud {0} must be manually reconfigured",
                     getDisplayName());
-        }
-
-        if (this.cachedTemplateSlaves == null) {
-            this.cachedTemplateSlaves = new ConcurrentHashMap<>();
         }
 
         return this;


### PR DESCRIPTION
How current fix is incomplete
-----------------------------

`readResolve()` has an early return this on line 540 inside the credential migration path. The `cachedTemplateSlaves` null check was placed after this early return, so any EC2Cloud instance with legacy accessId/secretKey credentials matching an existing credential would exit `readResolve()` without initializing cachedTemplateSlaves, hitting the same NPE.

This change
-----------

Moves the `cachedTemplateSlaves` null-check initialization to the top of `readResolve()`, immediately after `slaveCountingLock`, so it executes before any early return path.