### PR TITLE
Fix SshClient thread leak in EC2SSHLauncher.launchRemotingAgent()

### DIFF
--- a/src/main/java/hudson/plugins/ec2/ssh/EC2SSHLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2SSHLauncher.java
@@ -116,43 +116,60 @@ public abstract class EC2SSHLauncher extends EC2ComputerLauncher {
         logInfo(computer, listener, "Launching remoting agent (via SSH2 Connection): " + launchString);
 
         final SshClient remotingClient = SSHClientHelper.getInstance().setupSshClient(computer);
-        final ClientSession remotingSession = connectToSsh(remotingClient, computer, listener, template);
-        KeyPair key = computer.getCloud().getKeyPair();
-        if (key != null) {
-            remotingSession.addPublicKeyIdentity(KeyHelper.decodeKeyPair(key.getMaterial(), ""));
-        }
-        remotingSession.auth().await(timeout);
-        ChannelExec agentExecChannel = remotingSession.createExecChannel(
-                launchString, StandardCharsets.US_ASCII, null, Collections.emptyMap());
-        agentExecChannel.open().verify(timeout);
+        boolean launched = false;
+        try {
+            final ClientSession remotingSession = connectToSsh(remotingClient, computer, listener, template);
+            KeyPair key = computer.getCloud().getKeyPair();
+            if (key != null) {
+                remotingSession.addPublicKeyIdentity(KeyHelper.decodeKeyPair(key.getMaterial(), ""));
+            }
+            remotingSession.auth().await(timeout);
+            ChannelExec agentExecChannel = remotingSession.createExecChannel(
+                    launchString, StandardCharsets.US_ASCII, null, Collections.emptyMap());
+            agentExecChannel.open().verify(timeout);
 
-        InputStream invertedOut = agentExecChannel.getInvertedOut();
-        OutputStream invertedIn = agentExecChannel.getInvertedIn();
+            InputStream invertedOut = agentExecChannel.getInvertedOut();
+            OutputStream invertedIn = agentExecChannel.getInvertedIn();
 
-        Listener channelListener = new Listener() {
+            Listener channelListener = new Listener() {
 
-            @Override
-            public void onClosed(Channel channel, IOException cause) {
-                try {
-                    agentExecChannel.close();
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "Error when closing the channel", e);
+                @Override
+                public void onClosed(Channel channel, IOException cause) {
+                    try {
+                        agentExecChannel.close();
+                    } catch (IOException e) {
+                        LOGGER.log(Level.WARNING, "Error when closing the channel", e);
+                    }
+                    try {
+                        remotingSession.close();
+                    } catch (IOException e) {
+                        LOGGER.log(Level.WARNING, "Error when closing the session", e);
+                    }
+                    try {
+                        remotingClient.stop();
+                        remotingClient.close();
+                    } catch (IOException e) {
+                        LOGGER.log(Level.WARNING, "Error when closing the client", e);
+                    }
                 }
-                try {
-                    remotingSession.close();
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "Error when closing the session", e);
-                }
+            };
+
+            computer.setChannel(invertedOut, invertedIn, logger, channelListener);
+            launched = true;
+        } finally {
+            if (!launched) {
                 try {
                     remotingClient.stop();
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Error stopping SSH client after failed launch", e);
+                }
+                try {
                     remotingClient.close();
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "Error when closing the client", e);
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Error closing SSH client after failed launch", e);
                 }
             }
-        };
-
-        computer.setChannel(invertedOut, invertedIn, logger, channelListener);
+        }
     }
 
     protected boolean executeRemote(

--- a/src/test/java/hudson/plugins/ec2/ssh/LaunchRemotingAgentThreadLeakTest.java
+++ b/src/test/java/hudson/plugins/ec2/ssh/LaunchRemotingAgentThreadLeakTest.java
@@ -1,0 +1,124 @@
+package hudson.plugins.ec2.ssh;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import hudson.model.TaskListener;
+import hudson.plugins.ec2.EC2AbstractSlave;
+import hudson.plugins.ec2.EC2Cloud;
+import hudson.plugins.ec2.EC2Computer;
+import hudson.plugins.ec2.SlaveTemplate;
+import hudson.plugins.ec2.util.SSHClientHelper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.channel.ChannelExec;
+import org.apache.sshd.client.future.AuthFuture;
+import org.apache.sshd.client.future.OpenFuture;
+import org.apache.sshd.client.session.ClientSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.mockito.MockedStatic;
+import software.amazon.awssdk.core.exception.SdkException;
+
+@WithJenkins
+class LaunchRemotingAgentThreadLeakTest {
+
+    private EC2Computer mockEC2Computer;
+    private TaskListener mockListener;
+    private PrintStream mockPS;
+    private EC2AbstractSlave mockNode;
+    private SlaveTemplate mockTemplate;
+    private EC2Cloud mockCloud;
+    private MockedStatic<SSHClientHelper> mockStaticSSHClientHelper;
+    private SSHClientHelper mockSSHClientHelper;
+    private SshClient mockSshClient;
+    private ClientSession mockClientSession;
+    private AuthFuture mockAuthFuture;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        mockEC2Computer = mock(EC2Computer.class);
+        mockListener = mock(TaskListener.class);
+        mockPS = mock(PrintStream.class);
+        mockNode = mock(EC2AbstractSlave.class);
+        mockTemplate = mock(SlaveTemplate.class);
+        mockCloud = mock(EC2Cloud.class);
+        mockStaticSSHClientHelper = mockStatic(SSHClientHelper.class);
+        mockSSHClientHelper = mock(SSHClientHelper.class);
+        mockSshClient = mock(SshClient.class);
+        mockClientSession = mock(ClientSession.class);
+        mockAuthFuture = mock(AuthFuture.class);
+
+        when(mockEC2Computer.getNode()).thenReturn(mockNode);
+        when(mockEC2Computer.getCloud()).thenReturn(mockCloud);
+        when(mockListener.getLogger()).thenReturn(mockPS);
+
+        mockStaticSSHClientHelper.when(SSHClientHelper::getInstance).thenReturn(mockSSHClientHelper);
+        when(mockSSHClientHelper.setupSshClient(any())).thenReturn(mockSshClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockStaticSSHClientHelper.close();
+    }
+
+    @Test
+    void sshClientIsCleanedUp_whenConnectToSshThrows() throws Exception {
+        EC2WindowsSSHLauncher launcher = spy(new EC2WindowsSSHLauncher());
+        doThrow(SdkException.builder().message("simulated connect failure").build())
+                .when(launcher)
+                .connectToSsh(eq(mockSshClient), any(), any(), any());
+
+        assertThrows(
+                SdkException.class,
+                () -> launcher.launchRemotingAgent(
+                        mockEC2Computer, mockListener, "java -jar remoting.jar", mockTemplate, 10_000L, mockPS));
+
+        verify(mockSshClient).stop();
+        verify(mockSshClient).close();
+    }
+
+    @Test
+    void sshClientIsCleanedUp_whenCreateExecChannelThrows() throws Exception {
+        EC2WindowsSSHLauncher launcher = spy(new EC2WindowsSSHLauncher());
+        doReturn(mockClientSession).when(launcher).connectToSsh(eq(mockSshClient), any(), any(), any());
+        when(mockClientSession.auth()).thenReturn(mockAuthFuture);
+        when(mockClientSession.createExecChannel(any(), any(), any(), any()))
+                .thenThrow(new IOException("simulated channel failure"));
+
+        assertThrows(
+                IOException.class,
+                () -> launcher.launchRemotingAgent(
+                        mockEC2Computer, mockListener, "java -jar remoting.jar", mockTemplate, 10_000L, mockPS));
+
+        verify(mockSshClient).stop();
+        verify(mockSshClient).close();
+    }
+
+    @Test
+    void sshClientIsNotClosedEarly_whenLaunchSucceeds() throws Exception {
+        EC2WindowsSSHLauncher launcher = spy(new EC2WindowsSSHLauncher());
+        ChannelExec mockChannelExec = mock(ChannelExec.class);
+        OpenFuture mockOpenFuture = mock(OpenFuture.class);
+
+        doReturn(mockClientSession).when(launcher).connectToSsh(eq(mockSshClient), any(), any(), any());
+        when(mockClientSession.auth()).thenReturn(mockAuthFuture);
+        when(mockClientSession.createExecChannel(any(), any(), any(), any())).thenReturn(mockChannelExec);
+        when(mockChannelExec.open()).thenReturn(mockOpenFuture);
+        when(mockChannelExec.getInvertedOut()).thenReturn(mock(InputStream.class));
+        when(mockChannelExec.getInvertedIn()).thenReturn(mock(OutputStream.class));
+
+        launcher.launchRemotingAgent(
+                mockEC2Computer, mockListener, "java -jar remoting.jar", mockTemplate, 10_000L, mockPS);
+
+        verify(mockSshClient, never()).stop();
+        verify(mockSshClient, never()).close();
+    }
+}


### PR DESCRIPTION
  - each launchRemotingAgent() creates an Apache MINA SshClient (which spawns internal thread pools nio acceptor/selectors) but only registers cleanup via a Channel.Listener callback at the end when happens of the method. If any exception occurs before computer.setChannel() is reached, the client is never cleaned up and so leaking many threads.
  - With Windows SSH agents that retry frequently during boot, this produces thousands of leaked sshd-SshClient threads.


Signed-off-by: Olivier Lamy <olamy@apache.org>

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
