### PR TITLE
Add option to enable nested virtualization on EC2 agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ def slaveTemplateUsEast1Parameters = [
   metadataTokensRequired:        true, // `true` enforces IMDSv2 only (over IMDSv1), an important AWS security best practice
   metadataHopsLimit:             1,
   enclaveEnabled:                true, // launches the instance with Nitro Enclave enabled
+  nestedVirtualizationEnabled:   false, // launches the instance with nested virtualization enabled (set via setter, see below)
   minimumNumberOfInstances:      0,
   minimumNumberOfSpareInstances: 0,
   maxTotalUses:                  -1,
@@ -463,6 +464,9 @@ SlaveTemplate slaveTemplateUsEast1 = new SlaveTemplate(
   slaveTemplateUsEast1Parameters.metadataHopsLimit,
   slaveTemplateUsEast1Parameters.enclaveEnabled,
 )
+
+// Optional settings exposed as setters rather than constructor arguments
+slaveTemplateUsEast1.setNestedVirtualizationEnabled(slaveTemplateUsEast1Parameters.nestedVirtualizationEnabled)
 
 // https://javadoc.jenkins.io/plugin/ec2/hudson/plugins/ec2/EC2Cloud.html
 EC2Cloud ec2Cloud = new EC2Cloud(

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,24 @@ THE SOFTWARE.
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!--
+        Override the aws-java-sdk2 plugin (which bundles the AWS SDK v2) to a release providing
+        AWS SDK >= 2.42.33. That version adds CpuOptionsRequest#nestedVirtualization, required to
+        launch instances with nested virtualization enabled. This release still targets Jenkins
+        core 2.479.1, so the plugin baseline does not need to change. These direct entries take
+        precedence over the version managed by the imported bom and can be dropped once the Jenkins
+        BOM baseline ships this aws-java-sdk2 version.
+      -->
+      <dependency>
+        <groupId>io.jenkins.plugins.aws-java-sdk2</groupId>
+        <artifactId>aws-java-sdk2-core</artifactId>
+        <version>2.42.33-70.vd69c0763fa_60</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins.aws-java-sdk2</groupId>
+        <artifactId>aws-java-sdk2-ec2</artifactId>
+        <version>2.42.33-70.vd69c0763fa_60</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -89,6 +89,7 @@ import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.BlockDeviceMapping;
 import software.amazon.awssdk.services.ec2.model.CancelSpotInstanceRequestsRequest;
+import software.amazon.awssdk.services.ec2.model.CpuOptionsRequest;
 import software.amazon.awssdk.services.ec2.model.CreateTagsRequest;
 import software.amazon.awssdk.services.ec2.model.CreditSpecificationRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeImagesRequest;
@@ -119,6 +120,7 @@ import software.amazon.awssdk.services.ec2.model.InstanceType;
 import software.amazon.awssdk.services.ec2.model.InstanceTypeHypervisor;
 import software.amazon.awssdk.services.ec2.model.InstanceTypeInfo;
 import software.amazon.awssdk.services.ec2.model.MarketType;
+import software.amazon.awssdk.services.ec2.model.NestedVirtualizationSpecification;
 import software.amazon.awssdk.services.ec2.model.NitroEnclavesSupport;
 import software.amazon.awssdk.services.ec2.model.Placement;
 import software.amazon.awssdk.services.ec2.model.RequestSpotInstancesRequest;
@@ -253,6 +255,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     private Integer metadataHopsLimit;
 
     private Boolean enclaveEnabled;
+
+    private Boolean nestedVirtualizationEnabled;
 
     private transient /* almost final */ Set<LabelAtom> labelSet;
 
@@ -2074,6 +2078,15 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return enclaveEnabled;
     }
 
+    public boolean getNestedVirtualizationEnabled() {
+        return nestedVirtualizationEnabled != null && nestedVirtualizationEnabled;
+    }
+
+    @DataBoundSetter
+    public void setNestedVirtualizationEnabled(boolean nestedVirtualizationEnabled) {
+        this.nestedVirtualizationEnabled = nestedVirtualizationEnabled;
+    }
+
     public DescribableList<NodeProperty<?>, NodePropertyDescriptor> getNodeProperties() {
         return Objects.requireNonNull(nodeProperties);
     }
@@ -2321,6 +2334,13 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             EnclaveOptionsRequest.Builder enclaveOptionsRequestBuilder =
                     EnclaveOptionsRequest.builder().enabled(true);
             riRequestBuilder.enclaveOptions(enclaveOptionsRequestBuilder.build());
+        }
+
+        if (getNestedVirtualizationEnabled()) {
+            riRequestBuilder.cpuOptions(CpuOptionsRequest.builder()
+                    .nestedVirtualization(NestedVirtualizationSpecification.ENABLED)
+                    .build());
+            logProvisionInfo("Setting CPU Options: NestedVirtualization=enabled");
         }
 
         HashMap<RunInstancesRequest, List<Filter>> ret = new HashMap<>();
@@ -3741,6 +3761,16 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                         return FormValidation.error("The selected instance type does not support AWS Nitro Enclaves.");
                     }
                 }
+            }
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckNestedVirtualizationEnabled(@QueryParameter boolean nestedVirtualizationEnabled) {
+            if (nestedVirtualizationEnabled) {
+                return FormValidation.warning(
+                        "Nested virtualization is only supported on specific instance families (for example C8i, M8i, R8i)"
+                                + " and requires an AMI with a compatible L1 hypervisor (KVM or Hyper-V)."
+                                + " Enabling it automatically disables Virtual Secure Mode (VSM).");
             }
             return FormValidation.ok();
         }

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -251,6 +251,10 @@ THE SOFTWARE.
       <f:checkbox default="false"/>
     </f:entry>
 
+    <f:entry title="${%Nested Virtualization Enabled}" field="nestedVirtualizationEnabled">
+      <f:checkbox default="false"/>
+    </f:entry>
+
   </f:advanced>
 
   <f:entry title="">

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-nestedVirtualizationEnabled.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-nestedVirtualizationEnabled.html
@@ -1,0 +1,18 @@
+<div>
+  <p>
+    If checked, the instance is launched with nested virtualization enabled, allowing it to run a
+    hypervisor (KVM or Hyper-V) and start nested virtual machines.
+  </p>
+  <p>
+    Nested virtualization is only supported on specific instance families (for example C8i, M8i and
+    R8i) and requires an AMI with a compatible L1 hypervisor. Leave it unchecked for instance types
+    or AMIs that do not support it. Enabling nested virtualization automatically disables Virtual
+    Secure Mode (VSM).
+  </p>
+  <p>
+    See
+    <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-ec2-nested-virtualization.html" rel="noopener noreferrer" target="_blank">
+      Use nested virtualization to run hypervisors in Amazon EC2 instances</a>
+    for details.
+  </p>
+</div>

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -74,6 +74,7 @@ import software.amazon.awssdk.services.ec2.model.InstanceNetworkInterfaceSpecifi
 import software.amazon.awssdk.services.ec2.model.InstanceStateName;
 import software.amazon.awssdk.services.ec2.model.InstanceType;
 import software.amazon.awssdk.services.ec2.model.KeyPairInfo;
+import software.amazon.awssdk.services.ec2.model.NestedVirtualizationSpecification;
 import software.amazon.awssdk.services.ec2.model.RequestSpotInstancesRequest;
 import software.amazon.awssdk.services.ec2.model.Reservation;
 import software.amazon.awssdk.services.ec2.model.RunInstancesRequest;
@@ -1608,6 +1609,130 @@ class SlaveTemplateTest {
         RunInstancesRequest actualRequest = riRequestCaptor.getValue();
         EnclaveOptionsRequest enclaveOptionsRequest = actualRequest.enclaveOptions();
         assertEquals(Boolean.TRUE, enclaveOptionsRequest.enabled());
+    }
+
+    @Test
+    void provisionOnDemandWithNestedVirtualizationEnabled() throws Exception {
+        SlaveTemplate template = new SlaveTemplate(
+                TEST_AMI,
+                TEST_ZONE,
+                TEST_SPOT_CFG,
+                TEST_SEC_GROUPS,
+                TEST_REMOTE_FS,
+                TEST_INSTANCE_TYPE.toString(),
+                TEST_EBSO,
+                TEST_LABEL,
+                Node.Mode.NORMAL,
+                "",
+                "bar",
+                "bbb",
+                "aaa",
+                "10",
+                "fff",
+                null,
+                "java",
+                "-Xmx1g",
+                false,
+                "subnet 456",
+                null,
+                null,
+                0,
+                0,
+                null,
+                "",
+                true,
+                false,
+                "",
+                AssociateIPStrategy.SUBNET,
+                "",
+                true,
+                false,
+                false,
+                ConnectionStrategy.PUBLIC_IP,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                null,
+                true,
+                null,
+                true,
+                false);
+        template.setNestedVirtualizationEnabled(true);
+
+        Ec2Client mockedEC2 = setupTestForProvisioning(template);
+
+        ArgumentCaptor<RunInstancesRequest> riRequestCaptor = ArgumentCaptor.forClass(RunInstancesRequest.class);
+
+        template.provision(2, EnumSet.noneOf(ProvisionOptions.class));
+        verify(mockedEC2).runInstances(riRequestCaptor.capture());
+
+        RunInstancesRequest actualRequest = riRequestCaptor.getValue();
+        assertNotNull(actualRequest.cpuOptions());
+        assertEquals(
+                NestedVirtualizationSpecification.ENABLED,
+                actualRequest.cpuOptions().nestedVirtualization());
+    }
+
+    @Test
+    void provisionOnDemandWithoutNestedVirtualizationEnabled() throws Exception {
+        SlaveTemplate template = new SlaveTemplate(
+                TEST_AMI,
+                TEST_ZONE,
+                TEST_SPOT_CFG,
+                TEST_SEC_GROUPS,
+                TEST_REMOTE_FS,
+                TEST_INSTANCE_TYPE.toString(),
+                TEST_EBSO,
+                TEST_LABEL,
+                Node.Mode.NORMAL,
+                "",
+                "bar",
+                "bbb",
+                "aaa",
+                "10",
+                "fff",
+                null,
+                "java",
+                "-Xmx1g",
+                false,
+                "subnet 456",
+                null,
+                null,
+                0,
+                0,
+                null,
+                "",
+                true,
+                false,
+                "",
+                AssociateIPStrategy.SUBNET,
+                "",
+                true,
+                false,
+                false,
+                ConnectionStrategy.PUBLIC_IP,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                null,
+                true,
+                null,
+                true,
+                false);
+
+        Ec2Client mockedEC2 = setupTestForProvisioning(template);
+
+        ArgumentCaptor<RunInstancesRequest> riRequestCaptor = ArgumentCaptor.forClass(RunInstancesRequest.class);
+
+        template.provision(2, EnumSet.noneOf(ProvisionOptions.class));
+        verify(mockedEC2).runInstances(riRequestCaptor.capture());
+
+        RunInstancesRequest actualRequest = riRequestCaptor.getValue();
+        assertNull(actualRequest.cpuOptions());
     }
 
     @Test


### PR DESCRIPTION
## What

Adds a **Nested Virtualization Enabled** option to the EC2 agent template. When enabled, instances are launched with `CpuOptions.NestedVirtualization=ENABLED`, allowing the agent to run a hypervisor (KVM or Hyper-V) and start nested VMs.

Closes #1996

## Why

AWS [introduced nested virtualization](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-ec2-nested-virtualization.html) on non-bare-metal instance families (C8i, M8i, R8i). It is opt-in per instance at launch and was not exposed by the plugin. The required SDK support landed in aws-java-sdk2-plugin (AWS SDK 2.42.33), as discussed in #1996.

## How

- `SlaveTemplate` gains a `nestedVirtualizationEnabled` field, exposed via `@DataBoundSetter` (consistent with other recent optional fields rather than the legacy constructor).
- `makeRunInstancesRequestAndFilters` sets `cpuOptions(NestedVirtualization=ENABLED)` when the option is on. Scope matches the existing `enclaveEnabled` precedent (on-demand `RunInstances`).
- UI checkbox + help text under the template's Advanced section, plus a Config-as-Code-friendly getter/setter (round-trips automatically; `false` is the default so existing configs are unaffected).
- An informational form-validation note reminds users that nested virtualization needs a supported instance family and a compatible AMI/hypervisor.

## Dependency change — open question for maintainers

The feature needs **AWS SDK >= 2.42.33** (`CpuOptionsRequest#nestedVirtualization`), but the Jenkins BOM on the current baseline (`2.479`) still pins aws-java-sdk2 to an older SDK. I took the **surgical route**: an explicit `dependencyManagement` override of `aws-java-sdk2-core`/`aws-java-sdk2-ec2` to `2.42.33-70.vd69c0763fa_60`. That release still declares `requiredCore: 2.479.1`, so **this does not raise the plugin's minimum Jenkins version**.

The alternative would be a full **BOM + baseline bump** (the first baseline whose BOM ships this SDK is `2.528`), which raises the minimum core. I went with the override to keep the change minimal, but I'm happy to switch to a BOM/baseline bump if that's the preferred direction. The override is commented and easy to drop once the BOM baseline catches up.

## Testing

**Automated** — `mvn clean verify` passes (327 tests, 0 failures, spotbugs + spotless clean, `.hpi` builds). Added two unit tests asserting the CPU option is set when enabled and absent when disabled.

**Manual** — built the `.hpi`, deployed to a Jenkins instance, configured an agent template with the option enabled, and ran a pipeline on the provisioned agent:

```groovy
stage('Check virt') {
  steps {
    sh '''
      grep -cE 'vmx|svm' /proc/cpuinfo && echo 'VMX/SVM flags present' || echo 'ERROR: no virt flags found'
      lsmod | grep kvm || echo 'ERROR: KVM modules not loaded'
      ls -la /dev/kvm || echo 'ERROR: /dev/kvm not present'
      /usr/sbin/kvm-ok
    '''
  }
}
```

The provisioned agent showed the VMX/SVM flags, loaded KVM modules, a present `/dev/kvm`, and `kvm-ok` reporting that hardware virtualization is usable. With the option disabled, the same template provisions instances without nested virtualization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
