### PR TITLE
Apply tag specifications to spot instances on request

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -2694,6 +2694,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             RequestSpotLaunchSpecification.Builder launchSpecificationBuilder =
                     RequestSpotLaunchSpecification.builder();
 
+            // Build tags early so they can be included in the launch specification
+            HashSet<Tag> instTags = buildTags(EC2Cloud.EC2_SLAVE_TYPE_SPOT);
+
             launchSpecificationBuilder.imageId(imageId);
             launchSpecificationBuilder.instanceType(type);
             launchSpecificationBuilder.ebsOptimized(ebsOptimized);
@@ -2752,8 +2755,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             netBuilder.deviceIndex(0);
             launchSpecificationBuilder.networkInterfaces(netBuilder.build());
 
-            HashSet<Tag> instTags = buildTags(EC2Cloud.EC2_SLAVE_TYPE_SPOT);
-
             if (StringUtils.isNotBlank(getIamInstanceProfile())) {
                 launchSpecificationBuilder.iamInstanceProfile(IamInstanceProfileSpecification.builder()
                         .arn(getIamInstanceProfile())
@@ -2763,6 +2764,16 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             launchSpecificationBuilder.blockDeviceMappings(getBlockDeviceMappings(image));
 
             spotRequestBuilder.launchSpecification(launchSpecificationBuilder.build());
+
+            // Add tag specifications to automatically tag the instance when fulfilled
+            // This ensures tags are applied before boot delay, enabling external automation
+            if (!instTags.isEmpty()) {
+                TagSpecification tagSpec = TagSpecification.builder()
+                        .resourceType("instance")
+                        .tags(instTags)
+                        .build();
+                spotRequestBuilder.tagSpecifications(tagSpec);
+            }
 
             if (getSpotBlockReservationDuration() != 0) {
                 spotRequestBuilder.blockDurationMinutes(getSpotBlockReservationDuration() * 60);


### PR DESCRIPTION
Moves tag building earlier and adds tagSpecifications to the spot request to ensure tags are applied immediately when the spot instance is fulfilled, before any boot delay. This enables external automation to properly detect and act on newly launched spot instances.

Fixes #1926

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
