### PR TITLE
Only reconnect offline agent if it is not idle

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -317,7 +317,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
      */
     private void attemptReconnectIfOffline(EC2Computer computer) {
         try {
-            if (computer.getState() == InstanceState.RUNNING && computer.isOffline()) {
+            if (computer.isOffline() && !computer.isIdle() && computer.getState() == InstanceState.RUNNING) {
                 LOGGER.warning("EC2Computer " + computer.getName() + " is offline");
                 if (!computer.isConnecting()) {
                     // Keep retrying connection to agent until the job times out

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -196,7 +196,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                     || (slaveTemplate != null && slaveTemplate.stopOnTerminate)
                             && (InstanceState.STOPPED.equals(state) || InstanceState.STOPPING.equals(state))) {
                 if (computer.isOnline()) {
-                    LOGGER.info("External Stop of " + computer.getName() + " detected - disconnecting. instance status"
+                    LOGGER.info("External Stop of " + computer.getName() + " detected - disconnecting. instance status "
                             + state);
                     try {
                         Queue.withLock(() -> computer.disconnect(null));

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -680,11 +680,11 @@ class EC2RetentionStrategyTest {
         logging.capture(5);
 
         /*
-        Our goal here it to call the EC2RetentionStrategy#check, which invokes the EC2AbstractSlave#idleTimeout.
+        Our goal here is to call the EC2RetentionStrategy#check, which invokes the EC2AbstractSlave#idleTimeout.
         To make it possible, the Computer#getIdleStartMilliseconds() should return a value that is matches,
         (Current time - IdleStartTime) > Idle Termination Minutes.
 
-        The mock machinery doesn't allow us to cause old value to be returned for `Computer#getIdleStartMilliseconds()`,
+        The mock based setup doesn't allow us to force old value to be returned for `Computer#getIdleStartMilliseconds()`,
         so we bump the - Current Time - value to +5min1sec to simulate the same behavior.
         * */
         Instant fiveMinutesFromNow = Instant.now().plus(Duration.ofMinutes(5));

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.*;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -710,9 +711,7 @@ class EC2RetentionStrategyTest {
 
         // Also assert there was no reconnection attempt logs.
         assertThat(
-                "No reconnection logs",
-                logging.getMessages().stream().noneMatch(m -> m.contains("Attempting to reconnect")),
-                equalTo(true));
+                "No reconnection logs", logging.getMessages(), not(hasItem(containsString("Attempting to reconnect"))));
     }
 
     /**

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -673,7 +673,7 @@ class EC2RetentionStrategyTest {
                                 "offline but not connecting, will check if it should be terminated because of the idle time configured")));
     }
 
-    @Issue("jenkinsci/ec2-plugin#1752")
+    @Issue("https://github.com/jenkinsci/ec2-plugin/issues/1752")
     @Test
     void testDoNotReconnectOfflineIdleComputer() throws Exception {
         logging.record(hudson.plugins.ec2.EC2RetentionStrategy.class, Level.FINE);
@@ -685,8 +685,8 @@ class EC2RetentionStrategyTest {
         (Current time - IdleStartTime) > Idle Termination Minutes.
 
         The mock based setup doesn't allow us to force old value to be returned for `Computer#getIdleStartMilliseconds()`,
-        so we bump the - Current Time - value to +5min1sec to simulate the same behavior.
-        * */
+        so we bump the Current Time value to +5min1sec to simulate the same behavior.
+        */
         Instant fiveMinutesFromNow = Instant.now().plus(Duration.ofMinutes(5));
         long nextCheckAfter = fiveMinutesFromNow.toEpochMilli();
         Clock clock = Clock.fixed(fiveMinutesFromNow.plusSeconds(1), zoneId);

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -46,6 +47,7 @@ import jenkins.model.Jenkins;
 import jenkins.util.NonLocalizable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
@@ -669,6 +671,48 @@ class EC2RetentionStrategyTest {
                 hasItem(
                         containsString(
                                 "offline but not connecting, will check if it should be terminated because of the idle time configured")));
+    }
+
+    @Issue("jenkinsci/ec2-plugin#1752")
+    @Test
+    void testDoNotReconnectOfflineIdleComputer() throws Exception {
+        logging.record(hudson.plugins.ec2.EC2RetentionStrategy.class, Level.FINE);
+        logging.capture(5);
+
+        /*
+        Our goal here it to call the EC2RetentionStrategy#check, which invokes the EC2AbstractSlave#idleTimeout.
+        To make it possible, the Computer#getIdleStartMilliseconds() should return a value that is matches,
+        (Current time - IdleStartTime) > Idle Termination Minutes.
+
+        The mock machinery doesn't allow us to cause old value to be returned for `Computer#getIdleStartMilliseconds()`,
+        so we bump the - Current Time - value to +5min1sec to simulate the same behavior.
+        * */
+        Instant fiveMinutesFromNow = Instant.now().plus(Duration.ofMinutes(5));
+        long nextCheckAfter = fiveMinutesFromNow.toEpochMilli();
+        Clock clock = Clock.fixed(fiveMinutesFromNow.plusSeconds(1), zoneId);
+        EC2RetentionStrategy rs = new EC2RetentionStrategy("1", clock, nextCheckAfter);
+
+        // mock computer marked offline
+        EC2Computer computer = computerWithUpTime(0, 0, null, false);
+        computer.setTemporarilyOffline(true, OfflineCause.create(new NonLocalizable("test offline")));
+
+        // run the EC2RetentionStrategy#check
+        rs.check(computer);
+
+        // assert log line that appears just before the EC2AbstractSlave#idleTimeout call
+        assertThat(logging.getMessages(), hasItem(containsString("Idle timeout of " + computer.getName() + " after")));
+
+        // The idle timeout still expires and the instance is idle-terminated.
+        assertThat(
+                "The mock sets `idleTimeoutCalled` to true, if EC2AbstractSlave#idleTimeout is called",
+                idleTimeoutCalled.get(),
+                is(true));
+
+        // Also assert there was no reconnection attempt logs.
+        assertThat(
+                "No reconnection logs",
+                logging.getMessages().stream().noneMatch(m -> m.contains("Attempting to reconnect")),
+                equalTo(true));
     }
 
     /**


### PR DESCRIPTION
Fixes #1752, checked the reconnection logic introduced in #1142 that it was intended for reconnecting busy agent that faced  intermittent network failure.

Re-ordered the conditional logic to do the local check before making AWS API call in `computer.getState()`.

Previously such agents would never hit the idle termination because the `Computer#connect` would bump its connect time, thus never allowing to expire the idle timeout (described in https://github.com/jenkinsci/ec2-plugin/issues/1752#issuecomment-4932349224)

I believe it will also address the agents not being deleted during ssh key failure https://github.com/jenkinsci/ec2-plugin/issues/1990#issuecomment-4867371039. Note: this PR doesn't address the ssh key failure, but just that agent deletion would now start to happen when that issue is faced.

**Testing**

**Automated Testing**

Added a new unit test that using the existing machinery.

**Manual Testing**

* Idle agent gets deleted
   * kept the `Maximum Total Uses` to the default `-1` so the agent is not deleted after build is done.
   * configured `Idle termination time` to `3`
   * triggered simple build `node('ec2') { sh 'date' }`
   * marked the agent offline manually
   * after 3 minutes agent is deleted.
      <details><summary>logs</summary>

      ```
        2026-07-10 07:51:33.792+0000 [id=213]   FINE    h.p.ec2.EC2RetentionStrategy#taskAccepted: maxTotalUses set to unlimited (-1) for agent i-008505dcc737b4cec
        2026-07-10 07:51:48.908+0000 [id=88]    FINER   h.p.e.EC2Cloud$EC2ConnectionUpdater#doRun: Checking EC2 Connection on: ec2
        2026-07-10 07:52:48.909+0000 [id=89]    FINER   h.p.e.EC2Cloud$EC2ConnectionUpdater#doRun: Checking EC2 Connection on: ec2
        2026-07-10 07:52:49.319+0000 [id=250]   FINE    h.p.ec2.EC2RetentionStrategy#internalCheck: Computer i-008505dcc737b4cec offline but not connecting, will check if it should be terminated because of the idle time configured
        2026-07-10 07:53:44.171+0000 [id=254]   FINE    hudson.model.AsyncPeriodicWork#lambda$doRun$0: Started EC2 alive agents monitor
        2026-07-10 07:53:45.055+0000 [id=254]   FINE    hudson.model.AsyncPeriodicWork#lambda$doRun$0: Finished EC2 alive agents monitor. 879 ms
        2026-07-10 07:53:48.803+0000 [id=250]   FINE    h.p.ec2.EC2RetentionStrategy#internalCheck: Computer i-008505dcc737b4cec offline but not connecting, will check if it should be terminated because of the idle time configured
        2026-07-10 07:53:48.913+0000 [id=90]    FINER   h.p.e.EC2Cloud$EC2ConnectionUpdater#doRun: Checking EC2 Connection on: ec2
        2026-07-10 07:54:48.912+0000 [id=98]    FINER   h.p.e.EC2Cloud$EC2ConnectionUpdater#doRun: Checking EC2 Connection on: ec2
        2026-07-10 07:54:49.351+0000 [id=250]   FINE    h.p.ec2.EC2RetentionStrategy#internalCheck: Computer i-008505dcc737b4cec offline but not connecting, will check if it should be terminated because of the idle time configured
        2026-07-10 07:55:48.913+0000 [id=97]    FINER   h.p.e.EC2Cloud$EC2ConnectionUpdater#doRun: Checking EC2 Connection on: ec2
        2026-07-10 07:55:49.374+0000 [id=250]   FINE    h.p.ec2.EC2RetentionStrategy#internalCheck: Computer i-008505dcc737b4cec offline but not connecting, will check if it should be terminated because of the idle time configured
        2026-07-10 07:55:49.375+0000 [id=250]   INFO    h.p.ec2.EC2RetentionStrategy#internalCheck: Idle timeout of EC2 (ec2) - ec2-agent (i-008505dcc737b4cec) after 3 idle minutes, instance statusRUNNING
        2026-07-10 07:55:49.375+0000 [id=250]   INFO    h.p.ec2.EC2RetentionStrategy#internalCheck: Idle timeout of EC2 (ec2) - ec2-agent (i-008505dcc737b4cec) after 3 idle minutes, instance statusRUNNING
        2026-07-10 07:55:49.377+0000 [id=250]   INFO    h.plugins.ec2.EC2AbstractSlave#idleTimeout: EC2 instance idle time expired: i-008505dcc737b4cec
        2026-07-10 07:55:49.377+0000 [id=250]   INFO    h.plugins.ec2.EC2AbstractSlave#idleTimeout: EC2 instance idle time expired: i-008505dcc737b4cec
        2026-07-10 07:55:50.262+0000 [id=259]   INFO    h.plugins.ec2.EC2OndemandSlave#lambda$terminate$0: Terminated EC2 instance (terminated): i-008505dcc737b4cec
        2026-07-10 07:55:50.262+0000 [id=259]   INFO    h.plugins.ec2.EC2OndemandSlave#lambda$terminate$0: Terminated EC2 instance (terminated): i-008505dcc737b4cec
        2026-07-10 07:55:50.274+0000 [id=259]   INFO    h.plugins.ec2.EC2OndemandSlave#lambda$terminate$0: Removed EC2 instance from jenkins controller: i-008505dcc737b4cec
        2026-07-10 07:55:50.274+0000 [id=259]   INFO    h.plugins.ec2.EC2OndemandSlave#lambda$terminate$0: Removed EC2 instance from jenkins controller: i-008505dcc737b4cec
        2026-07-10 07:55:50.485+0000 [id=231]   INFO    h.r.SynchronousCommandTransport$ReaderThread#run: I/O error in channel EC2 (ec2) - ec2-agent (i-008505dcc737b4cec)
        java.io.EOFException
                at java.base/java.io.ObjectInputStream$PeekInputStream.readFully(ObjectInputStream.java:2933)
                at java.base/java.io.ObjectInputStream$BlockDataInputStream.readShort(ObjectInputStream.java:3428)
                at java.base/java.io.ObjectInputStream.readStreamHeader(ObjectInputStream.java:985)
                at java.base/java.io.ObjectInputStream.<init>(ObjectInputStream.java:416)
                at hudson.remoting.ObjectInputStreamEx.<init>(ObjectInputStreamEx.java:50)
                at hudson.remoting.Command.readFrom(Command.java:141)
                at hudson.remoting.Command.readFrom(Command.java:127)
                at hudson.remoting.AbstractSynchronousByteArrayCommandTransport.read(AbstractSynchronousByteArrayCommandTransport.java:35)
                at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:62)
        Caused: java.io.IOException: Unexpected termination of the channel
                at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:80)                

      ```
      </details>

* Busy agent facing intermittent network issue is reconnected (behaves as before)
  * same setup was above, but changed the pipeline to  `node('ec2') { sh 'sleep 240' }`
  * while the build was in progress, went to the ssh console of the VM (amazon linux), and restarted the ssh service with a 1 minute delay.
     ```
     sudo dnf install iptables -y
     sudo nohup bash -c 'iptables -I INPUT -p tcp --dport 22 -j DROP; sleep 120; iptables -D INPUT -p tcp --dport 22 -j DROP' > /dev/null 2>&1 &
     ```
   * jenkins showed connection drop logs,
     <details><summary>logs</summary>

     ```
     2026-07-10 08:16:48.904+0000 [id=99]    FINER   h.p.e.EC2Cloud$EC2ConnectionUpdater#doRun: Checking EC2 Connection on: ec2
      2026-07-10 08:17:03.616+0000 [id=314]   WARNING o.a.s.c.u.logging.LoggingUtils#warn: exceptionCaught(ClientSessionImpl[ec2-user@/98.92.160.168:22])[state=Opened] IOException: Operation timed out
      2026-07-10 08:17:03.619+0000 [id=317]   INFO    h.r.SynchronousCommandTransport$ReaderThread#run: I/O error in channel EC2 (ec2) - ec2-agent (i-085c66e880d34e8a6)
      java.io.EOFException
              at java.base/java.io.ObjectInputStream$PeekInputStream.readFully(ObjectInputStream.java:2933)
              at java.base/java.io.ObjectInputStream$BlockDataInputStream.readShort(ObjectInputStream.java:3428)
              at java.base/java.io.ObjectInputStream.readStreamHeader(ObjectInputStream.java:985)
              at java.base/java.io.ObjectInputStream.<init>(ObjectInputStream.java:416)
              at hudson.remoting.ObjectInputStreamEx.<init>(ObjectInputStreamEx.java:50)
              at hudson.remoting.Command.readFrom(Command.java:141)
              at hudson.remoting.Command.readFrom(Command.java:127)
              at hudson.remoting.AbstractSynchronousByteArrayCommandTransport.read(AbstractSynchronousByteArrayCommandTransport.java:35)
              at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:62)
      Caused: java.io.IOException: Unexpected termination of the channel
              at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:80)
      2026-07-10 08:17:48.907+0000 [id=89]    FINER   h.p.e.EC2Cloud$EC2ConnectionUpdater#doRun: Checking EC2 Connection on: ec2
      2026-07-10 08:17:49.453+0000 [id=415]   WARNING h.p.ec2.EC2RetentionStrategy#attemptReconnectIfOffline: EC2Computer EC2 (ec2) - ec2-agent (i-085c66e880d34e8a6) is offline
      2026-07-10 08:17:49.453+0000 [id=415]   WARNING h.p.ec2.EC2RetentionStrategy#attemptReconnectIfOffline: EC2Computer EC2 (ec2) - ec2-agent (i-085c66e880d34e8a6) is offline
      2026-07-10 08:17:49.454+0000 [id=415]   WARNING h.p.ec2.EC2RetentionStrategy#attemptReconnectIfOffline: Attempting to reconnect EC2Computer EC2 (ec2) - ec2-agent (i-085c66e880d34e8a6)
      2026-07-10 08:17:49.454+0000 [id=415]   WARNING h.p.ec2.EC2RetentionStrategy#attemptReconnectIfOffline: Attempting to reconnect EC2Computer EC2 (ec2) - ec2-agent (i-085c66e880d34e8a6)
      2026-07-10 08:17:49.455+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: Launching instance: i-085c66e880d34e8a6
      2026-07-10 08:17:49.455+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: Launching instance: i-085c66e880d34e8a6
      2026-07-10 08:17:49.456+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: bootstrap()
      2026-07-10 08:17:49.456+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: bootstrap()
      2026-07-10 08:17:49.456+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: Getting keypair...
      2026-07-10 08:17:49.456+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: Getting keypair...
      2026-07-10 08:17:49.456+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: Using private key gbhat (SHA-1 fingerprint 6e:7c:32:94:5f:c8:f1:92:b4:b0:68:d1:ef:ef:35:1c:0c:a6:e0:82)
      2026-07-10 08:17:49.456+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: Using private key gbhat (SHA-1 fingerprint 6e:7c:32:94:5f:c8:f1:92:b4:b0:68:d1:ef:ef:35:1c:0c:a6:e0:82)
      2026-07-10 08:17:49.456+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: Authenticating as ec2-user
      2026-07-10 08:17:49.456+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: Authenticating as ec2-user
      2026-07-10 08:17:49.755+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: Connecting to 98.92.160.168 on port 22, with timeout 10000.
      2026-07-10 08:17:49.755+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: Connecting to 98.92.160.168 on port 22, with timeout 10000.
      2026-07-10 08:17:49.978+0000 [id=314]   FINE    h.p.e.u.SSHClientManager$ClientHolder$1#sessionNegotiationOptionsCreated: Reordered host key algorithms for session: ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp256,sk-ecdsa-sha2-nistp256@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-512,rsa-sha2-256,ssh-rsa
      2026-07-10 08:17:49.979+0000 [id=416]   INFO    hudson.plugins.ec2.EC2Cloud#log: Connected via SSH.
      ```
      </details>

  * Build succeeded
    <details><summary>build log</summary>

    ```
    Started by user unknown or anonymous
    [Pipeline] Start of Pipeline
    [Pipeline] node
    Still waiting to schedule task
    ‘Jenkins’ doesn’t have label ‘ec2’
    Running on EC2 (ec2) - ec2-agent (i-085c66e880d34e8a6) in /home/ec2-user/workspace/p
    [Pipeline] {
    [Pipeline] sh
    + sleep 240
    Cannot contact EC2 (ec2) - ec2-agent (i-085c66e880d34e8a6): java.lang.InterruptedException
    [Pipeline] }
    [Pipeline] // node
    [Pipeline] End of Pipeline
    Finished: SUCCESS
    ```
    </details>
  * This online agent becomes idle and gets deleted as expected too. (same behavior as before)
     <details><summary>logs</summary>

     ```
      2026-07-10 08:20:48.907+0000 [id=97]    FINER   h.p.e.EC2Cloud$EC2ConnectionUpdater#doRun: Checking EC2 Connection on: ec2
      ^[[B2026-07-10 08:21:48.907+0000 [id=90]        FINER   h.p.e.EC2Cloud$EC2ConnectionUpdater#doRun: Checking EC2 Connection on: ec2
      2026-07-10 08:21:49.397+0000 [id=415]   INFO    h.p.ec2.EC2RetentionStrategy#internalCheck: Idle timeout of EC2 (ec2) - ec2-agent (i-085c66e880d34e8a6) after 3 idle minutes, instance statusRUNNING
      2026-07-10 08:21:49.397+0000 [id=415]   INFO    h.p.ec2.EC2RetentionStrategy#internalCheck: Idle timeout of EC2 (ec2) - ec2-agent (i-085c66e880d34e8a6) after 3 idle minutes, instance statusRUNNING
      2026-07-10 08:21:49.397+0000 [id=415]   INFO    h.plugins.ec2.EC2AbstractSlave#idleTimeout: EC2 instance idle time expired: i-085c66e880d34e8a6
      2026-07-10 08:21:49.397+0000 [id=415]   INFO    h.plugins.ec2.EC2AbstractSlave#idleTimeout: EC2 instance idle time expired: i-085c66e880d34e8a6
      2026-07-10 08:21:50.318+0000 [id=451]   INFO    h.plugins.ec2.EC2OndemandSlave#lambda$terminate$0: Terminated EC2 instance (terminated): i-085c66e880d34e8a6
      2026-07-10 08:21:50.318+0000 [id=451]   INFO    h.plugins.ec2.EC2OndemandSlave#lambda$terminate$0: Terminated EC2 instance (terminated): i-085c66e880d34e8a6
      2026-07-10 08:21:50.330+0000 [id=451]   INFO    h.plugins.ec2.EC2OndemandSlave#lambda$terminate$0: Removed EC2 instance from jenkins controller: i-085c66e880d34e8a6
      2026-07-10 08:21:50.330+0000 [id=451]   INFO    h.plugins.ec2.EC2OndemandSlave#lambda$terminate$0: Removed EC2 instance from jenkins controller: i-085c66e880d34e8a6
     ```
     </details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed