### PR TITLE
Remove Commons Lang 2 usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@ THE SOFTWARE.
     <hpi.compatibleSinceVersion>1885</hpi.compatibleSinceVersion>
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/hudson/plugins/ec2/CloudHelper.java
+++ b/src/main/java/hudson/plugins/ec2/CloudHelper.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
-import org.apache.commons.lang.StringUtils;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.ec2.Ec2Client;
@@ -46,7 +45,7 @@ final class CloudHelper {
 
     @CheckForNull
     static Instance getInstance(String instanceId, EC2Cloud cloud) throws SdkException {
-        if (StringUtils.isEmpty(instanceId) || cloud == null) {
+        if (instanceId == null || instanceId.isEmpty() || cloud == null) {
             return null;
         }
 

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -50,7 +50,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.verb.POST;
@@ -1124,7 +1123,7 @@ public abstract class EC2AbstractSlave extends Slave {
     public static ListBoxModel fillZoneItems(AwsCredentialsProvider credentialsProvider, String region) {
         ListBoxModel model = new ListBoxModel();
 
-        if (!StringUtils.isEmpty(region)) {
+        if (region != null && !region.isEmpty()) {
             Ec2Client client =
                     AmazonEC2Factory.getInstance().connect(credentialsProvider, EC2Cloud.parseRegion(region), null);
             DescribeAvailabilityZonesResponse zones = client.describeAvailabilityZones();

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -94,7 +94,6 @@ import java.util.regex.Pattern;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.util.Timer;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -924,8 +923,8 @@ public class EC2Cloud extends Cloud {
                 if (template != null) {
                     List<Tag> instanceTags = sir.tags();
                     for (Tag tag : instanceTags) {
-                        if (StringUtils.equals(tag.key(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE)
-                                && StringUtils.equals(
+                        if (Objects.equals(tag.key(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE)
+                                && Objects.equals(
                                         tag.value(), getSlaveTypeTagValue(EC2_SLAVE_TYPE_SPOT, template.description))
                                 && sir.launchSpecification().imageId().equals(template.getAmi())) {
 
@@ -988,16 +987,16 @@ public class EC2Cloud extends Cloud {
 
     private boolean isEc2ProvisionedAmiSlave(List<Tag> tags, String description) {
         for (Tag tag : tags) {
-            if (StringUtils.equals(tag.key(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE)) {
+            if (Objects.equals(tag.key(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE)) {
                 if (description == null) {
                     return true;
-                } else if (StringUtils.equals(tag.value(), EC2Cloud.EC2_SLAVE_TYPE_DEMAND)
-                        || StringUtils.equals(tag.value(), EC2Cloud.EC2_SLAVE_TYPE_SPOT)) {
+                } else if (Objects.equals(tag.value(), EC2Cloud.EC2_SLAVE_TYPE_DEMAND)
+                        || Objects.equals(tag.value(), EC2Cloud.EC2_SLAVE_TYPE_SPOT)) {
                     // To handle cases where description is null and also upgrade cases for existing agent nodes.
                     return true;
-                } else if (StringUtils.equals(
+                } else if (Objects.equals(
                                 tag.value(), getSlaveTypeTagValue(EC2Cloud.EC2_SLAVE_TYPE_DEMAND, description))
-                        || StringUtils.equals(
+                        || Objects.equals(
                                 tag.value(), getSlaveTypeTagValue(EC2Cloud.EC2_SLAVE_TYPE_SPOT, description))) {
                     return true;
                 } else {
@@ -1229,7 +1228,7 @@ public class EC2Cloud extends Cloud {
                                         t);
                                 return null;
                             }
-                            if (StringUtils.isEmpty(instanceId)) {
+                            if (instanceId == null || instanceId.isEmpty()) {
                                 try {
                                     Thread.sleep(5000);
                                 } catch (InterruptedException e) {
@@ -1394,7 +1393,7 @@ public class EC2Cloud extends Cloud {
             final boolean useInstanceProfileForCredentials, final String credentialsId) {
         if (useInstanceProfileForCredentials) {
             return InstanceProfileCredentialsProvider.create();
-        } else if (StringUtils.isBlank(credentialsId)) {
+        } else if (credentialsId == null || credentialsId.isBlank()) {
             return DefaultCredentialsProvider.builder().build();
         } else {
             AmazonWebServicesCredentials credentials = getCredentials(credentialsId);
@@ -1414,10 +1413,11 @@ public class EC2Cloud extends Cloud {
 
         AwsCredentialsProvider provider = createCredentialsProvider(useInstanceProfileForCredentials, credentialsId);
 
-        if (StringUtils.isNotEmpty(roleArn)) {
+        if (roleArn != null && !roleArn.isEmpty()) {
             AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
                     .roleArn(roleArn)
-                    .roleSessionName(StringUtils.defaultIfBlank(roleSessionName, "Jenkins"))
+                    .roleSessionName(
+                            roleSessionName != null && !roleSessionName.isBlank() ? roleSessionName : "Jenkins")
                     .build();
 
             StsClientBuilder stsClientBuilder = StsClient.builder()
@@ -1441,7 +1441,7 @@ public class EC2Cloud extends Cloud {
 
     @CheckForNull
     private static AmazonWebServicesCredentials getCredentials(@CheckForNull String credentialsId) {
-        if (StringUtils.isBlank(credentialsId)) {
+        if (credentialsId == null || credentialsId.isBlank()) {
             return null;
         }
         return CredentialsMatchers.firstOrNull(
@@ -1592,7 +1592,7 @@ public class EC2Cloud extends Cloud {
                 @QueryParameter String roleArn, @QueryParameter String roleSessionName) {
             // Don't do anything if the user is only reading the configuration
             if (Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
-                if (StringUtils.isNotEmpty(roleArn) && StringUtils.isBlank(roleSessionName)) {
+                if (roleArn != null && !roleArn.isEmpty() && (roleSessionName == null || roleSessionName.isBlank())) {
                     return FormValidation.warning(
                             "Session Name is recommended when specifying an Arn Role. If empty, 'Jenkins' will be used.");
                 }
@@ -1628,7 +1628,7 @@ public class EC2Cloud extends Cloud {
                 if (k == null) {
                     validations.add(FormValidation.error(
                             "Failed to find private key file " + System.getProperty(SSH_PRIVATE_KEY_FILEPATH)));
-                    if (!StringUtils.isEmpty(value)) {
+                    if (value != null && !value.isEmpty()) {
                         validations.add(FormValidation.warning(
                                 "Private key file path defined, selected credential will be ignored"));
                     }
@@ -1658,7 +1658,7 @@ public class EC2Cloud extends Cloud {
             }
 
             if (!System.getProperty(SSH_PRIVATE_KEY_FILEPATH, "").isEmpty()) {
-                if (!StringUtils.isEmpty(value)) {
+                if (value != null && !value.isEmpty()) {
                     validations.add(FormValidation.warning("Using private key file instead of selected credential"));
                 } else {
                     validations.add(FormValidation.ok("Using private key file"));
@@ -1722,7 +1722,7 @@ public class EC2Cloud extends Cloud {
                     if (k == null) {
                         validations.add(FormValidation.error(
                                 "Failed to find private key file " + System.getProperty(SSH_PRIVATE_KEY_FILEPATH)));
-                        if (!StringUtils.isEmpty(sshKeysCredentialsId)) {
+                        if (sshKeysCredentialsId != null && !sshKeysCredentialsId.isEmpty()) {
                             validations.add(FormValidation.warning(
                                     "Private key file path defined, selected credential will be ignored"));
                         }
@@ -1753,7 +1753,7 @@ public class EC2Cloud extends Cloud {
                 }
 
                 if (!System.getProperty(SSH_PRIVATE_KEY_FILEPATH, "").isEmpty()) {
-                    if (!StringUtils.isEmpty(sshKeysCredentialsId)) {
+                    if (sshKeysCredentialsId != null && !sshKeysCredentialsId.isEmpty()) {
                         validations.add(
                                 FormValidation.warning("Using private key file instead of selected credential"));
                     } else {

--- a/src/main/java/hudson/plugins/ec2/EC2HostAddressProvider.java
+++ b/src/main/java/hudson/plugins/ec2/EC2HostAddressProvider.java
@@ -1,7 +1,6 @@
 package hudson.plugins.ec2;
 
 import java.util.Optional;
-import org.apache.commons.lang.StringUtils;
 import software.amazon.awssdk.services.ec2.model.Instance;
 
 public class EC2HostAddressProvider {
@@ -62,6 +61,6 @@ public class EC2HostAddressProvider {
     }
 
     private static Optional<String> filterNonEmpty(String value) {
-        return Optional.ofNullable(value).filter(StringUtils::isNotEmpty);
+        return Optional.ofNullable(value).filter(s -> !s.isEmpty());
     }
 }

--- a/src/main/java/hudson/plugins/ec2/EC2PrivateKey.java
+++ b/src/main/java/hudson/plugins/ec2/EC2PrivateKey.java
@@ -38,7 +38,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.crypto.Cipher;
 import jenkins.bouncycastle.api.PEMEncodable;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import software.amazon.awssdk.core.exception.SdkException;
@@ -145,7 +144,7 @@ public class EC2PrivateKey {
             cipher.init(
                     Cipher.DECRYPT_MODE,
                     PEMEncodable.decode(privateKey.getPlainText()).toPrivateKey());
-            byte[] cipherText = Base64.getDecoder().decode(StringUtils.deleteWhitespace(encodedPassword));
+            byte[] cipherText = Base64.getDecoder().decode(encodedPassword.replaceAll("\\s+", ""));
             byte[] plainText = cipher.doFinal(cipherText);
             return new String(plainText, StandardCharsets.US_ASCII);
         } catch (Exception e) {
@@ -161,7 +160,7 @@ public class EC2PrivateKey {
 
     @CheckForNull
     public static EC2PrivateKey fetchFromDisk(String filepath) {
-        if (StringUtils.isNotEmpty(filepath)) {
+        if (filepath != null && !filepath.isEmpty()) {
             try {
                 return new EC2PrivateKey(Files.readString(Paths.get(filepath), StandardCharsets.UTF_8));
             } catch (IOException e) {

--- a/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java
@@ -14,7 +14,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.ec2.model.Ec2Exception;
 import software.amazon.awssdk.services.ec2.model.Instance;
@@ -51,7 +50,7 @@ public class EC2SlaveMonitor extends AsyncPeriodicWork {
         for (Node node : Jenkins.get().getNodes()) {
             if (node instanceof EC2AbstractSlave ec2Slave) {
                 String instanceId = ec2Slave.getInstanceId();
-                if (StringUtils.isEmpty(instanceId)) {
+                if (instanceId == null || instanceId.isEmpty()) {
                     continue;
                 }
                 EC2Cloud cloud = ec2Slave.getCloud();

--- a/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2SpotSlave.java
@@ -16,7 +16,6 @@ import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.ec2.Ec2Client;
@@ -308,7 +307,7 @@ public class EC2SpotSlave extends EC2AbstractSlave implements EC2Readiness {
 
     @Override
     public String getInstanceId() {
-        if (StringUtils.isEmpty(instanceId)) {
+        if (instanceId == null || instanceId.isEmpty()) {
             SpotInstanceRequest sr = getSpotRequest();
             if (sr != null) {
                 instanceId = sr.instanceId();

--- a/src/main/java/hudson/plugins/ec2/MacData.java
+++ b/src/main/java/hudson/plugins/ec2/MacData.java
@@ -3,7 +3,6 @@ package hudson.plugins.ec2;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class MacData extends SSHData {
@@ -59,29 +58,29 @@ public class MacData extends SSHData {
             return false;
         }
         final MacData other = (MacData) obj;
-        if (StringUtils.isEmpty(rootCommandPrefix)) {
-            if (!StringUtils.isEmpty(other.rootCommandPrefix)) {
+        if (rootCommandPrefix == null || rootCommandPrefix.isEmpty()) {
+            if (other.rootCommandPrefix != null && !other.rootCommandPrefix.isEmpty()) {
                 return false;
             }
         } else if (!rootCommandPrefix.equals(other.rootCommandPrefix)) {
             return false;
         }
-        if (StringUtils.isEmpty(slaveCommandPrefix)) {
-            if (!StringUtils.isEmpty(other.slaveCommandPrefix)) {
+        if (slaveCommandPrefix == null || slaveCommandPrefix.isEmpty()) {
+            if (other.slaveCommandPrefix != null && !other.slaveCommandPrefix.isEmpty()) {
                 return false;
             }
         } else if (!slaveCommandPrefix.equals(other.slaveCommandPrefix)) {
             return false;
         }
-        if (StringUtils.isEmpty(slaveCommandSuffix)) {
-            if (!StringUtils.isEmpty(other.slaveCommandSuffix)) {
+        if (slaveCommandSuffix == null || slaveCommandSuffix.isEmpty()) {
+            if (other.slaveCommandSuffix != null && !other.slaveCommandSuffix.isEmpty()) {
                 return false;
             }
         } else if (!slaveCommandSuffix.equals(other.slaveCommandSuffix)) {
             return false;
         }
-        if (StringUtils.isEmpty(sshPort)) {
-            if (!StringUtils.isEmpty(other.sshPort)) {
+        if (sshPort == null || sshPort.isEmpty()) {
+            if (other.sshPort != null && !other.sshPort.isEmpty()) {
                 return false;
             }
         } else if (!sshPort.equals(other.sshPort)) {

--- a/src/main/java/hudson/plugins/ec2/SSHData.java
+++ b/src/main/java/hudson/plugins/ec2/SSHData.java
@@ -1,7 +1,6 @@
 package hudson.plugins.ec2;
 
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 
 public abstract class SSHData extends AMITypeData {
     protected final String rootCommandPrefix;
@@ -103,29 +102,29 @@ public abstract class SSHData extends AMITypeData {
             return false;
         }
         final SSHData other = (SSHData) obj;
-        if (StringUtils.isEmpty(rootCommandPrefix)) {
-            if (!StringUtils.isEmpty(other.rootCommandPrefix)) {
+        if (rootCommandPrefix == null || rootCommandPrefix.isEmpty()) {
+            if (other.rootCommandPrefix != null && !other.rootCommandPrefix.isEmpty()) {
                 return false;
             }
         } else if (!rootCommandPrefix.equals(other.rootCommandPrefix)) {
             return false;
         }
-        if (StringUtils.isEmpty(slaveCommandPrefix)) {
-            if (!StringUtils.isEmpty(other.slaveCommandPrefix)) {
+        if (slaveCommandPrefix == null || slaveCommandPrefix.isEmpty()) {
+            if (other.slaveCommandPrefix != null && !other.slaveCommandPrefix.isEmpty()) {
                 return false;
             }
         } else if (!slaveCommandPrefix.equals(other.slaveCommandPrefix)) {
             return false;
         }
-        if (StringUtils.isEmpty(slaveCommandSuffix)) {
-            if (!StringUtils.isEmpty(other.slaveCommandSuffix)) {
+        if (slaveCommandSuffix == null || slaveCommandSuffix.isEmpty()) {
+            if (other.slaveCommandSuffix != null && !other.slaveCommandSuffix.isEmpty()) {
                 return false;
             }
         } else if (!slaveCommandSuffix.equals(other.slaveCommandSuffix)) {
             return false;
         }
-        if (StringUtils.isEmpty(sshPort)) {
-            if (!StringUtils.isEmpty(other.sshPort)) {
+        if (sshPort == null || sshPort.isEmpty()) {
+            if (other.sshPort != null && !other.sshPort.isEmpty()) {
                 return false;
             }
         } else if (!sshPort.equals(other.sshPort)) {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -2137,9 +2137,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     private boolean isSameIamInstanceProfile(Instance instance) {
-        return (getIamInstanceProfile() == null || getIamInstanceProfile().isBlank())
+        String iamProfile = getIamInstanceProfile();
+        return (iamProfile == null || iamProfile.isBlank())
                 || (instance.iamInstanceProfile() != null
-                        && instance.iamInstanceProfile().arn().equals(getIamInstanceProfile()));
+                        && instance.iamInstanceProfile().arn().equals(iamProfile));
     }
 
     private boolean isTerminatingOrShuttindDown(InstanceStateName instanceStateName) {
@@ -2208,13 +2209,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 .build());
 
         Placement.Builder placementBuilder = Placement.builder();
-        if (getZone() != null && !getZone().isBlank()) {
+        String zone = getZone();
+        if (zone != null && !zone.isBlank()) {
             if (getTenancyAttribute().equals(Tenancy.Dedicated)) {
                 placementBuilder.tenancy("dedicated");
             }
             riRequestBuilder.placement(placementBuilder.build());
             diFilters.add(
-                    Filter.builder().name("availability-zone").values(getZone()).build());
+                    Filter.builder().name("availability-zone").values(zone).build());
         }
 
         if (getTenancyAttribute().equals(Tenancy.Host)) {
@@ -2296,10 +2298,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                     .build());
         }
 
-        if (getIamInstanceProfile() != null && !getIamInstanceProfile().isBlank()) {
-            riRequestBuilder.iamInstanceProfile(IamInstanceProfileSpecification.builder()
-                    .arn(getIamInstanceProfile())
-                    .build());
+        String iamProfile = getIamInstanceProfile();
+        if (iamProfile != null && !iamProfile.isBlank()) {
+            riRequestBuilder.iamInstanceProfile(
+                    IamInstanceProfileSpecification.builder().arn(iamProfile).build());
         }
 
         List<TagSpecification> tagList = new ArrayList<>();
@@ -2701,9 +2703,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             launchSpecificationBuilder.monitoring(
                     RunInstancesMonitoringEnabled.builder().enabled(monitoring).build());
 
-            if (getZone() != null && !getZone().isBlank()) {
+            String zone = getZone();
+            if (zone != null && !zone.isBlank()) {
                 SpotPlacement placement =
-                        SpotPlacement.builder().availabilityZone(getZone()).build();
+                        SpotPlacement.builder().availabilityZone(zone).build();
                 launchSpecificationBuilder.placement(placement);
             }
 
@@ -2755,9 +2758,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             HashSet<Tag> instTags = buildTags(EC2Cloud.EC2_SLAVE_TYPE_SPOT);
 
-            if (getIamInstanceProfile() != null && !getIamInstanceProfile().isBlank()) {
+            String iamProfile = getIamInstanceProfile();
+            if (iamProfile != null && !iamProfile.isBlank()) {
                 launchSpecificationBuilder.iamInstanceProfile(IamInstanceProfileSpecification.builder()
-                        .arn(getIamInstanceProfile())
+                        .arn(iamProfile)
                         .build());
             }
 

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -74,7 +74,6 @@ import java.util.stream.Stream;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.slaves.iterators.api.NodeIterator;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -349,7 +348,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             Boolean metadataSupported,
             Boolean enclaveEnabled) {
 
-        if (StringUtils.isNotBlank(remoteAdmin) || StringUtils.isNotBlank(jvmopts) || StringUtils.isNotBlank(tmpDir)) {
+        if ((remoteAdmin != null && !remoteAdmin.isBlank())
+                || (jvmopts != null && !jvmopts.isBlank())
+                || (tmpDir != null && !tmpDir.isBlank())) {
             LOGGER.log(
                     Level.FINE,
                     "As remoteAdmin, jvmopts or tmpDir is not blank, we must ensure the user has ADMINISTER rights.");
@@ -374,11 +375,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.description = description;
         this.initScript = initScript;
         this.tmpDir = tmpDir;
-        this.userData = StringUtils.trimToEmpty(userData);
+        this.userData = userData == null ? "" : userData.trim();
         this.numExecutors = Util.fixNull(numExecutors).trim();
         this.remoteAdmin = remoteAdmin;
 
-        if (StringUtils.isNotBlank(javaPath)) {
+        if (javaPath != null && !javaPath.isBlank()) {
             this.javaPath = javaPath;
         } else {
             this.javaPath = EC2AbstractSlave.DEFAULT_JAVA_PATH;
@@ -1714,7 +1715,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     public String chooseSubnetId() {
-        if (StringUtils.isBlank(subnetId)) {
+        if (subnetId == null || subnetId.isBlank()) {
             return null;
         } else {
             String[] subnetIdList = getSubnetId().split(EC2_RESOURCE_ID_DELIMETERS);
@@ -2136,7 +2137,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     private boolean isSameIamInstanceProfile(Instance instance) {
-        return StringUtils.isBlank(getIamInstanceProfile())
+        return (getIamInstanceProfile() == null || getIamInstanceProfile().isBlank())
                 || (instance.iamInstanceProfile() != null
                         && instance.iamInstanceProfile().arn().equals(getIamInstanceProfile()));
     }
@@ -2207,7 +2208,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 .build());
 
         Placement.Builder placementBuilder = Placement.builder();
-        if (StringUtils.isNotBlank(getZone())) {
+        if (getZone() != null && !getZone().isBlank()) {
             if (getTenancyAttribute().equals(Tenancy.Dedicated)) {
                 placementBuilder.tenancy("dedicated");
             }
@@ -2238,7 +2239,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         LOGGER.log(Level.FINE, () -> String.format("Chose subnetId %s", subnetId));
 
         InstanceNetworkInterfaceSpecification.Builder netBuilder = InstanceNetworkInterfaceSpecification.builder();
-        if (StringUtils.isNotBlank(subnetId)) {
+        if (subnetId != null && !subnetId.isBlank()) {
             netBuilder.subnetId(subnetId);
 
             diFilters.add(Filter.builder().name("subnet-id").values(subnetId).build());
@@ -2295,7 +2296,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                     .build());
         }
 
-        if (StringUtils.isNotBlank(getIamInstanceProfile())) {
+        if (getIamInstanceProfile() != null && !getIamInstanceProfile().isBlank()) {
             riRequestBuilder.iamInstanceProfile(IamInstanceProfileSpecification.builder()
                     .arn(getIamInstanceProfile())
                     .build());
@@ -2657,7 +2658,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     private void setupCustomDeviceMapping(List<BlockDeviceMapping> deviceMappings) {
-        if (StringUtils.isNotBlank(customDeviceMapping)) {
+        if (customDeviceMapping != null && !customDeviceMapping.isBlank()) {
             deviceMappings.addAll(DeviceMappingParser.parse(customDeviceMapping));
         }
     }
@@ -2700,7 +2701,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             launchSpecificationBuilder.monitoring(
                     RunInstancesMonitoringEnabled.builder().enabled(monitoring).build());
 
-            if (StringUtils.isNotBlank(getZone())) {
+            if (getZone() != null && !getZone().isBlank()) {
                 SpotPlacement placement =
                         SpotPlacement.builder().availabilityZone(getZone()).build();
                 launchSpecificationBuilder.placement(placement);
@@ -2709,7 +2710,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             InstanceNetworkInterfaceSpecification.Builder netBuilder = InstanceNetworkInterfaceSpecification.builder();
             String subnetId = chooseSubnetId();
             LOGGER.log(Level.FINE, () -> String.format("Chose subnetId %s", subnetId));
-            if (StringUtils.isNotBlank(subnetId)) {
+            if (subnetId != null && !subnetId.isBlank()) {
                 netBuilder.subnetId(subnetId);
 
                 /*
@@ -2754,7 +2755,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             HashSet<Tag> instTags = buildTags(EC2Cloud.EC2_SLAVE_TYPE_SPOT);
 
-            if (StringUtils.isNotBlank(getIamInstanceProfile())) {
+            if (getIamInstanceProfile() != null && !getIamInstanceProfile().isBlank()) {
                 launchSpecificationBuilder.iamInstanceProfile(IamInstanceProfileSpecification.builder()
                         .arn(getIamInstanceProfile())
                         .build());
@@ -2860,7 +2861,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         if (useEphemeralDevices) {
             newMappings.addAll(getNewEphemeralDeviceMapping(image));
         } else {
-            if (StringUtils.isNotBlank(customDeviceMapping)) {
+            if (customDeviceMapping != null && !customDeviceMapping.isBlank()) {
                 newMappings.addAll(DeviceMappingParser.parse(customDeviceMapping));
             }
         }
@@ -2874,10 +2875,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         if (tags != null && !tags.isEmpty()) {
             for (EC2Tag t : tags) {
                 instTags.add(Tag.builder().key(t.getName()).value(t.getValue()).build());
-                if (StringUtils.equals(t.getName(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE)) {
+                if (Objects.equals(t.getName(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE)) {
                     hasCustomTypeTag = true;
                 }
-                if (StringUtils.equals(t.getName(), EC2Tag.TAG_NAME_JENKINS_SERVER_URL)) {
+                if (Objects.equals(t.getName(), EC2Tag.TAG_NAME_JENKINS_SERVER_URL)) {
                     hasJenkinsServerUrlTag = true;
                 }
             }
@@ -2896,7 +2897,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                     .build());
         }
 
-        if (parent != null && StringUtils.isNotBlank(parent.name)) {
+        if (parent != null && parent.name != null && !parent.name.isBlank()) {
             instTags.add(Tag.builder()
                     .key(EC2Tag.TAG_NAME_JENKINS_CLOUD_NAME)
                     .value(parent.name)
@@ -3175,7 +3176,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         if (metadataHopsLimit == null) {
             metadataHopsLimit = EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT;
         }
-        if (StringUtils.isBlank(javaPath)) {
+        if (javaPath == null || javaPath.isBlank()) {
             javaPath = EC2AbstractSlave.DEFAULT_JAVA_PATH;
         }
         if (enclaveEnabled == null) {

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.scp.client.CloseableScpClient;
 import org.apache.sshd.scp.common.helpers.ScpTimestampCommandDetails;
@@ -163,7 +162,8 @@ public class EC2MacLauncher extends EC2SSHLauncher {
                 logInfo(computer, listener, "Creating tmp directory (" + tmpDir + ") if it does not exist");
                 executeRemote(clientSession, "mkdir -p " + tmpDir, logger);
 
-                if (StringUtils.isNotBlank(initScript)
+                if (initScript != null
+                        && !initScript.isBlank()
                         && !executeRemote(clientSession, "test -e ~/.hudson-run-init", logger)) {
                     logInfo(computer, listener, "Upload init script");
                     scp.upload(

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2SSHLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2SSHLauncher.java
@@ -41,6 +41,7 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -402,11 +403,9 @@ public abstract class EC2SSHLauncher extends EC2ComputerLauncher {
             } catch (IOException e) {
                 logInfo(computer, listener, "Failed to connect via ssh: " + e.getMessage());
 
-                String offlineCauseReason = computer.getOfflineCauseReason();
                 if (computer.isOffline()
-                        && offlineCauseReason != null
-                        && !offlineCauseReason.isBlank()
-                        && offlineCauseReason.equals(Messages.OfflineCause_SSHKeyCheckFailed())) {
+                        && Objects.equals(
+                                computer.getOfflineCauseReason(), Messages.OfflineCause_SSHKeyCheckFailed())) {
                     throw SdkException.create(
                             "The connection couldn't be established and the computer is now offline", e);
                 } else {

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2SSHLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2SSHLauncher.java
@@ -46,7 +46,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.channel.ChannelExec;
 import org.apache.sshd.client.future.ConnectFuture;
@@ -353,7 +352,7 @@ public abstract class EC2SSHLauncher extends EC2ComputerLauncher {
                     throw new IOException("goto sleep");
                 }
 
-                if (StringUtils.isBlank(host)) {
+                if (host == null || host.isBlank()) {
                     logWarning(computer, listener, "Empty host, your host is most likely waiting for an ip address.");
                     throw new IOException("goto sleep");
                 }
@@ -403,9 +402,11 @@ public abstract class EC2SSHLauncher extends EC2ComputerLauncher {
             } catch (IOException e) {
                 logInfo(computer, listener, "Failed to connect via ssh: " + e.getMessage());
 
+                String offlineCauseReason = computer.getOfflineCauseReason();
                 if (computer.isOffline()
-                        && StringUtils.isNotBlank(computer.getOfflineCauseReason())
-                        && computer.getOfflineCauseReason().equals(Messages.OfflineCause_SSHKeyCheckFailed())) {
+                        && offlineCauseReason != null
+                        && !offlineCauseReason.isBlank()
+                        && offlineCauseReason.equals(Messages.OfflineCause_SSHKeyCheckFailed())) {
                     throw SdkException.create(
                             "The connection couldn't be established and the computer is now offline", e);
                 } else {

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.scp.client.CloseableScpClient;
 import org.apache.sshd.scp.common.helpers.ScpTimestampCommandDetails;
@@ -160,7 +159,8 @@ public class EC2UnixLauncher extends EC2SSHLauncher {
                 logInfo(computer, listener, "Creating tmp directory (" + tmpDir + ") if it does not exist");
                 executeRemote(clientSession, "mkdir -p " + tmpDir, logger);
 
-                if (StringUtils.isNotBlank(initScript)
+                if (initScript != null
+                        && !initScript.isBlank()
                         && !executeRemote(clientSession, "test -e ~/.hudson-run-init", logger)) {
                     logInfo(computer, listener, "Upload init script");
                     scp.upload(

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2WindowsSSHLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2WindowsSSHLauncher.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.scp.client.CloseableScpClient;
 import org.apache.sshd.scp.common.helpers.ScpTimestampCommandDetails;
@@ -134,7 +133,8 @@ public class EC2WindowsSSHLauncher extends EC2SSHLauncher {
                 logInfo(computer, listener, "Creating tmp directory (" + tmpDir + ") if it does not exist");
                 executeRemote(clientSession, "IF NOT EXIST " + tmpDir + " MKDIR " + tmpDir, logger);
 
-                if (StringUtils.isNotBlank(initScript)
+                if (initScript != null
+                        && !initScript.isBlank()
                         && !executeRemote(
                                 clientSession, "IF NOT EXIST %USERPROFILE%\\.hudson-run-init EXIT /B 999", logger)) {
                     logInfo(computer, listener, "Upload init script");

--- a/src/main/java/hudson/plugins/ec2/util/DeviceMappingParser.java
+++ b/src/main/java/hudson/plugins/ec2/util/DeviceMappingParser.java
@@ -25,7 +25,6 @@ package hudson.plugins.ec2.util;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
 import software.amazon.awssdk.services.ec2.model.BlockDeviceMapping;
 import software.amazon.awssdk.services.ec2.model.EbsBlockDevice;
 
@@ -65,25 +64,25 @@ public class DeviceMappingParser {
         String[] parts = blockDevice.split(":");
 
         EbsBlockDevice.Builder ebsBuilder = EbsBlockDevice.builder();
-        if (StringUtils.isNotBlank(getOrEmpty(parts, 0))) {
+        if (!getOrEmpty(parts, 0).isBlank()) {
             ebsBuilder.snapshotId(parts[0]);
         }
-        if (StringUtils.isNotBlank(getOrEmpty(parts, 1))) {
+        if (!getOrEmpty(parts, 1).isBlank()) {
             ebsBuilder.volumeSize(Integer.valueOf(parts[1]));
         }
-        if (StringUtils.isNotBlank(getOrEmpty(parts, 2))) {
+        if (!getOrEmpty(parts, 2).isBlank()) {
             ebsBuilder.deleteOnTermination(Boolean.valueOf(parts[2]));
         }
-        if (StringUtils.isNotBlank(getOrEmpty(parts, 3))) {
+        if (!getOrEmpty(parts, 3).isBlank()) {
             ebsBuilder.volumeType(parts[3]);
         }
-        if (StringUtils.isNotBlank(getOrEmpty(parts, 4))) {
+        if (!getOrEmpty(parts, 4).isBlank()) {
             ebsBuilder.iops(Integer.valueOf(parts[4]));
         }
-        if (StringUtils.isNotBlank(getOrEmpty(parts, 5))) {
+        if (!getOrEmpty(parts, 5).isBlank()) {
             ebsBuilder.encrypted(parts[5].equals("encrypted"));
         }
-        if (StringUtils.isNotBlank(getOrEmpty(parts, 6))) {
+        if (!getOrEmpty(parts, 6).isBlank()) {
             ebsBuilder.throughput(Integer.valueOf(parts[6]));
         }
 

--- a/src/main/java/hudson/plugins/ec2/util/FIPS140Utils.java
+++ b/src/main/java/hudson/plugins/ec2/util/FIPS140Utils.java
@@ -11,7 +11,6 @@ import java.security.interfaces.ECKey;
 import java.security.interfaces.RSAKey;
 import jenkins.bouncycastle.api.PEMEncodable;
 import jenkins.security.FIPS140;
-import org.apache.commons.lang.StringUtils;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.params.DSAPublicKeyParameters;
 import org.bouncycastle.crypto.params.ECPublicKeyParameters;
@@ -75,7 +74,7 @@ public class FIPS140Utils {
      * @throws IllegalArgumentException if there is a risk that the password will leak
      */
     public static void ensureNoPasswordLeak(boolean useHTTPS, String password) {
-        ensureNoPasswordLeak(useHTTPS, !StringUtils.isEmpty(password));
+        ensureNoPasswordLeak(useHTTPS, password != null && !password.isEmpty());
     }
 
     /**
@@ -101,7 +100,7 @@ public class FIPS140Utils {
      */
     public static void ensurePasswordLength(String password) {
         if (FIPS140.useCompliantAlgorithms()) {
-            if (StringUtils.isBlank(password) || password.length() < 14) {
+            if (password == null || password.isBlank() || password.length() < 14) {
                 throw new IllegalArgumentException(Messages.EC2Cloud_passwordLengthInFIPSMode());
             }
         }
@@ -137,7 +136,7 @@ public class FIPS140Utils {
         if (!FIPS140.useCompliantAlgorithms()) {
             return;
         }
-        if (StringUtils.isBlank(privateKeyString)) {
+        if (privateKeyString == null || privateKeyString.isBlank()) {
             throw new IllegalArgumentException(Messages.EC2Cloud_keyIsMandatoryInFIPSMode());
         }
         try {


### PR DESCRIPTION
Jenkins core is removing commons-lang2 dependency - https://github.com/jenkinsci/jenkins/pull/26105. This project is using lang2 transitively, needing to drop those usages. Instead of migrating and depending on commons-lang3-api, due to the simple usages, this PR migrates to JDK apis.

**Testing**

```console
$ grep -rn 'import org\.apache\.commons\.lang[.;]' --include='*.java' src/
Exit code: 1
```

```console
$ mvn clean test-compile -DskipTests -Dban-commons-lang-2.skip=false
[INFO] BUILD SUCCESS
[INFO] Total time:  8.115 s
```

```console
$ mvn clean compile spotbugs:check -DskipTests -Dban-commons-lang-2.skip=false
[INFO] Done SpotBugs Analysis....
[INFO] BUILD SUCCESS
[INFO] Total time:  12.231 s
```