### PR TITLE
Improve multi-AZ provisioning by being capacity-aware

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -53,6 +53,7 @@ import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -67,6 +68,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -74,6 +77,7 @@ import java.util.stream.Stream;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.slaves.iterators.api.NodeIterator;
+import jenkins.util.SystemProperties;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -149,6 +153,39 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     private static final Logger LOGGER = Logger.getLogger(SlaveTemplate.class.getName());
 
     private static final String EC2_RESOURCE_ID_DELIMETERS = "[\\s,;]+";
+
+    /**
+     * Default period, in milliseconds, during which a subnet is skipped by
+     * {@link #chooseSubnetId()} after it reported an insufficient-capacity error
+     * for this template's instance type.
+     */
+    static final long DEFAULT_SUBNET_CAPACITY_COOLDOWN_MILLIS = TimeUnit.MINUTES.toMillis(5);
+
+    /**
+     * How long (ms) a subnet is considered capacity-unavailable after an
+     * insufficient-capacity error. Configurable via the system property
+     * {@code hudson.plugins.ec2.SlaveTemplate.subnetCapacityCooldownMillis}.
+     */
+    private static final long SUBNET_CAPACITY_COOLDOWN_MILLIS = SystemProperties.getLong(
+            SlaveTemplate.class.getName() + ".subnetCapacityCooldownMillis", DEFAULT_SUBNET_CAPACITY_COOLDOWN_MILLIS);
+
+    /**
+     * AWS {@code RunInstances} error codes that indicate the chosen subnet/AZ cannot
+     * currently supply the requested instance type, so provisioning should try a
+     * different subnet rather than fail.
+     */
+    private static final Set<String> INSUFFICIENT_CAPACITY_ERROR_CODES =
+            Set.of("InsufficientInstanceCapacity", "InsufficientHostCapacity", "InsufficientReservedInstancesCapacity");
+
+    /**
+     * Maps a subnet id to the epoch-millis timestamp until which the subnet should be
+     * skipped because it recently reported insufficient capacity for this template's
+     * instance type. Transient: cooldowns are best-effort and need not survive restarts.
+     */
+    private transient ConcurrentHashMap<String, Long> subnetCapacityCooldownUntil;
+
+    /** Clock used for cooldown bookkeeping. Overridable in tests via {@link #setClock(Clock)}. */
+    private transient Clock clock;
 
     public String ami;
 
@@ -1720,10 +1757,22 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         } else {
             String[] subnetIdList = getSubnetId().split(EC2_RESOURCE_ID_DELIMETERS);
 
-            // Round-robin subnet selection.
+            // Round-robin subnet selection, skipping any subnet currently in a capacity
+            // cooldown (i.e. one that recently reported insufficient capacity for this
+            // template's instance type).
+            for (int i = 0; i < subnetIdList.length; i++) {
+                String candidate = subnetIdList[nextSubnet];
+                nextSubnet = (nextSubnet + 1) % subnetIdList.length;
+                if (!isSubnetInCooldown(candidate)) {
+                    currentSubnetId = candidate;
+                    return currentSubnetId;
+                }
+            }
+
+            // Every subnet is currently cooling down. Rather than refuse to provision,
+            // fall back to plain round-robin so we still attempt a launch.
             currentSubnetId = subnetIdList[nextSubnet];
             nextSubnet = (nextSubnet + 1) % subnetIdList.length;
-
             return currentSubnetId;
         }
     }
@@ -1734,6 +1783,84 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         } else {
             return this.currentSubnetId;
         }
+    }
+
+    /**
+     * @return the number of subnets configured for this template (0 if none).
+     */
+    int getSubnetCount() {
+        if (subnetId == null || subnetId.isBlank()) {
+            return 0;
+        }
+        return getSubnetId().split(EC2_RESOURCE_ID_DELIMETERS).length;
+    }
+
+    private synchronized ConcurrentHashMap<String, Long> getSubnetCapacityCooldownMap() {
+        if (subnetCapacityCooldownUntil == null) {
+            subnetCapacityCooldownUntil = new ConcurrentHashMap<>();
+        }
+        return subnetCapacityCooldownUntil;
+    }
+
+    private synchronized Clock getClock() {
+        if (clock == null) {
+            clock = Clock.systemUTC();
+        }
+        return clock;
+    }
+
+    /**
+     * Overrides the clock used for subnet cooldown bookkeeping. For tests only.
+     */
+    void setClock(Clock clock) {
+        synchronized (this) {
+            this.clock = clock;
+        }
+    }
+
+    /**
+     * Marks a subnet as temporarily unavailable because it reported insufficient
+     * capacity for this template's instance type. The subnet will be skipped by
+     * {@link #chooseSubnetId()} until the cooldown period elapses.
+     */
+    void markSubnetUnavailable(String subnet) {
+        if (subnet == null || subnet.isBlank()) {
+            return;
+        }
+        long until = getClock().millis() + SUBNET_CAPACITY_COOLDOWN_MILLIS;
+        getSubnetCapacityCooldownMap().put(subnet, until);
+        LOGGER.log(
+                Level.FINE,
+                () -> String.format(
+                        "Marking subnet %s as capacity-unavailable for instance type %s until %d",
+                        subnet, type, until));
+    }
+
+    /**
+     * @return {@code true} if the subnet is currently in a capacity cooldown. Expired
+     *     cooldowns are cleaned up as a side effect.
+     */
+    boolean isSubnetInCooldown(String subnet) {
+        if (subnet == null) {
+            return false;
+        }
+        Long until = getSubnetCapacityCooldownMap().get(subnet);
+        if (until == null) {
+            return false;
+        }
+        if (getClock().millis() >= until) {
+            getSubnetCapacityCooldownMap().remove(subnet, until);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @return {@code true} if the given AWS error code indicates the subnet/AZ cannot
+     *     currently supply the requested instance type.
+     */
+    static boolean isInsufficientCapacityError(String errorCode) {
+        return errorCode != null && INSUFFICIENT_CAPACITY_ERROR_CODES.contains(errorCode);
     }
 
     public String getSubnetId() {
@@ -2440,15 +2567,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 }
             }
         } else {
-            try {
-                newInstances = new ArrayList<>(
-                        ec2.runInstances(riRequestBuilder.build()).instances());
-            } catch (Ec2Exception e) {
-                logProvisionInfo("Jenkins attempted to reserve "
-                        + riRequest.maxCount()
-                        + " instances and received this EC2 exception: " + e.getMessage());
-                throw e;
-            }
+            newInstances = runOndemandInstancesWithSubnetFailover(
+                    ec2, image, number - orphansOrStopped.size(), riRequestBuilder);
         }
         // Have to create a new instance
 
@@ -2459,6 +2579,69 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         newInstances.addAll(orphansOrStopped);
 
         return toSlaves(newInstances);
+    }
+
+    /**
+     * Runs on-demand instances, retrying against the next subnet if the current one
+     * reports an insufficient-capacity error. The exhausted subnet is put into a
+     * cooldown so subsequent provisioning rounds skip it. Up to one attempt per
+     * configured subnet is made; if all fail with capacity errors the last exception
+     * is rethrown.
+     */
+    private List<Instance> runOndemandInstancesWithSubnetFailover(
+            Ec2Client ec2, Image image, int countToCreate, RunInstancesRequest.Builder initialBuilder)
+            throws IOException {
+        int subnetCount = getSubnetCount();
+        int maxAttempts = Math.max(1, subnetCount);
+        RunInstancesRequest.Builder builder = initialBuilder;
+        Ec2Exception lastCapacityException = null;
+
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
+            try {
+                return new ArrayList<>(ec2.runInstances(builder.build()).instances());
+            } catch (Ec2Exception e) {
+                String errorCode =
+                        e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : null;
+                boolean canFailover =
+                        isInsufficientCapacityError(errorCode) && subnetCount > 1 && attempt < maxAttempts - 1;
+                if (!canFailover) {
+                    logProvisionInfo(
+                            "Jenkins attempted to reserve " + builder.build().maxCount()
+                                    + " instances and received this EC2 exception: " + e.getMessage());
+                    throw e;
+                }
+
+                String exhaustedSubnet = getCurrentSubnetId();
+                markSubnetUnavailable(exhaustedSubnet);
+                lastCapacityException = e;
+                logProvisionInfo(String.format(
+                        "Subnet %s has insufficient capacity for instance type %s (%s); trying next subnet",
+                        exhaustedSubnet, type, errorCode));
+
+                // Rebuild the request against the next subnet. This re-selects the subnet
+                // (skipping cooled-down ones) and re-resolves the VPC security groups.
+                HashMap<RunInstancesRequest, List<Filter>> retryMap =
+                        makeRunInstancesRequestAndFilters(image, countToCreate, ec2);
+                if (retryMap == null || retryMap.isEmpty()) {
+                    throw e;
+                }
+                RunInstancesRequest retryRequest =
+                        retryMap.entrySet().iterator().next().getKey();
+                builder = retryRequest.toBuilder();
+                builder.maxCount(countToCreate);
+
+                // If rotation could only offer the same (exhausted) subnet, there is
+                // nothing left to try.
+                if (Objects.equals(exhaustedSubnet, getCurrentSubnetId())) {
+                    throw e;
+                }
+            }
+        }
+
+        if (lastCapacityException != null) {
+            throw lastCapacityException;
+        }
+        return new ArrayList<>();
     }
 
     void wakeOrphansOrStoppedUp(Ec2Client ec2, List<Instance> orphansOrStopped) {

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
@@ -7,6 +7,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import hudson.model.Node;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1477,6 +1481,140 @@ class SlaveTemplateUnitTest {
         String exported = Jenkins.XSTREAM.toXML(template);
         assertThat(exported, containsString("usePrivateDnsName"));
         assertThat(exported, containsString("connectUsingPublicIp"));
+    }
+
+    private static SlaveTemplate slaveTemplateWithSubnets(String subnets) {
+        return new SlaveTemplate(
+                "ami-123",
+                EC2AbstractSlave.TEST_ZONE,
+                null,
+                "default",
+                "foo",
+                InstanceType.M1_LARGE.toString(),
+                false,
+                "ttt",
+                Node.Mode.NORMAL,
+                "AMI description",
+                "bar",
+                "bbb",
+                "aaa",
+                "10",
+                "fff",
+                null,
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "-Xmx1g",
+                false,
+                subnets,
+                null,
+                null,
+                0,
+                0,
+                null,
+                "",
+                false,
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                false,
+                ConnectionStrategy.PRIVATE_DNS,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
+                EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED);
+    }
+
+    @Test
+    void testChooseSubnetIdSkipsSubnetInCooldown() {
+        SlaveTemplate slaveTemplate = slaveTemplateWithSubnets("subnet-1 subnet-2 subnet-3");
+
+        // Mark the first subnet as capacity-unavailable; it should be skipped.
+        slaveTemplate.markSubnetUnavailable("subnet-1");
+
+        assertEquals("subnet-2", slaveTemplate.chooseSubnetId());
+        assertEquals("subnet-3", slaveTemplate.chooseSubnetId());
+        // subnet-1 is still in cooldown, so rotation skips it again.
+        assertEquals("subnet-2", slaveTemplate.chooseSubnetId());
+    }
+
+    @Test
+    void testSubnetCooldownExpires() {
+        SlaveTemplate slaveTemplate = slaveTemplateWithSubnets("subnet-1 subnet-2");
+
+        Instant now = Instant.parse("2026-01-01T00:00:00Z");
+        MutableClock testClock = new MutableClock(now);
+        slaveTemplate.setClock(testClock);
+
+        slaveTemplate.markSubnetUnavailable("subnet-1");
+        assertTrue(slaveTemplate.isSubnetInCooldown("subnet-1"));
+
+        // Advance beyond the default cooldown window.
+        testClock.advance(Duration.ofMillis(SlaveTemplate.DEFAULT_SUBNET_CAPACITY_COOLDOWN_MILLIS + 1));
+        assertFalse(slaveTemplate.isSubnetInCooldown("subnet-1"));
+    }
+
+    @Test
+    void testChooseSubnetIdFallsBackWhenAllSubnetsInCooldown() {
+        SlaveTemplate slaveTemplate = slaveTemplateWithSubnets("subnet-1 subnet-2");
+
+        slaveTemplate.markSubnetUnavailable("subnet-1");
+        slaveTemplate.markSubnetUnavailable("subnet-2");
+
+        // With every subnet cooling down we still return something (plain round-robin)
+        // so provisioning is attempted rather than blocked.
+        String chosen = slaveTemplate.chooseSubnetId();
+        assertTrue("subnet-1".equals(chosen) || "subnet-2".equals(chosen));
+    }
+
+    @Test
+    void testIsInsufficientCapacityError() {
+        assertTrue(SlaveTemplate.isInsufficientCapacityError("InsufficientInstanceCapacity"));
+        assertTrue(SlaveTemplate.isInsufficientCapacityError("InsufficientHostCapacity"));
+        assertTrue(SlaveTemplate.isInsufficientCapacityError("InsufficientReservedInstancesCapacity"));
+        assertFalse(SlaveTemplate.isInsufficientCapacityError("RequestLimitExceeded"));
+        assertFalse(SlaveTemplate.isInsufficientCapacityError(null));
+    }
+
+    @Test
+    void testGetSubnetCount() {
+        assertEquals(3, slaveTemplateWithSubnets("subnet-1 subnet-2 subnet-3").getSubnetCount());
+        assertEquals(1, slaveTemplateWithSubnets("subnet-1").getSubnetCount());
+        assertEquals(0, slaveTemplateWithSubnets("").getSubnetCount());
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        void advance(Duration duration) {
+            instant = instant.plus(duration);
+        }
+
+        @Override
+        public ZoneOffset getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(java.time.ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
     }
 
     class TestHandler extends Handler {


### PR DESCRIPTION
Jenkins LoadStatistics clock cycle is 10 seconds by default.  When configuring a template with multiple availability zones some AZs may not have capacity.  If provisioning throws an exception there's no fallback AZ and current provisioning is delayed by LoadStatistics clock cycle.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Testing is WIP

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
