### PR TITLE
Wait for asynchronous instance types in config tests

### DIFF
--- a/src/main/java/hudson/plugins/ec2/util/SSHClientManager.java
+++ b/src/main/java/hudson/plugins/ec2/util/SSHClientManager.java
@@ -131,8 +131,9 @@ public final class SSHClientManager {
 
         for (String algo : algorithms) {
             String trimmed = algo.trim();
-            boolean isPreferred = preferredAlgorithms.stream().anyMatch(pref -> trimmed.toLowerCase()
-                    .contains(pref.toLowerCase().replace("ssh-", "")));
+            boolean isPreferred = preferredAlgorithms.stream()
+                    .anyMatch(pref ->
+                            trimmed.toLowerCase().contains(pref.toLowerCase().replace("ssh-", "")));
             if (isPreferred) {
                 preferred.add(trimmed);
             } else {

--- a/src/test/java/hudson/plugins/ec2/EC2CloudPrivateKeyWithFIPSTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudPrivateKeyWithFIPSTest.java
@@ -14,8 +14,7 @@ import org.junitpioneer.jupiter.SetSystemProperty;
 @SetSystemProperty(key = "jenkins.security.FIPS140.COMPLIANCE", value = "true")
 class EC2CloudPrivateKeyWithFIPSTest {
 
-    public static String PRIVATE_KEY_DSA_1024 =
-            """
+    public static String PRIVATE_KEY_DSA_1024 = """
             -----BEGIN DSA PRIVATE KEY-----"
             MIIBuwIBAAKBgQDdxPbkTmoDD5cK4W9bE5OVKO1Qu7vw32ZOAFHEdOCjK/JxLEyu
             yV/nlywOmG3fjMKjQdaFDggg9TAZx6Kjor/lXSnpxbWvS5/Blv6QXWMsJZCmVSen
@@ -30,8 +29,7 @@ class EC2CloudPrivateKeyWithFIPSTest {
             -----END DSA PRIVATE KEY-----
             """;
 
-    public static String PRIVATE_KEY_RSA_1024 =
-            """
+    public static String PRIVATE_KEY_RSA_1024 = """
             -----BEGIN RSA PRIVATE KEY-----
             MIICXQIBAAKBgQC/+fn2CosvVV26//CaY4tLHWxoK1XjSp2HYF6lxDgMWw4Rq+Rx
             ds62LC2oHjsO/YHtKmwh+C61jk0UNAENer5V9SiHCStzB/l8qLG4jHZb4JggpRsn
@@ -49,8 +47,7 @@ class EC2CloudPrivateKeyWithFIPSTest {
             -----END RSA PRIVATE KEY-----
             """;
 
-    public static String PRIVATE_KEY_RSA_2048 =
-            """
+    public static String PRIVATE_KEY_RSA_2048 = """
             -----BEGIN RSA PRIVATE KEY-----
             MIIEogIBAAKCAQEAuKaL32E+cTIvWlfX6U4Q+ky+9/PREwVw/HA0nNWdf1bV8qxU
             8XQh/JFHuGr8Jr5i64VE70rlvE/q/jM3m6G+s5INYjG5x0VXXtNEQoab12/WELFJ
@@ -80,8 +77,7 @@ class EC2CloudPrivateKeyWithFIPSTest {
             -----END RSA PRIVATE KEY-----
             """;
 
-    public static String PRIVATE_KEY_RSA_3072 =
-            """
+    public static String PRIVATE_KEY_RSA_3072 = """
             -----BEGIN RSA PRIVATE KEY-----
             MIIG4wIBAAKCAYEAxiHReDpOX+whDtLOFJ1lcisLs3qgnlrN2EocdQ6Ir64MkrE6
             9xnmFW2ePzyxpamWKGAkj5Bh97/4ShCVYr7lfzTy8KrrOOyy6Dxv7FL+RjljGNjE
@@ -123,8 +119,7 @@ class EC2CloudPrivateKeyWithFIPSTest {
             -----END RSA PRIVATE KEY-----
             """;
 
-    public static String PRIVATE_KEY_RSA_4096 =
-            """
+    public static String PRIVATE_KEY_RSA_4096 = """
             -----BEGIN RSA PRIVATE KEY-----
             MIIJKQIBAAKCAgEA34JSqlJeo9Kipy82+zprwJs9wLyDZJ5S4Obskz0kbNB3JQgQ
             J4lUkSCzOuLOOChGCxpuKgd2MmL1P4YmsHU77FMFisZlJ301Ts4EuYpn0uS8106E
@@ -178,8 +173,7 @@ class EC2CloudPrivateKeyWithFIPSTest {
             -----END RSA PRIVATE KEY-----
             """;
 
-    public static String PRIVATE_KEY_ECDSA_256 =
-            """
+    public static String PRIVATE_KEY_ECDSA_256 = """
             -----BEGIN EC PRIVATE KEY-----
             MHcCAQEEICK/NJcJmy18Co6iL023g9/4K+6CNqLJBAHE8/sGYarLoAoGCCqGSM49
             AwEHoUQDQgAE+P+p3NmQK4QnrFNgeiNOwjGkikQ3Gf3yuf8O5WbfRbUFunP/dtnp
@@ -187,8 +181,7 @@ class EC2CloudPrivateKeyWithFIPSTest {
             -----END EC PRIVATE KEY-----
             """;
 
-    public static String PRIVATE_KEY_ECDSA_384 =
-            """
+    public static String PRIVATE_KEY_ECDSA_384 = """
             -----BEGIN EC PRIVATE KEY-----
             MIGkAgEBBDDPRHa8rL2Gx9vmI70pjQJbnyDxU0TOkwqj7ILfsv90fSsO19qQARhB
             w7gH1qOkclmgBwYFK4EEACKhZANiAAR2v/iys6np24cCT+/5Hi/pmjsCpj9OQaUP
@@ -197,8 +190,7 @@ class EC2CloudPrivateKeyWithFIPSTest {
             -----END EC PRIVATE KEY-----
             """;
 
-    public static String PRIVATE_KEY_ECDSA_521 =
-            """
+    public static String PRIVATE_KEY_ECDSA_521 = """
             -----BEGIN EC PRIVATE KEY-----
             MIHcAgEBBEIBVoBkpQalEMfeJGPQubTF3EyEqc9uveqRGmHtzjsK1ZyXZPqGfTdA
             nyS22O2PDwyUh/tmQBZ98XY5f6zmf8+NIimgBwYFK4EEACOhgYkDgYYABACVlF0S

--- a/src/test/java/hudson/plugins/ec2/EC2PrivateKeyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2PrivateKeyTest.java
@@ -39,8 +39,7 @@ import software.amazon.awssdk.core.exception.SdkException;
 class EC2PrivateKeyTest {
 
     private EC2PrivateKey getPrivateKey() {
-        return new EC2PrivateKey(
-                """
+        return new EC2PrivateKey("""
                 -----BEGIN RSA PRIVATE KEY-----
                 MIIEowIBAAKCAQEAlpK/pGxCRoHpbIObxYW53fl4qA+EQNHuSveNyxt+6m/HAdRLhEMGHe7/b7dR
                 e8bnJLtJD7+rTyKnhIiAQ3ZKSAXUNjbcwnH/lxfT39ht/PkupK0Vbdzgdm4vYfciFsqO/H1T5WPb

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateTest.java
@@ -1797,6 +1797,9 @@ class SlaveTemplateTest {
     }
 
     private HtmlForm getConfigForm(EC2Cloud ac) throws IOException, SAXException {
-        return r.createWebClient().goTo(ac.getUrl() + "configure").getFormByName("config");
+        JenkinsRule.WebClient webClient = r.createWebClient();
+        var page = webClient.goTo(ac.getUrl() + "configure");
+        webClient.waitForBackgroundJavaScript(5000);
+        return page.getFormByName("config");
     }
 }

--- a/src/test/java/hudson/plugins/ec2/util/AmazonEC2FactoryMockImpl.java
+++ b/src/test/java/hudson/plugins/ec2/util/AmazonEC2FactoryMockImpl.java
@@ -270,10 +270,11 @@ public class AmazonEC2FactoryMockImpl implements AmazonEC2Factory {
         Mockito.doAnswer(invocationOnMock -> {
                     TerminateInstancesRequest request = invocationOnMock.getArgument(0);
                     List<Instance> instancesToRemove = new ArrayList<>();
-                    request.instanceIds().forEach(instanceId -> instances.stream()
-                            .filter(instance -> instance.instanceId().equals(instanceId))
-                            .findFirst()
-                            .ifPresent(instancesToRemove::add));
+                    request.instanceIds()
+                            .forEach(instanceId -> instances.stream()
+                                    .filter(instance -> instance.instanceId().equals(instanceId))
+                                    .findFirst()
+                                    .ifPresent(instancesToRemove::add));
                     instances.removeAll(instancesToRemove);
                     return TerminateInstancesResponse.builder()
                             .terminatingInstances(instancesToRemove.stream()

--- a/src/test/java/hudson/plugins/ec2/util/ConnectionExtension.java
+++ b/src/test/java/hudson/plugins/ec2/util/ConnectionExtension.java
@@ -29,8 +29,7 @@ public class ConnectionExtension implements BeforeAllCallback, AfterAllCallback 
 
     private static final String USER = "jenkins";
     private static final int SSH_PORT = 22;
-    private static final String privateKey =
-            """
+    private static final String privateKey = """
                     -----BEGIN RSA PRIVATE KEY-----
                     MIIEowIBAAKCAQEA3x7Q+RNxkeqlDAbosRm7tXrFLuN1fcyZ4ERLEume/JLVSYny
                     BM4v0KhKMkTFsyVXiMukHCS0/mYnfTvjGld76pzYdoXSzncc8zZruDnMVgzAUoSS


### PR DESCRIPTION
The upgraded test harness can submit the cloud configuration form before the asynchronous instance-type selector finishes loading. That makes the round-trip test retain a different instance type than the one it selected.

This waits for background JavaScript before returning the configuration form. The other touched lines are the formatting changes required by the upgraded parent's Spotless rules.

Verification:
- `JAVA_HOME=$(/usr/libexec/java_home -v 25) mvn -B -T 1C clean verify`
- 335 tests passed (1 skipped)
- SpotBugs passed with zero findings
- Spotless passed with zero remaining changes
