### PR TITLE
Show Mac agents as Mac in the launch log

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -26,8 +26,10 @@ package hudson.plugins.ec2;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Util;
 import hudson.model.Node;
+import hudson.remoting.Channel;
 import hudson.slaves.SlaveComputer;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -73,6 +75,23 @@ public class EC2Computer extends SlaveComputer {
 
     public EC2Computer(EC2AbstractSlave slave) {
         super(slave);
+    }
+
+    /**
+     * Jenkins core reports every non-Windows node as a Unix agent. Rewrite that launch-log line for Mac nodes.
+     */
+    @Override
+    public void setChannel(Channel channel, OutputStream launchLog, Channel.Listener listener)
+            throws IOException, InterruptedException {
+        if (isMacAgent() && launchLog != null) {
+            launchLog = new MacAgentLaunchLog(launchLog);
+        }
+        super.setChannel(channel, launchLog, listener);
+    }
+
+    private boolean isMacAgent() {
+        EC2AbstractSlave node = getNode();
+        return node != null && node.amiType != null && node.amiType.isMac();
     }
 
     @Override

--- a/src/main/java/hudson/plugins/ec2/MacAgentLaunchLog.java
+++ b/src/main/java/hudson/plugins/ec2/MacAgentLaunchLog.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.ec2;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Replaces Jenkins core's "This is a Unix agent" launch-log line for EC2 Mac agents.
+ */
+final class MacAgentLaunchLog extends FilterOutputStream {
+    static final String UNIX_AGENT_LINE = "This is a Unix agent";
+    static final String MAC_AGENT_LINE = "This is a Mac agent";
+
+    private final ByteArrayOutputStream line = new ByteArrayOutputStream();
+
+    MacAgentLaunchLog(OutputStream out) {
+        super(out);
+    }
+
+    @Override
+    public synchronized void write(int b) throws IOException {
+        if (b == '\n') {
+            flushLine();
+            out.write('\n');
+        } else if (b != '\r') {
+            line.write(b);
+        }
+    }
+
+    @Override
+    public synchronized void write(byte[] b, int off, int len) throws IOException {
+        for (int i = 0; i < len; i++) {
+            write(b[off + i] & 0xFF);
+        }
+    }
+
+    @Override
+    public synchronized void flush() throws IOException {
+        if (line.size() > 0) {
+            out.write(line.toByteArray());
+            line.reset();
+        }
+        super.flush();
+    }
+
+    private void flushLine() throws IOException {
+        String text = line.toString(StandardCharsets.UTF_8);
+        line.reset();
+        if (UNIX_AGENT_LINE.equals(text)) {
+            text = MAC_AGENT_LINE;
+        }
+        out.write(text.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2MacLauncher.java
@@ -51,7 +51,7 @@ import software.amazon.awssdk.services.ec2.model.Instance;
 import software.amazon.awssdk.services.ec2.model.InstanceType;
 
 /**
- * {@link ComputerLauncher} that connects to a Unix agent on EC2 by using SSH.
+ * {@link ComputerLauncher} that connects to a Mac agent on EC2 by using SSH.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/src/test/java/hudson/plugins/ec2/EC2ComputerMacAgentLogTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2ComputerMacAgentLogTest.java
@@ -1,0 +1,33 @@
+package hudson.plugins.ec2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class EC2ComputerMacAgentLogTest {
+
+    @Test
+    void rewritesUnixAgentLineToMacAgent() throws Exception {
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        try (PrintStream log = new PrintStream(new MacAgentLaunchLog(captured), true, StandardCharsets.UTF_8)) {
+            log.println("Remoting version: 3352.v17a_fb_4_b_2773f");
+            log.println("Launcher: EC2MacLauncher");
+            log.println("Communication Protocol: Standard in/out");
+            log.println(MacAgentLaunchLog.UNIX_AGENT_LINE);
+            log.println("Agent successfully connected and online");
+        }
+
+        String output = captured.toString(StandardCharsets.UTF_8).replace("\r\n", "\n");
+        assertEquals(
+                "Remoting version: 3352.v17a_fb_4_b_2773f\n"
+                        + "Launcher: EC2MacLauncher\n"
+                        + "Communication Protocol: Standard in/out\n"
+                        + MacAgentLaunchLog.MAC_AGENT_LINE
+                        + "\n"
+                        + "Agent successfully connected and online\n",
+                output);
+    }
+}


### PR DESCRIPTION
Jenkins core always prints "This is a Unix agent" for non-Windows nodes. Wrap the launch log for EC2 Mac agents so the line reads "This is a Mac agent".

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
