### PR TITLE
Retry dedicated-host capacity errors across all configured subnets

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -171,11 +171,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     /**
      * AWS {@code RunInstances} error codes that indicate the chosen subnet/AZ cannot
-     * currently supply the requested instance type, so provisioning should try a
-     * different subnet rather than fail.
+     * currently supply the requested instance type (including Mac dedicated hosts),
+     * so provisioning should try a different subnet rather than fail.
      */
-    private static final Set<String> INSUFFICIENT_CAPACITY_ERROR_CODES =
-            Set.of("InsufficientInstanceCapacity", "InsufficientHostCapacity", "InsufficientReservedInstancesCapacity");
+    private static final Set<String> INSUFFICIENT_CAPACITY_ERROR_CODES = Set.of(
+            "InsufficientInstanceCapacity",
+            "InsufficientHostCapacity",
+            "InsufficientReservedInstancesCapacity",
+            "DedicatedHostLimitExceeded");
 
     /**
      * Maps a subnet id to the epoch-millis timestamp until which the subnet should be
@@ -1795,6 +1798,21 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return getSubnetId().split(EC2_RESOURCE_ID_DELIMETERS).length;
     }
 
+    /**
+     * Replaces the single chosen-subnet describe filter with every configured subnet
+     * so existing instances can be reused regardless of AZ.
+     */
+    void expandDescribeFiltersToAllSubnets(List<Filter> diFilters) {
+        if (getSubnetCount() == 0) {
+            return;
+        }
+        diFilters.removeIf(f -> "subnet-id".equals(f.name()));
+        diFilters.add(Filter.builder()
+                .name("subnet-id")
+                .values(Arrays.asList(getSubnetId().split(EC2_RESOURCE_ID_DELIMETERS)))
+                .build());
+    }
+
     private synchronized ConcurrentHashMap<String, Long> getSubnetCapacityCooldownMap() {
         if (subnetCapacityCooldownUntil == null) {
             subnetCapacityCooldownUntil = new ConcurrentHashMap<>();
@@ -2511,6 +2529,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 runInstancesRequestFilterMap.entrySet().iterator().next();
         RunInstancesRequest riRequest = entry.getKey();
         List<Filter> diFilters = entry.getValue();
+        expandDescribeFiltersToAllSubnets(diFilters);
 
         DescribeInstancesRequest diRequest =
                 DescribeInstancesRequest.builder().filters(diFilters).build();
@@ -3472,23 +3491,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         List<Filter> diFilters = entry.getValue();
 
         if (allSubnets) {
-            /* remove any existing subnet-id filters */
-            List<Filter> rmvFilters = new ArrayList<>();
-            for (Filter f : diFilters) {
-                if (f.name().equals("subnet-id")) {
-                    rmvFilters.add(f);
-                }
-            }
-            for (Filter f : rmvFilters) {
-                diFilters.remove(f);
-            }
-
-            /* Add filter using all subnets defined for this SlaveTemplate */
-            Filter subnetFilter = Filter.builder()
-                    .name("subnet-id")
-                    .values(Arrays.asList(getSubnetId().split(EC2_RESOURCE_ID_DELIMETERS)))
-                    .build();
-            diFilters.add(subnetFilter);
+            expandDescribeFiltersToAllSubnets(diFilters);
         }
 
         DescribeInstancesRequest diRequest =

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-subnetId.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-subnetId.html
@@ -1,3 +1,3 @@
 <div>
-  List of subnet IDs to launch instances into.<br/><br/>Specify one or more subnet IDs separated with space, comma, or semicolon if you're using a non-default VPC. If more than one subnet ID is provided, instances will be launched in each subnet in a round-robin fashion beginning with the first subnet in the list.
+  List of subnet IDs to launch instances into.<br/><br/>Specify one or more subnet IDs separated with space, comma, or semicolon if you're using a non-default VPC. If more than one subnet ID is provided, instances will be launched in each subnet in a round-robin fashion beginning with the first subnet in the list. Existing instances are searched in every listed subnet. If a subnet reports insufficient capacity (including dedicated-host limits), the plugin immediately retries the next subnet.
 </div>

--- a/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
+++ b/src/test/java/hudson/plugins/ec2/SlaveTemplateUnitTest.java
@@ -1579,6 +1579,7 @@ class SlaveTemplateUnitTest {
         assertTrue(SlaveTemplate.isInsufficientCapacityError("InsufficientInstanceCapacity"));
         assertTrue(SlaveTemplate.isInsufficientCapacityError("InsufficientHostCapacity"));
         assertTrue(SlaveTemplate.isInsufficientCapacityError("InsufficientReservedInstancesCapacity"));
+        assertTrue(SlaveTemplate.isInsufficientCapacityError("DedicatedHostLimitExceeded"));
         assertFalse(SlaveTemplate.isInsufficientCapacityError("RequestLimitExceeded"));
         assertFalse(SlaveTemplate.isInsufficientCapacityError(null));
     }
@@ -1588,6 +1589,23 @@ class SlaveTemplateUnitTest {
         assertEquals(3, slaveTemplateWithSubnets("subnet-1 subnet-2 subnet-3").getSubnetCount());
         assertEquals(1, slaveTemplateWithSubnets("subnet-1").getSubnetCount());
         assertEquals(0, slaveTemplateWithSubnets("").getSubnetCount());
+    }
+
+    @Test
+    void testExpandDescribeFiltersToAllSubnets() {
+        SlaveTemplate template = slaveTemplateWithSubnets("subnet-1 subnet-2 subnet-3");
+        List<Filter> filters = new ArrayList<>();
+        filters.add(Filter.builder().name("image-id").values("ami-123").build());
+        filters.add(Filter.builder().name("subnet-id").values("subnet-1").build());
+
+        template.expandDescribeFiltersToAllSubnets(filters);
+
+        Filter subnetFilter = filters.stream()
+                .filter(f -> "subnet-id".equals(f.name()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(List.of("subnet-1", "subnet-2", "subnet-3"), subnetFilter.values());
+        assertEquals(2, filters.size());
     }
 
     private static final class MutableClock extends Clock {


### PR DESCRIPTION
Search existing instances in every configured subnet, and treat DedicatedHostLimitExceeded as a capacity error so Mac dedicated-host launches retry the next AZ immediately.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
