### PR TITLE
Autoscale hot spares by agent label with weighted failover across templates

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -157,6 +157,20 @@ public abstract class EC2AbstractSlave extends Slave {
 
     private transient Instant createdTime;
 
+    /**
+     * Epoch millis when this node object was created, i.e. when provisioning was requested. This is
+     * earlier than the EC2 instance launch time and is available even if the instance never starts,
+     * which is what makes it a usable baseline for the provisioning grace period.
+     */
+    private transient volatile long provisionRequestedAtMillis;
+
+    /**
+     * Epoch millis when the agent channel first came up, or {@code 0} if it never has. Idle time is
+     * measured from this rather than from the EC2 launch time so that slow user data or init
+     * scripts do not consume the idle budget.
+     */
+    private transient volatile long onlineSinceMillis;
+
     public static final String TEST_ZONE = "testZone";
 
     public EC2AbstractSlave(
@@ -546,7 +560,30 @@ public abstract class EC2AbstractSlave extends Slave {
             o.terminateScheduled = new ResettableCountDownLatch(1, false);
         }
 
+        /*
+         * Transient, so this is zero both for a freshly constructed node (this method is called at the
+         * end of the constructor) and for one deserialized from disk. In either case "now" is the best
+         * available approximation of when provisioning was requested.
+         */
+        if (o.provisionRequestedAtMillis == 0) {
+            o.provisionRequestedAtMillis = System.currentTimeMillis();
+        }
+
         return o;
+    }
+
+    /**
+     * @return epoch millis when provisioning was requested for this node.
+     */
+    public long getProvisionRequestedAtMillis() {
+        return provisionRequestedAtMillis;
+    }
+
+    /**
+     * @return epoch millis when the agent channel first came up, or {@code 0} if it never has.
+     */
+    public long getOnlineSinceMillis() {
+        return onlineSinceMillis;
     }
 
     public EC2Cloud getCloud() {
@@ -831,6 +868,11 @@ public abstract class EC2AbstractSlave extends Slave {
         terminate();
     }
 
+    void graceTimeout() {
+        LOGGER.info("EC2 instance never came online within the grace period: " + getInstanceId());
+        terminate();
+    }
+
     public long getLaunchTimeoutInMillis() {
         // this should be fine as long as launchTimeout remains an int type
         return launchTimeout * 1000L;
@@ -898,6 +940,9 @@ public abstract class EC2AbstractSlave extends Slave {
      */
     public void onConnected() {
         isConnected = true;
+        if (onlineSinceMillis == 0) {
+            onlineSinceMillis = System.currentTimeMillis();
+        }
     }
 
     protected boolean isAlive(boolean force) {

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -516,6 +516,22 @@ public class EC2Cloud extends Cloud {
     }
 
     /**
+     * @return the hot spare rule whose policy governs a label, or {@code null} if none does. A rule
+     *     governs a label when it covers a template that can serve it, which is what lets one rule
+     *     set the policy for several labels while each of them scales on its own.
+     */
+    @CheckForNull
+    public HotSpareConfigByLabel getHotSpareConfigForLabel(@NonNull Label label) {
+        Collection<SlaveTemplate> serving = getTemplates(label);
+        for (HotSpareConfigByLabel config : getHotSpareConfigsByLabel()) {
+            if (serving.stream().anyMatch(config::matches)) {
+                return config;
+            }
+        }
+        return null;
+    }
+
+    /**
      * @return the idle timeout configured for a label, or {@code null} if no rule covers it.
      */
     @CheckForNull

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -1509,7 +1509,7 @@ public class EC2Cloud extends Cloud {
 
     /**
      * Provisions {@code number} instances from the label group, starting at {@code startIndex} and
-     * falling back to the next template when one cannot deliver.
+     * asking the next template for whatever the ones before it could not supply.
      *
      * <p>Failing over here rather than returning {@code null} is what makes a label provision as
      * fast as its fastest available instance type: an insufficient-capacity error used to cost a
@@ -1517,17 +1517,33 @@ public class EC2Cloud extends Cloud {
      * capacity error puts a template into the rotation cooldown; being at its instance cap or
      * failing for any other reason just moves on to the next candidate for this request.
      *
+     * <p>A template that delivers some of the request but not all of it is treated the same way as
+     * one that delivered nothing: the remainder is offered to the templates behind it, and the
+     * request is only short once the whole group has been asked. EC2 launches as many instances as
+     * it can rather than refusing a request it can only partly fill, and an instance type is a
+     * single spot pool, so a wide request routinely needs more than one of them.
+     *
      * @return the provisioned agents, or {@code null} if no template in the group could provide any.
      */
     private List<EC2AbstractSlave> provisionFromGroup(List<SlaveTemplate> ordered, int startIndex, int number) {
+        final List<EC2AbstractSlave> provisioned = new ArrayList<>();
         for (int i = startIndex; i < ordered.size(); i++) {
             final SlaveTemplate t = ordered.get(i);
+            final int remaining = number - provisioned.size();
             try {
-                List<EC2AbstractSlave> slaves = provisionFromTemplate(t, number);
+                List<EC2AbstractSlave> slaves = provisionFromTemplate(t, remaining);
                 if (slaves != null && !slaves.isEmpty()) {
-                    return slaves;
+                    provisioned.addAll(slaves);
+                    if (provisioned.size() >= number) {
+                        return provisioned;
+                    }
+                    LOGGER.log(
+                            Level.INFO,
+                            "{0}. Provisioned {1} of the {2} instance(s) asked for, offering the rest to the next template",
+                            new Object[] {t, slaves.size(), remaining});
+                } else {
+                    LOGGER.log(Level.INFO, "{0}. Provisioning returned no instances, trying next template", t);
                 }
-                LOGGER.log(Level.INFO, "{0}. Provisioning returned no instances, trying next template", t);
             } catch (AwsServiceException e) {
                 String errorCode =
                         e.awsErrorDetails() == null ? null : e.awsErrorDetails().errorCode();
@@ -1559,7 +1575,52 @@ public class EC2Cloud extends Cloud {
              */
             invalidateInstanceCountCache();
         }
-        return null;
+        return provisioned.isEmpty() ? null : provisioned;
+    }
+
+    /**
+     * Provisions up to {@code number} agents from an ordered group of templates and attaches them
+     * to Jenkins, taking what each template can deliver and asking the next one for the rest.
+     *
+     * <p>For callers that are not the {@link hudson.slaves.NodeProvisioner}, which attaches the
+     * nodes it planned itself. Warming hot spares goes through here so a label reaches its target
+     * within one pass, across as many instance types as it takes, rather than being limited to
+     * whatever the template at the head of its group happens to have.
+     *
+     * @return the number of agents provisioned and attached, which is less than {@code number} when
+     *     the group as a whole could not supply it.
+     */
+    @Restricted(NoExternalUse.class)
+    public int provisionAcrossGroup(@NonNull List<SlaveTemplate> ordered, int number) {
+        Jenkins jenkinsInstance = Jenkins.get();
+        if (jenkinsInstance.isQuietingDown()) {
+            LOGGER.log(Level.FINE, "Not provisioning nodes, Jenkins instance is quieting down");
+            return 0;
+        } else if (jenkinsInstance.isTerminating()) {
+            LOGGER.log(Level.FINE, "Not provisioning nodes, Jenkins instance is terminating");
+            return 0;
+        }
+
+        List<EC2AbstractSlave> slaves = provisionFromGroup(ordered, 0, number);
+        if (slaves == null || slaves.isEmpty()) {
+            return 0;
+        }
+
+        int attached = 0;
+        for (EC2AbstractSlave slave : slaves) {
+            if (slave == null) {
+                continue;
+            }
+            try {
+                attachSlavesToJenkins(
+                        jenkinsInstance, Collections.singletonList(slave), templateOf(slave, ordered.get(0)));
+                attached++;
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to attach " + slave.getNodeName(), e);
+            }
+        }
+        invalidateInstanceCountCache();
+        return attached;
     }
 
     /**

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -677,7 +677,6 @@ public class EC2Cloud extends Cloud {
         if (this.lastCountedInstanceIds == null) {
             this.lastCountedInstanceIds = Collections.emptySet();
         }
-        this.rotation = new LabelTemplateRotation(this::isRoundRobinTemplatesByLabel);
         if (this.hotSpareConfigsByLabel == null) {
             this.hotSpareConfigsByLabel = new ArrayList<>();
         }

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -176,6 +176,17 @@ public class EC2Cloud extends Cloud {
     private volatile int cachedTotalSlaves = -1;
     private transient ConcurrentHashMap<String, Integer> cachedTemplateSlaves = new ConcurrentHashMap<>();
 
+    /**
+     * How long a launched instance keeps counting against the caps while EC2 has not reported it.
+     * Long enough for describe-instances and describe-spot-instance-requests to catch up, short
+     * enough that an instance which never appears stops blocking provisioning.
+     */
+    private static final long IN_FLIGHT_INSTANCE_TTL_MS =
+            Long.getLong("jenkins.ec2.inFlightInstanceTtlMs", TimeUnit.MINUTES.toMillis(2));
+
+    private transient ConcurrentHashMap<String, InFlightInstance> inFlightInstances = new ConcurrentHashMap<>();
+    private transient volatile Set<String> lastCountedInstanceIds = Collections.emptySet();
+
     private static final ExecutorService PROVISIONING_EXECUTOR = Executors.newCachedThreadPool(r -> {
         Thread t = new Thread(r, "EC2Cloud-provisioning");
         t.setDaemon(true);
@@ -243,9 +254,23 @@ public class EC2Cloud extends Cloud {
 
     private boolean noDelayProvisioning;
 
+    /**
+     * Whether templates matching the same label are rotated instead of being tried in configured
+     * order. Default {@code false} so existing installations keep their template ordering.
+     */
+    private boolean roundRobinTemplatesByLabel;
+
+    /**
+     * Hot spare scaling rules, each owning the spare count for one label across every template
+     * carrying it.
+     */
+    private List<HotSpareConfigByLabel> hotSpareConfigsByLabel = new ArrayList<>();
+
     private boolean cleanUpOrphanedNodes;
 
     private transient volatile Ec2Client connection;
+
+    private transient LabelTemplateRotation rotation;
 
     @DataBoundConstructor
     public EC2Cloud(
@@ -423,6 +448,145 @@ public class EC2Cloud extends Cloud {
         this.noDelayProvisioning = noDelayProvisioning;
     }
 
+    /**
+     * @return whether templates matching the same label are treated as interchangeable hardware and
+     *     rotated, honouring {@link SlaveTemplate#getHotSpareWeight()}. When disabled, templates are
+     *     tried in configured order.
+     */
+    public boolean isRoundRobinTemplatesByLabel() {
+        return roundRobinTemplatesByLabel;
+    }
+
+    @DataBoundSetter
+    public void setRoundRobinTemplatesByLabel(boolean roundRobinTemplatesByLabel) {
+        this.roundRobinTemplatesByLabel = roundRobinTemplatesByLabel;
+    }
+
+    @NonNull
+    public List<HotSpareConfigByLabel> getHotSpareConfigsByLabel() {
+        return hotSpareConfigsByLabel == null ? Collections.emptyList() : hotSpareConfigsByLabel;
+    }
+
+    @DataBoundSetter
+    public void setHotSpareConfigsByLabel(List<HotSpareConfigByLabel> hotSpareConfigsByLabel) {
+        this.hotSpareConfigsByLabel = hotSpareConfigsByLabel == null ? new ArrayList<>() : hotSpareConfigsByLabel;
+    }
+
+    /**
+     * @return the hot spare rule that applies to this computer, or {@code null} if none does. A
+     *     computer matches a rule when the rule's label is carried by the computer's template, the
+     *     same homogeneity test {@link #getTemplates(Label)} uses.
+     */
+    @CheckForNull
+    public HotSpareConfigByLabel getHotSpareConfigFor(@NonNull EC2Computer computer) {
+        return getHotSpareConfigFor(computer.getSlaveTemplate());
+    }
+
+    @CheckForNull
+    HotSpareConfigByLabel getHotSpareConfigFor(@CheckForNull SlaveTemplate template) {
+        if (template == null) {
+            return null;
+        }
+        for (HotSpareConfigByLabel config : getHotSpareConfigsByLabel()) {
+            if (config.matches(template)) {
+                return config;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return the idle timeout configured for a label, or {@code null} if no rule covers it.
+     */
+    @CheckForNull
+    public Integer getIdleTerminationForLabel(@NonNull String label) {
+        for (HotSpareConfigByLabel config : getHotSpareConfigsByLabel()) {
+            if (label.equals(config.getLabel())) {
+                return config.getIdleTimeoutMinutes();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Idle termination for a computer as governed by a matching hot spare rule.
+     *
+     * <p>The rule wins by default. A template only takes precedence when the rule opts in to it
+     * <em>and</em> the template sets an idle termination time of its own: without that second
+     * condition every default template would beat the rule with its own unset value.
+     *
+     * @return the effective idle termination in minutes, or {@code null} to keep the value the
+     *     retention strategy was configured with.
+     */
+    @CheckForNull
+    public Integer resolveIdleTerminationMinutes(@NonNull EC2Computer computer) {
+        HotSpareConfigByLabel config = getHotSpareConfigFor(computer);
+        if (config == null) {
+            return null;
+        }
+        SlaveTemplate template = computer.getSlaveTemplate();
+        if (config.isAllowTemplateIdleTimeoutOverride() && hasExplicitIdleTermination(template)) {
+            return null;
+        }
+        return config.getIdleTimeoutMinutes();
+    }
+
+    /**
+     * Grace period for a computer, resolved the same way as the idle termination time.
+     *
+     * @return the effective grace period in minutes; 0 means no grace period.
+     */
+    public int resolveGracePeriodMinutes(@NonNull EC2Computer computer) {
+        SlaveTemplate template = computer.getSlaveTemplate();
+        int templateGrace = template == null ? 0 : template.getGracePeriodMinutes();
+        HotSpareConfigByLabel config = getHotSpareConfigFor(computer);
+        if (config == null) {
+            return templateGrace;
+        }
+        if (config.isAllowTemplateGracePeriodOverride() && templateGrace != 0) {
+            return templateGrace;
+        }
+        return config.getGracePeriodMinutes();
+    }
+
+    /**
+     * Whether grace-period expiry discards the agent rather than starting its idle clock. A plain
+     * boolean cannot express "unset", so this flag travels with whichever grace period won rather
+     * than having a precedence rule of its own.
+     */
+    public boolean resolveDiscardAfterGracePeriod(@NonNull EC2Computer computer) {
+        SlaveTemplate template = computer.getSlaveTemplate();
+        boolean templateDiscard = template == null || template.isDiscardAfterGracePeriod();
+        int templateGrace = template == null ? 0 : template.getGracePeriodMinutes();
+        HotSpareConfigByLabel config = getHotSpareConfigFor(computer);
+        if (config == null) {
+            return templateDiscard;
+        }
+        if (config.isAllowTemplateGracePeriodOverride() && templateGrace != 0) {
+            return templateDiscard;
+        }
+        return config.isDiscardAfterGracePeriod();
+    }
+
+    /**
+     * @return whether the template sets an idle termination time of its own. The field is a string,
+     *     so blank means unset, which is the tri-state the override checkbox needs.
+     */
+    private static boolean hasExplicitIdleTermination(@CheckForNull SlaveTemplate template) {
+        return template != null && Util.fixEmptyAndTrim(template.getidleTerminationMinutes()) != null;
+    }
+
+    /**
+     * @return the rotation state for this cloud's labels. Transient, so it is recreated after a
+     *     restart or a configuration reload.
+     */
+    synchronized LabelTemplateRotation getRotation() {
+        if (rotation == null) {
+            rotation = new LabelTemplateRotation(this::isRoundRobinTemplatesByLabel);
+        }
+        return rotation;
+    }
+
     public boolean isCleanUpOrphanedNodes() {
         return cleanUpOrphanedNodes;
     }
@@ -506,6 +670,16 @@ public class EC2Cloud extends Cloud {
         this.slaveCountingLock = new ReentrantLock();
         if (this.cachedTemplateSlaves == null) {
             this.cachedTemplateSlaves = new ConcurrentHashMap<>();
+        }
+        if (this.inFlightInstances == null) {
+            this.inFlightInstances = new ConcurrentHashMap<>();
+        }
+        if (this.lastCountedInstanceIds == null) {
+            this.lastCountedInstanceIds = Collections.emptySet();
+        }
+        this.rotation = new LabelTemplateRotation(this::isRoundRobinTemplatesByLabel);
+        if (this.hotSpareConfigsByLabel == null) {
+            this.hotSpareConfigsByLabel = new ArrayList<>();
         }
 
         for (SlaveTemplate t : templates) {
@@ -805,6 +979,8 @@ public class EC2Cloud extends Cloud {
 
         n += countCurrentEC2SpotSlaves(template, jenkinsServerUrl, instanceIds);
 
+        observeCountedInstances(instanceIds, template == null);
+
         return n;
     }
 
@@ -1010,17 +1186,24 @@ public class EC2Cloud extends Cloud {
     /**
      * Returns the maximum number of possible agents that can be created.
      * Uses cached instance counts when fresh (within TTL) to avoid repeated EC2 API calls.
+     *
+     * <p>Instances this cloud has launched but EC2 has not reported yet are counted on top of
+     * whatever EC2 says, so a request that arrives before the launch is visible still sees the caps
+     * as full. Without that, two requests a moment apart both pass the same cap: the second reads
+     * either the cached count or an EC2 answer that does not include the first launch yet.
+     *
+     * @see <a href="https://github.com/jenkinsci/ec2-plugin/issues/2030">ec2-plugin issue 2030</a>
      */
     private int getPossibleNewSlavesCount(SlaveTemplate template) throws SdkException {
         long now = System.currentTimeMillis();
-        String templateKey = Objects.toString(template.description, "") + ":" + template.getAmi();
+        String templateKey = templateCountKey(template);
 
         if (now - instanceCountCacheTimestamp < INSTANCE_COUNT_CACHE_TTL_MS) {
             int total = cachedTotalSlaves;
             Integer templateCount = cachedTemplateSlaves.get(templateKey);
             if (total >= 0 && templateCount != null && templateCount >= 0) {
-                int availableTotalSlaves = instanceCap - total;
-                int availableAmiSlaves = template.getInstanceCap() - templateCount;
+                int availableTotalSlaves = instanceCap - total - countInFlight(null);
+                int availableAmiSlaves = template.getInstanceCap() - templateCount - countInFlight(templateKey);
                 return Math.min(availableAmiSlaves, availableTotalSlaves);
             }
         }
@@ -1032,8 +1215,8 @@ public class EC2Cloud extends Cloud {
         cachedTotalSlaves = estimatedTotalSlaves;
         cachedTemplateSlaves.put(templateKey, estimatedAmiSlaves);
 
-        int availableTotalSlaves = instanceCap - estimatedTotalSlaves;
-        int availableAmiSlaves = template.getInstanceCap() - estimatedAmiSlaves;
+        int availableTotalSlaves = instanceCap - estimatedTotalSlaves - countInFlight(null);
+        int availableAmiSlaves = template.getInstanceCap() - estimatedAmiSlaves - countInFlight(templateKey);
         LOGGER.log(
                 Level.FINE,
                 "Available Total Agents: " + availableTotalSlaves + " Available AMI agents: " + availableAmiSlaves
@@ -1042,10 +1225,94 @@ public class EC2Cloud extends Cloud {
         return Math.min(availableAmiSlaves, availableTotalSlaves);
     }
 
+    private static String templateCountKey(SlaveTemplate template) {
+        return Objects.toString(template.description, "") + ":" + template.getAmi();
+    }
+
+    /**
+     * Records instances that have just been launched so they count against the caps until EC2
+     * reports them. Called while the counting lock is held, so the next request to reach the cap
+     * check already sees them.
+     *
+     * <p>An instance the last count already reported is not recorded: reusing an orphaned or
+     * stopped instance is not a new launch, and counting it twice would understate the headroom.
+     */
+    private void recordInFlight(SlaveTemplate template, @CheckForNull List<EC2AbstractSlave> slaves) {
+        if (slaves == null || slaves.isEmpty()) {
+            return;
+        }
+        String templateKey = templateCountKey(template);
+        long now = System.currentTimeMillis();
+        for (EC2AbstractSlave slave : slaves) {
+            String instanceId = slave.getInstanceId();
+            if (instanceId != null && !instanceId.isBlank() && !lastCountedInstanceIds.contains(instanceId)) {
+                inFlightInstances.put(instanceId, new InFlightInstance(templateKey, now));
+            }
+        }
+    }
+
+    /**
+     * Drops the in-flight records EC2 has caught up with, so they are not counted twice.
+     *
+     * @param countedInstanceIds the instances the count just returned.
+     * @param wasCloudWideCount whether the count covered every template, which is the only case
+     *     where the absence of an instance means EC2 really has not reported it yet.
+     */
+    private void observeCountedInstances(Set<String> countedInstanceIds, boolean wasCloudWideCount) {
+        if (wasCloudWideCount) {
+            lastCountedInstanceIds = Set.copyOf(countedInstanceIds);
+        }
+        inFlightInstances.keySet().removeAll(countedInstanceIds);
+    }
+
+    /**
+     * @param templateKey the template to count for, or {@code null} for every template.
+     * @return how many launched instances EC2 has not reported yet. Records older than
+     *     {@link #IN_FLIGHT_INSTANCE_TTL_MS} are discarded: by then the instance is either counted
+     *     by EC2 or gone, and holding on to it would understate the headroom forever.
+     */
+    private int countInFlight(@CheckForNull String templateKey) {
+        long cutoff = System.currentTimeMillis() - IN_FLIGHT_INSTANCE_TTL_MS;
+        inFlightInstances.values().removeIf(inFlight -> inFlight.launchedAtMillis < cutoff);
+        if (templateKey == null) {
+            return inFlightInstances.size();
+        }
+        return (int) inFlightInstances.values().stream()
+                .filter(inFlight -> templateKey.equals(inFlight.templateKey))
+                .count();
+    }
+
+    private static final class InFlightInstance {
+
+        private final String templateKey;
+        private final long launchedAtMillis;
+
+        InFlightInstance(String templateKey, long launchedAtMillis) {
+            this.templateKey = templateKey;
+            this.launchedAtMillis = launchedAtMillis;
+        }
+    }
+
     private void invalidateInstanceCountCache() {
         instanceCountCacheTimestamp = 0;
         cachedTotalSlaves = -1;
         cachedTemplateSlaves.clear();
+    }
+
+    /**
+     * @return how many more instances a template may launch before it, or the cloud, reaches its
+     *     instance cap. Never negative, and 0 means the template must be skipped.
+     */
+    public int getAvailableCapacity(@NonNull SlaveTemplate template) {
+        slaveCountingLock.lock();
+        try {
+            return Math.max(0, getPossibleNewSlavesCount(template));
+        } catch (SdkException e) {
+            LOGGER.log(Level.WARNING, template + ". Exception checking capacity", e);
+            return 0;
+        } finally {
+            slaveCountingLock.unlock();
+        }
     }
 
     /**
@@ -1079,7 +1346,9 @@ public class EC2Cloud extends Cloud {
                 number = possibleSlavesCount;
             }
 
-            return t.provision(number, provisionOptions);
+            List<EC2AbstractSlave> slaves = t.provision(number, provisionOptions);
+            recordInFlight(t, slaves);
+            return slaves;
         } finally {
             slaveCountingLock.unlock();
         }
@@ -1099,7 +1368,16 @@ public class EC2Cloud extends Cloud {
             return Collections.emptyList();
         }
 
-        for (final SlaveTemplate t : matchingTemplates) {
+        /*
+         * Templates matching a label are candidates for the same work. With rotation enabled they
+         * are rotated so the label spreads across the interchangeable instance types the admin
+         * configured; otherwise they keep their configured order. Everything below operates on the
+         * resolved order, so the fallback to the next template behaves the same either way.
+         */
+        final List<SlaveTemplate> ordered = orderTemplatesForLabel(label, matchingTemplates);
+
+        for (int candidateIndex = 0; candidateIndex < ordered.size(); candidateIndex++) {
+            final SlaveTemplate t = ordered.get(candidateIndex);
             LOGGER.log(
                     Level.INFO,
                     "{0}. Attempting to provision agent needed by excess workload of " + excessWorkload + " units",
@@ -1124,55 +1402,11 @@ public class EC2Cloud extends Cloud {
             }
 
             final int number = actualNumber;
+            final int startIndex = candidateIndex;
 
             // Defer runInstances to background; return PlannedNodes immediately for fast NodeProvisioner response
             CompletableFuture<List<EC2AbstractSlave>> provisionFuture = CompletableFuture.supplyAsync(
-                    () -> {
-                        try {
-                            slaveCountingLock.lock();
-                            try {
-                                int possibleSlavesCount = getPossibleNewSlavesCount(t);
-                                if (possibleSlavesCount <= 0) {
-                                    LOGGER.log(Level.INFO, "{0}. Cannot provision - no capacity", t);
-                                    return null;
-                                }
-
-                                EnumSet<SlaveTemplate.ProvisionOptions> provisionOptions =
-                                        EnumSet.of(SlaveTemplate.ProvisionOptions.ALLOW_CREATE);
-                                int provisionCount = Math.min(number, possibleSlavesCount);
-
-                                if (provisionCount != number) {
-                                    LOGGER.log(
-                                            Level.INFO,
-                                            String.format(
-                                                    "%d nodes were requested for the template %s, "
-                                                            + "but because of instance cap only %d can be provisioned",
-                                                    number, t, provisionCount));
-                                }
-
-                                return t.provision(provisionCount, provisionOptions);
-                            } finally {
-                                slaveCountingLock.unlock();
-                            }
-                        } catch (AwsServiceException e) {
-                            LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
-                            if ("RequestExpired".equals(e.awsErrorDetails().errorCode())
-                                    || "ExpiredToken".equals(e.awsErrorDetails().errorCode())) {
-                                LOGGER.log(
-                                        Level.INFO, "Reconnecting to EC2 due to RequestExpired or ExpiredToken error");
-                                try {
-                                    reconnectToEc2();
-                                } catch (IOException e2) {
-                                    LOGGER.log(Level.WARNING, "Failed to reconnect ec2", e2);
-                                }
-                            }
-                            return null;
-                        } catch (SdkException | IOException e) {
-                            LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
-                            return null;
-                        }
-                    },
-                    PROVISIONING_EXECUTOR);
+                    () -> provisionFromGroup(ordered, startIndex, number), PROVISIONING_EXECUTOR);
 
             provisionFuture.whenComplete((slaves, ex) -> {
                 if (slaves != null && !slaves.isEmpty()) {
@@ -1189,7 +1423,10 @@ public class EC2Cloud extends Cloud {
                                 PROVISIONING_EXECUTOR)
                         .thenComposeAsync(
                                 slave -> slave != null
-                                        ? waitForRunningAndConnectAsync(t, slave)
+                                        // The group is homogeneous, but the agent may have come from
+                                        // a later template than the one planned, so log against its
+                                        // own template.
+                                        ? waitForRunningAndConnectAsync(templateOf(slave, t), slave)
                                         : CompletableFuture.completedFuture(null),
                                 Computer.threadPoolForRemoting);
 
@@ -1207,6 +1444,122 @@ public class EC2Cloud extends Cloud {
             });
         }
         return plannedNodes;
+    }
+
+    /**
+     * @return the template an agent was actually provisioned from, or {@code fallback} when it can
+     *     no longer be resolved.
+     */
+    private SlaveTemplate templateOf(EC2AbstractSlave slave, SlaveTemplate fallback) {
+        SlaveTemplate actual = getTemplate(slave.templateDescription);
+        return actual == null ? fallback : actual;
+    }
+
+    /**
+     * Resolves the order in which the templates matching a label are tried.
+     *
+     * @return the rotation order when {@link #isRoundRobinTemplatesByLabel()} is enabled, and the
+     *     configured order otherwise.
+     */
+    @Restricted(NoExternalUse.class)
+    public List<SlaveTemplate> orderTemplatesForLabel(Label label, Collection<SlaveTemplate> matching) {
+        if (!roundRobinTemplatesByLabel) {
+            return new ArrayList<>(matching);
+        }
+        return getRotation().order(label == null ? "" : label.getName(), matching);
+    }
+
+    /**
+     * Provisions {@code number} instances from the label group, starting at {@code startIndex} and
+     * falling back to the next template when one cannot deliver.
+     *
+     * <p>Failing over here rather than returning {@code null} is what makes a label provision as
+     * fast as its fastest available instance type: an insufficient-capacity error used to cost a
+     * whole {@link hudson.slaves.NodeProvisioner} cycle before another template was tried. Only a
+     * capacity error puts a template into the rotation cooldown; being at its instance cap or
+     * failing for any other reason just moves on to the next candidate for this request.
+     *
+     * @return the provisioned agents, or {@code null} if no template in the group could provide any.
+     */
+    private List<EC2AbstractSlave> provisionFromGroup(List<SlaveTemplate> ordered, int startIndex, int number) {
+        for (int i = startIndex; i < ordered.size(); i++) {
+            final SlaveTemplate t = ordered.get(i);
+            try {
+                List<EC2AbstractSlave> slaves = provisionFromTemplate(t, number);
+                if (slaves != null && !slaves.isEmpty()) {
+                    return slaves;
+                }
+                LOGGER.log(Level.INFO, "{0}. Provisioning returned no instances, trying next template", t);
+            } catch (AwsServiceException e) {
+                String errorCode =
+                        e.awsErrorDetails() == null ? null : e.awsErrorDetails().errorCode();
+                if (SlaveTemplate.isInsufficientCapacityError(errorCode)) {
+                    getRotation().markTemplateUnavailable(t, ordered.size());
+                    LOGGER.log(
+                            Level.INFO,
+                            String.format(
+                                    "Template %s has insufficient capacity for instance type %s (%s); trying next template",
+                                    t.getDescription(), t.getType(), errorCode));
+                } else {
+                    LOGGER.log(Level.WARNING, t + ". Exception during provisioning, trying next template", e);
+                    if ("RequestExpired".equals(errorCode) || "ExpiredToken".equals(errorCode)) {
+                        LOGGER.log(Level.INFO, "Reconnecting to EC2 due to RequestExpired or ExpiredToken error");
+                        try {
+                            reconnectToEc2();
+                        } catch (IOException e2) {
+                            LOGGER.log(Level.WARNING, "Failed to reconnect ec2", e2);
+                        }
+                    }
+                }
+            } catch (SdkException | IOException e) {
+                LOGGER.log(Level.WARNING, t + ". Exception during provisioning, trying next template", e);
+            }
+            /*
+             * The next candidate must see current instance counts rather than the ones cached
+             * before this attempt, otherwise the cloud-wide cap could be overshot while walking
+             * down the group.
+             */
+            invalidateInstanceCountCache();
+        }
+        return null;
+    }
+
+    /**
+     * Provisions up to {@code number} instances from a single template, respecting its instance cap.
+     *
+     * <p>A launch is recorded as in flight while the counting lock is still held, so a request that
+     * arrives moments later counts it against the cap even though neither the cached count nor EC2
+     * itself reports it yet. Two concurrent requests would otherwise both pass the same cap.
+     *
+     * @return the provisioned agents, or {@code null} if the template is at its cap.
+     * @see <a href="https://github.com/jenkinsci/ec2-plugin/issues/2030">ec2-plugin issue 2030</a>
+     */
+    private List<EC2AbstractSlave> provisionFromTemplate(SlaveTemplate t, int number) throws IOException {
+        slaveCountingLock.lock();
+        try {
+            int possibleSlavesCount = getPossibleNewSlavesCount(t);
+            if (possibleSlavesCount <= 0) {
+                LOGGER.log(Level.INFO, "{0}. Cannot provision - no capacity", t);
+                return null;
+            }
+
+            int provisionCount = Math.min(number, possibleSlavesCount);
+            if (provisionCount != number) {
+                LOGGER.log(
+                        Level.INFO,
+                        String.format(
+                                "%d nodes were requested for the template %s, "
+                                        + "but because of instance cap only %d can be provisioned",
+                                number, t, provisionCount));
+            }
+
+            List<EC2AbstractSlave> slaves =
+                    t.provision(provisionCount, EnumSet.of(SlaveTemplate.ProvisionOptions.ALLOW_CREATE));
+            recordInFlight(t, slaves);
+            return slaves;
+        } finally {
+            slaveCountingLock.unlock();
+        }
     }
 
     /**

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -1278,17 +1278,19 @@ public class EC2Cloud extends Cloud {
             return inFlightInstances.size();
         }
         return (int) inFlightInstances.values().stream()
-                .filter(inFlight -> templateKey.equals(inFlight.templateKey))
+                .filter(inFlight -> templateKey.equals(inFlight.templateId))
                 .count();
     }
 
     private static final class InFlightInstance {
 
-        private final String templateKey;
+        /** The description and AMI of the template that launched it, from {@link #templateCountKey}. */
+        private final String templateId;
+
         private final long launchedAtMillis;
 
-        InFlightInstance(String templateKey, long launchedAtMillis) {
-            this.templateKey = templateKey;
+        InFlightInstance(String templateId, long launchedAtMillis) {
+            this.templateId = templateId;
             this.launchedAtMillis = launchedAtMillis;
         }
     }

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -261,6 +261,12 @@ public class EC2Cloud extends Cloud {
     private boolean roundRobinTemplatesByLabel;
 
     /**
+     * Whether the rotation treats a weight as a rank rather than as a share of the requests.
+     * Default {@code false}, which keeps the proportional rotation weights have always meant.
+     */
+    private boolean saturateHighestWeightFirst;
+
+    /**
      * Hot spare scaling rules, each owning the spare count for one label across every template
      * carrying it.
      */
@@ -462,6 +468,20 @@ public class EC2Cloud extends Cloud {
         this.roundRobinTemplatesByLabel = roundRobinTemplatesByLabel;
     }
 
+    /**
+     * @return whether the rotation exhausts the templates carrying the highest
+     *     {@link SlaveTemplate#getHotSpareWeight()} before it uses a lower one. When disabled, the
+     *     weights are shares of the requests and every weight keeps receiving some of them.
+     */
+    public boolean isSaturateHighestWeightFirst() {
+        return saturateHighestWeightFirst;
+    }
+
+    @DataBoundSetter
+    public void setSaturateHighestWeightFirst(boolean saturateHighestWeightFirst) {
+        this.saturateHighestWeightFirst = saturateHighestWeightFirst;
+    }
+
     @NonNull
     public List<HotSpareConfigByLabel> getHotSpareConfigsByLabel() {
         return hotSpareConfigsByLabel == null ? Collections.emptyList() : hotSpareConfigsByLabel;
@@ -582,7 +602,8 @@ public class EC2Cloud extends Cloud {
      */
     synchronized LabelTemplateRotation getRotation() {
         if (rotation == null) {
-            rotation = new LabelTemplateRotation(this::isRoundRobinTemplatesByLabel);
+            rotation =
+                    new LabelTemplateRotation(this::isRoundRobinTemplatesByLabel, this::isSaturateHighestWeightFirst);
         }
         return rotation;
     }

--- a/src/main/java/hudson/plugins/ec2/EC2Computer.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Computer.java
@@ -239,6 +239,30 @@ public class EC2Computer extends SlaveComputer {
     }
 
     /**
+     * Epoch millis when this agent came online, or {@code 0} if it never has.
+     * <p>
+     * Normally recorded by {@link EC2AbstractSlave#onConnected()} via {@link EC2ComputerListener}. That
+     * value is transient, so after a controller restart a node whose channel is already up would report
+     * zero; {@link #getConnectTime()} covers that case.
+     */
+    public long getOnlineSinceMillis() {
+        EC2AbstractSlave node = getNode();
+        long onlineSince = node == null ? 0 : node.getOnlineSinceMillis();
+        if (onlineSince == 0 && isOnline()) {
+            return getConnectTime();
+        }
+        return onlineSince;
+    }
+
+    /**
+     * @return epoch millis when provisioning was requested for this agent, or {@code 0} if unknown.
+     */
+    public long getProvisionRequestedAtMillis() {
+        EC2AbstractSlave node = getNode();
+        return node == null ? 0 : node.getProvisionRequestedAtMillis();
+    }
+
+    /**
      * When the agent is deleted, terminate the instance.
      */
     @Override

--- a/src/main/java/hudson/plugins/ec2/EC2HotSpareChecker.java
+++ b/src/main/java/hudson/plugins/ec2/EC2HotSpareChecker.java
@@ -1,0 +1,29 @@
+package hudson.plugins.ec2;
+
+import hudson.Extension;
+import hudson.model.PeriodicWork;
+import hudson.plugins.ec2.util.MinimumInstanceChecker;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Keeps hot spare counts current between the events that already trigger a check (a build becoming
+ * buildable, a task being accepted, or the ten-minute {@link EC2SlaveMonitor} sweep). Those cover
+ * the cases that matter for latency; this is the backstop that lets a label fade away when nothing
+ * is happening at all.
+ *
+ * <p>This deliberately makes no provisioning decisions of its own: they all belong in the one
+ * synchronized {@link MinimumInstanceChecker#checkForMinimumInstances()} pass.
+ */
+@Extension
+public class EC2HotSpareChecker extends PeriodicWork {
+
+    @Override
+    public long getRecurrencePeriod() {
+        return TimeUnit.MINUTES.toMillis(1);
+    }
+
+    @Override
+    protected void doRun() {
+        MinimumInstanceChecker.scheduleCheck();
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/EC2HotSpareQueueListener.java
+++ b/src/main/java/hudson/plugins/ec2/EC2HotSpareQueueListener.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.ec2;
+
+import hudson.Extension;
+import hudson.model.Queue;
+import hudson.model.queue.QueueListener;
+import hudson.plugins.ec2.util.MinimumInstanceChecker;
+import jenkins.model.Jenkins;
+
+/**
+ * Asks for a hot spare pass as soon as a build is ready to run.
+ *
+ * <p>Without this, the first build for a label that has nothing warm has to wait for the periodic
+ * sweep before any spare is even requested, and the label's own agents cannot fill the gap: an
+ * executor being taken is the other trigger, and with no capacity there is no executor to take.
+ * That is minutes of latency spent on exactly the case the spares exist to cover.
+ *
+ * <p>{@link Queue.BuildableItem} is in the queue's buildable list by the time this runs, so the
+ * pass this schedules counts it. No provisioning decision is made here: this runs under the Queue
+ * lock, where the only safe thing to do is hand the work to
+ * {@link MinimumInstanceChecker#scheduleCheck()} and return.
+ */
+@Extension
+public class EC2HotSpareQueueListener extends QueueListener {
+
+    @Override
+    public void onEnterBuildable(Queue.BuildableItem item) {
+        if (anyCloudKeepsSparesByLabel()) {
+            MinimumInstanceChecker.scheduleCheck();
+        }
+    }
+
+    /**
+     * @return whether any EC2 cloud has a label rule at all. Which rules the build actually matches
+     *     is worked out by the pass itself, off this thread.
+     */
+    private static boolean anyCloudKeepsSparesByLabel() {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins == null) {
+            return false;
+        }
+        return jenkins.clouds.stream()
+                .filter(EC2Cloud.class::isInstance)
+                .map(EC2Cloud.class::cast)
+                .anyMatch(cloud -> !cloud.getHotSpareConfigsByLabel().isEmpty());
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.ec2;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.init.InitMilestone;
 import hudson.model.Descriptor;
 import hudson.model.Executor;
@@ -150,9 +151,20 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
 
     private long internalCheck(EC2Computer computer) {
         /*
-         * If we've been told never to terminate, or node is null(deleted), no checks to perform
+         * If the node is null (deleted), there is nothing left to check.
          */
-        if (idleTerminationMinutes == 0 || computer.getNode() == null) {
+        if (computer.getNode() == null) {
+            return CHECK_INTERVAL_MINUTES;
+        }
+
+        /*
+         * The effective values have to be resolved before any early return, because a template that
+         * never idle-terminates may still have a grace period to enforce, and a label rule may
+         * supply an idle timeout the template itself does not configure.
+         */
+        final int effectiveIdleMinutes = effectiveIdleTerminationMinutes(computer);
+        final int graceMinutes = effectiveGracePeriodMinutes(computer);
+        if (effectiveIdleMinutes == 0 && graceMinutes == 0) {
             return CHECK_INTERVAL_MINUTES;
         }
 
@@ -207,6 +219,40 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                 return CHECK_INTERVAL_MINUTES;
             }
 
+            /*
+             * The grace period is measured from the moment provisioning was requested, so an agent
+             * that never establishes a channel is dealt with even while its launcher is still
+             * trying. The grace period and the launch timeout run independently and whichever
+             * expires first wins, so an unexpired grace period defers to the launch-timeout branch
+             * below instead of returning here.
+             */
+            boolean withinGracePeriod = false;
+            if (graceMinutes > 0 && computer.getOnlineSinceMillis() == 0) {
+                long provisionedAt = computer.getProvisionRequestedAtMillis();
+                if (provisionedAt == 0) {
+                    provisionedAt = launchedAt.toEpochMilli();
+                }
+                if (this.clock.millis() <= provisionedAt + TimeUnit.MINUTES.toMillis(graceMinutes)) {
+                    withinGracePeriod = true;
+                } else if (effectiveDiscardAfterGracePeriod(computer)) {
+                    LOGGER.info("Grace period of " + computer.getName() + " expired after " + graceMinutes
+                            + " minutes without the agent coming online, instance status " + state);
+                    EC2AbstractSlave node = computer.getNode();
+                    if (node != null) {
+                        try {
+                            Queue.withLock(node::graceTimeout);
+                        } catch (Exception e) {
+                            LOGGER.log(Level.FINE, "Error discarding after grace period for " + computer.getName(), e);
+                        }
+                    }
+                    return CHECK_INTERVAL_MINUTES;
+                }
+                /*
+                 * Expired without discarding: fall through so the idle clock runs from the grace
+                 * deadline rather than from the EC2 launch time.
+                 */
+            }
+
             // on rare occasions, AWS may return fault instance which shows running in AWS console but can not be
             // connected.
             // need terminate such fault instance.
@@ -244,13 +290,31 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                 }
             }
 
+            /*
+             * An agent that has not come online yet and is still inside its grace period is left
+             * alone: the idle clock only starts once the grace deadline has passed.
+             */
+            if (withinGracePeriod) {
+                return CHECK_INTERVAL_MINUTES;
+            }
+
+            /*
+             * Idle time is measured from the moment the agent became usable, not from when the EC2
+             * instance was launched, so that slow user data or init scripts do not consume the idle
+             * budget. See JENKINS-23792. An agent that never came online is measured from its grace
+             * deadline when one is configured, and otherwise keeps the instance launch time as its
+             * baseline.
+             */
+            long readyAtMillis = computer.getOnlineSinceMillis();
+            if (readyAtMillis == 0) {
+                readyAtMillis = graceMinutes > 0
+                        ? computer.getProvisionRequestedAtMillis() + TimeUnit.MINUTES.toMillis(graceMinutes)
+                        : launchedAt.toEpochMilli();
+            }
             final long idleMilliseconds =
-                    this.clock.millis() - Math.max(computer.getIdleStartMilliseconds(), launchedAt.toEpochMilli());
+                    this.clock.millis() - Math.max(computer.getIdleStartMilliseconds(), readyAtMillis);
 
-            if (idleTerminationMinutes > 0) {
-                // TODO: really think about the right strategy here, see
-                // JENKINS-23792
-
+            if (effectiveIdleMinutes > 0) {
                 boolean queueHasItemsForSlave;
                 try {
                     queueHasItemsForSlave = Queue.withLock(() -> itemsInQueueForThisSlave(computer));
@@ -258,7 +322,9 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                     LOGGER.log(Level.FINE, "Error checking queue for " + computer.getName(), e);
                     queueHasItemsForSlave = true; // safe default: do not terminate
                 }
-                if (idleMilliseconds > TimeUnit.MINUTES.toMillis(idleTerminationMinutes) && !queueHasItemsForSlave) {
+                if (idleMilliseconds > TimeUnit.MINUTES.toMillis(effectiveIdleMinutes)
+                        && !queueHasItemsForSlave
+                        && !keptAsHotSpare(computer)) {
 
                     LOGGER.info("Idle timeout of " + computer.getName() + " after "
                             + TimeUnit.MILLISECONDS.toMinutes(idleMilliseconds) + " idle minutes, instance status"
@@ -272,7 +338,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                         }
                     }
                 }
-            } else {
+            } else if (effectiveIdleMinutes < 0) {
                 final int oneHourSeconds = (int) TimeUnit.SECONDS.convert(1, TimeUnit.HOURS);
                 // AWS bills by the hour for EC2 Instances, so calculate the remaining seconds left in the "billing
                 // hour"
@@ -290,8 +356,9 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
                     LOGGER.log(Level.FINE, "Error checking queue for " + computer.getName(), e);
                     queueHasItemsForSlaveBilling = true;
                 }
-                if (freeSecondsLeft <= TimeUnit.MINUTES.toSeconds(Math.abs(idleTerminationMinutes))
-                        && !queueHasItemsForSlaveBilling) {
+                if (freeSecondsLeft <= TimeUnit.MINUTES.toSeconds(Math.abs(effectiveIdleMinutes))
+                        && !queueHasItemsForSlaveBilling
+                        && !keptAsHotSpare(computer)) {
                     LOGGER.info("Idle timeout of " + computer.getName() + " after "
                             + TimeUnit.MILLISECONDS.toMinutes(idleMilliseconds) + " idle minutes, with "
                             + TimeUnit.SECONDS.toMinutes(freeSecondsLeft)
@@ -308,6 +375,132 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
             }
         }
         return CHECK_INTERVAL_MINUTES;
+    }
+
+    /**
+     * @return whether a hot spare rule is still counting on this agent, in which case the idle
+     *     timeout leaves it alone. The target is the authority on how many spares a label holds, so
+     *     an agent is only reclaimed once the target has come down past it; letting the timeout
+     *     reclaim it first would just have the next pass provision a replacement.
+     */
+    private static boolean keptAsHotSpare(EC2Computer computer) {
+        EC2Cloud cloud = cloudOf(computer);
+        if (cloud == null) {
+            return false;
+        }
+        SlaveTemplate template = templateOf(computer);
+        if (template == null) {
+            return false;
+        }
+        for (HotSpareConfigByLabel config : cloud.getHotSpareConfigsByLabel()) {
+            if (config.matches(template) && MinimumInstanceChecker.isSpareStillWanted(cloud, config, computer)) {
+                LOGGER.log(
+                        Level.FINE,
+                        "Keeping {0} past its idle timeout: the hot spares for {1} are still counting on it",
+                        new Object[] {computer.getName(), config.getLabel()});
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Tells the hot spare prediction that this agent has just stopped being a spare, and asks for a
+     * replacement to be provisioned now rather than at the next periodic pass.
+     *
+     * <p>Only the bookkeeping happens here. Provisioning is left to
+     * {@link MinimumInstanceChecker#scheduleCheck()} because this runs on the executor thread, which
+     * is no place to wait on EC2.
+     */
+    private static void noteConsumedSpare(EC2Computer computer) {
+        EC2Cloud cloud = cloudOf(computer);
+        if (cloud == null) {
+            return;
+        }
+        SlaveTemplate template = templateOf(computer);
+        if (template == null) {
+            return;
+        }
+        boolean matched = false;
+        for (HotSpareConfigByLabel config : cloud.getHotSpareConfigsByLabel()) {
+            if (config.matches(template)) {
+                HotSpareDemand.spareConsumed(cloud, config);
+                matched = true;
+            }
+        }
+        if (matched) {
+            MinimumInstanceChecker.scheduleCheck();
+        }
+    }
+
+    /**
+     * @return the idle termination in minutes that applies to this computer. Zero means the agent
+     *     is never idle-terminated, negative values are minutes remaining in the billing period.
+     */
+    private int effectiveIdleTerminationMinutes(EC2Computer computer) {
+        EC2Cloud cloud = cloudOf(computer);
+        if (cloud != null) {
+            Integer fromLabelRule = cloud.resolveIdleTerminationMinutes(computer);
+            if (fromLabelRule != null) {
+                return fromLabelRule;
+            }
+        }
+        return idleTerminationMinutes;
+    }
+
+    /**
+     * @return the grace period in minutes that applies to this computer, or 0 when none is
+     *     configured.
+     */
+    private int effectiveGracePeriodMinutes(EC2Computer computer) {
+        EC2Cloud cloud = cloudOf(computer);
+        if (cloud != null) {
+            return cloud.resolveGracePeriodMinutes(computer);
+        }
+        SlaveTemplate template = computer.getSlaveTemplate();
+        return template == null ? 0 : template.getGracePeriodMinutes();
+    }
+
+    /**
+     * @return whether a computer still offline at the end of its grace period is discarded rather
+     *     than handed over to the idle-termination clock.
+     */
+    private boolean effectiveDiscardAfterGracePeriod(EC2Computer computer) {
+        EC2Cloud cloud = cloudOf(computer);
+        if (cloud != null) {
+            return cloud.resolveDiscardAfterGracePeriod(computer);
+        }
+        SlaveTemplate template = computer.getSlaveTemplate();
+        return template == null || template.isDiscardAfterGracePeriod();
+    }
+
+    /**
+     * The agent's template, or null for an agent whose cloud or template no longer exists. Resolving
+     * one goes through the cloud, so an agent left behind by a configuration change can fail here
+     * and must not take a build start down with it.
+     */
+    @CheckForNull
+    private static SlaveTemplate templateOf(EC2Computer computer) {
+        try {
+            return computer.getSlaveTemplate();
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.FINE, "Template not resolvable for " + computer.getName(), e);
+            return null;
+        }
+    }
+
+    @CheckForNull
+    private static EC2Cloud cloudOf(EC2Computer computer) {
+        EC2AbstractSlave node = computer.getNode();
+        if (node == null) {
+            return null;
+        }
+        try {
+            return node.getCloud();
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.FINE, "Cloud not resolvable for " + computer.getName(), e);
+            return null;
+        }
     }
 
     /**
@@ -413,6 +606,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
     public void taskAccepted(Executor executor, Queue.Task task) {
         EC2Computer computer = (EC2Computer) executor.getOwner();
         if (computer != null) {
+            noteConsumedSpare(computer);
             EC2AbstractSlave slaveNode = computer.getNode();
             if (slaveNode != null) {
                 int maxTotalUses = slaveNode.maxTotalUses;

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -388,18 +388,15 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
         if (cloud == null) {
             return false;
         }
-        SlaveTemplate template = templateOf(computer);
-        if (template == null) {
+        if (templateOf(computer) == null) {
             return false;
         }
-        for (HotSpareConfigByLabel config : cloud.getHotSpareConfigsByLabel()) {
-            if (config.matches(template) && MinimumInstanceChecker.isSpareStillWanted(cloud, config, computer)) {
-                LOGGER.log(
-                        Level.FINE,
-                        "Keeping {0} past its idle timeout: the hot spares for {1} are still counting on it",
-                        new Object[] {computer.getName(), config.getLabel()});
-                return true;
-            }
+        if (MinimumInstanceChecker.isSpareStillWanted(cloud, computer)) {
+            LOGGER.log(
+                    Level.FINE,
+                    "Keeping {0} past its idle timeout: the hot spares of a label it serves are still counting on it",
+                    computer.getName());
+            return true;
         }
         return false;
     }
@@ -412,25 +409,22 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
      * {@link MinimumInstanceChecker#scheduleCheck()} because this runs on the executor thread, which
      * is no place to wait on EC2.
      */
-    private static void noteConsumedSpare(EC2Computer computer) {
+    private static void noteConsumedSpare(EC2Computer computer, Queue.Task task) {
         EC2Cloud cloud = cloudOf(computer);
         if (cloud == null) {
             return;
         }
-        SlaveTemplate template = templateOf(computer);
-        if (template == null) {
+        /*
+         * The pool that just lost a spare is the one the build asked for, not every pool the agent
+         * belongs to: a build that wanted x86 hardware is no reason to keep arm64 agents warm, even
+         * where one rule covers both labels.
+         */
+        Label assigned = task == null ? null : task.getAssignedLabel();
+        if (assigned == null || cloud.getHotSpareConfigForLabel(assigned) == null) {
             return;
         }
-        boolean matched = false;
-        for (HotSpareConfigByLabel config : cloud.getHotSpareConfigsByLabel()) {
-            if (config.matches(template)) {
-                HotSpareDemand.spareConsumed(cloud, config);
-                matched = true;
-            }
-        }
-        if (matched) {
-            MinimumInstanceChecker.scheduleCheck();
-        }
+        HotSpareDemand.spareConsumed(cloud, assigned.getName());
+        MinimumInstanceChecker.scheduleCheck();
     }
 
     /**
@@ -606,7 +600,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> impleme
     public void taskAccepted(Executor executor, Queue.Task task) {
         EC2Computer computer = (EC2Computer) executor.getOwner();
         if (computer != null) {
-            noteConsumedSpare(computer);
+            noteConsumedSpare(computer, task);
             EC2AbstractSlave slaveNode = computer.getNode();
             if (slaveNode != null) {
                 int maxTotalUses = slaveNode.maxTotalUses;

--- a/src/main/java/hudson/plugins/ec2/HotSpareConfigByLabel.java
+++ b/src/main/java/hudson/plugins/ec2/HotSpareConfigByLabel.java
@@ -199,8 +199,10 @@ public class HotSpareConfigByLabel extends AbstractDescribableImpl<HotSpareConfi
             return false;
         }
         // The same test EC2Cloud#getTemplates(Label) uses, so a rule governs exactly the templates
-        // that label would provision from.
-        return Label.get(label).matches(template.getLabelSet());
+        // that label would provision from. Jenkins has no label for a blank expression, in which
+        // case the rule governs nothing.
+        Label parsed = Label.get(label);
+        return parsed != null && parsed.matches(template.getLabelSet());
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/ec2/HotSpareConfigByLabel.java
+++ b/src/main/java/hudson/plugins/ec2/HotSpareConfigByLabel.java
@@ -269,6 +269,11 @@ public class HotSpareConfigByLabel extends AbstractDescribableImpl<HotSpareConfi
 
         @POST
         public FormValidation doCheckLabel(@QueryParameter String value) {
+            // As everywhere else in this plugin, someone who cannot configure the cloud gets no
+            // validation rather than an error, so viewing the configuration read-only still works.
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                return FormValidation.ok();
+            }
             String label = Util.fixEmptyAndTrim(value);
             if (label == null) {
                 return FormValidation.error("A label is required");
@@ -287,16 +292,25 @@ public class HotSpareConfigByLabel extends AbstractDescribableImpl<HotSpareConfi
 
         @POST
         public FormValidation doCheckScalingFactor(@QueryParameter String value) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                return FormValidation.ok();
+            }
             return nonNegative(value, "Hot spare step");
         }
 
         @POST
         public FormValidation doCheckBaseHotSpares(@QueryParameter String value) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                return FormValidation.ok();
+            }
             return nonNegative(value, "Base hot spares");
         }
 
         @POST
         public FormValidation doCheckMaxHotSpares(@QueryParameter String value, @QueryParameter String baseHotSpares) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                return FormValidation.ok();
+            }
             FormValidation nonNegative = nonNegative(value, "Maximum hot spares");
             if (nonNegative.kind != FormValidation.Kind.OK || Util.fixEmptyAndTrim(value) == null) {
                 return nonNegative;
@@ -316,11 +330,17 @@ public class HotSpareConfigByLabel extends AbstractDescribableImpl<HotSpareConfi
 
         @POST
         public FormValidation doCheckGracePeriodMinutes(@QueryParameter String value) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                return FormValidation.ok();
+            }
             return nonNegative(value, "Grace period");
         }
 
         @POST
         public FormValidation doCheckIdleTimeoutMinutes(@QueryParameter String value) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                return FormValidation.ok();
+            }
             if (Util.fixEmptyAndTrim(value) == null) {
                 return FormValidation.ok();
             }

--- a/src/main/java/hudson/plugins/ec2/HotSpareConfigByLabel.java
+++ b/src/main/java/hudson/plugins/ec2/HotSpareConfigByLabel.java
@@ -1,0 +1,349 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.ec2;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.AutoCompletionCandidates;
+import hudson.model.Descriptor;
+import hudson.model.Label;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.Cloud;
+import hudson.util.FormValidation;
+import java.io.Serializable;
+import java.util.Set;
+import java.util.TreeSet;
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
+
+/**
+ * Hot spare scaling for one Jenkins label, across every {@link SlaveTemplate} of a cloud that
+ * carries that label.
+ *
+ * <p>Templates sharing a label are treated as interchangeable hardware, so the numbers here apply
+ * to the group as a whole: {@link #getMaxHotSpares()} caps the spares held by all of those
+ * templates combined, not each of them. A matching rule supersedes
+ * {@link SlaveTemplate#getMinimumNumberOfSpareInstances()} for those templates, because owning the
+ * spare count for the label is the point of the rule.
+ *
+ * <p>The idle timeout and grace period configured here also win over the template values by
+ * default. Ticking the corresponding {@code allowTemplate...Override} box gives precedence back to
+ * templates that set the value explicitly.
+ */
+public class HotSpareConfigByLabel extends AbstractDescribableImpl<HotSpareConfigByLabel> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Also the window a quiet label takes to give up one step of its spare target. */
+    public static final int DEFAULT_IDLE_TIMEOUT_MINUTES = 15;
+
+    private final String label;
+
+    private int scalingFactor = 5;
+
+    private int baseHotSpares = 0;
+
+    private Integer maxHotSpares;
+
+    private int idleTimeoutMinutes = DEFAULT_IDLE_TIMEOUT_MINUTES;
+
+    private int gracePeriodMinutes = 0;
+
+    private boolean discardAfterGracePeriod = true;
+
+    private boolean allowTemplateIdleTimeoutOverride = false;
+
+    private boolean allowTemplateGracePeriodOverride = false;
+
+    @DataBoundConstructor
+    public HotSpareConfigByLabel(String label) {
+        this.label = Util.fixEmptyAndTrim(label);
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * @return the amount the spare target moves by when the label cannot keep up with the work
+     *     arriving, and the amount it gives back when the spares go unused.
+     * @see HotSpareDemand
+     */
+    public int getScalingFactor() {
+        return scalingFactor;
+    }
+
+    @DataBoundSetter
+    public void setScalingFactor(int scalingFactor) {
+        this.scalingFactor = Math.max(0, scalingFactor);
+    }
+
+    /**
+     * @return the number of spares to keep warm for this label at all times, which is also the
+     *     floor the target decays to once the label goes quiet.
+     */
+    public int getBaseHotSpares() {
+        return baseHotSpares;
+    }
+
+    @DataBoundSetter
+    public void setBaseHotSpares(int baseHotSpares) {
+        this.baseHotSpares = Math.max(0, baseHotSpares);
+    }
+
+    /**
+     * @return the ceiling on spares held by the whole label group, or {@code null} for no ceiling.
+     */
+    @CheckForNull
+    public Integer getMaxHotSpares() {
+        return maxHotSpares;
+    }
+
+    @DataBoundSetter
+    public void setMaxHotSpares(Integer maxHotSpares) {
+        this.maxHotSpares = maxHotSpares == null ? null : Math.max(0, maxHotSpares);
+    }
+
+    /**
+     * @return idle termination for agents of this label, in minutes. 0 means never.
+     */
+    public int getIdleTimeoutMinutes() {
+        return idleTimeoutMinutes;
+    }
+
+    @DataBoundSetter
+    public void setIdleTimeoutMinutes(int idleTimeoutMinutes) {
+        this.idleTimeoutMinutes = idleTimeoutMinutes;
+    }
+
+    /**
+     * @return minutes an agent of this label is given to come online, or 0 for no grace period.
+     */
+    public int getGracePeriodMinutes() {
+        return gracePeriodMinutes;
+    }
+
+    @DataBoundSetter
+    public void setGracePeriodMinutes(int gracePeriodMinutes) {
+        this.gracePeriodMinutes = Math.max(0, gracePeriodMinutes);
+    }
+
+    public boolean isDiscardAfterGracePeriod() {
+        return discardAfterGracePeriod;
+    }
+
+    @DataBoundSetter
+    public void setDiscardAfterGracePeriod(boolean discardAfterGracePeriod) {
+        this.discardAfterGracePeriod = discardAfterGracePeriod;
+    }
+
+    /**
+     * @return whether a template that sets its own idle termination time takes precedence over this
+     *     rule. A template that leaves it blank still follows the rule.
+     */
+    public boolean isAllowTemplateIdleTimeoutOverride() {
+        return allowTemplateIdleTimeoutOverride;
+    }
+
+    @DataBoundSetter
+    public void setAllowTemplateIdleTimeoutOverride(boolean allowTemplateIdleTimeoutOverride) {
+        this.allowTemplateIdleTimeoutOverride = allowTemplateIdleTimeoutOverride;
+    }
+
+    /**
+     * @return whether a template that sets its own grace period takes precedence over this rule. A
+     *     template that leaves it at 0 still follows the rule.
+     */
+    public boolean isAllowTemplateGracePeriodOverride() {
+        return allowTemplateGracePeriodOverride;
+    }
+
+    @DataBoundSetter
+    public void setAllowTemplateGracePeriodOverride(boolean allowTemplateGracePeriodOverride) {
+        this.allowTemplateGracePeriodOverride = allowTemplateGracePeriodOverride;
+    }
+
+    /**
+     * @return whether this rule governs a template, i.e. whether the template carries the rule's
+     *     label.
+     */
+    boolean matches(SlaveTemplate template) {
+        if (label == null || template == null) {
+            return false;
+        }
+        // The same test EC2Cloud#getTemplates(Label) uses, so a rule governs exactly the templates
+        // that label would provision from.
+        return Label.get(label).matches(template.getLabelSet());
+    }
+
+    @Extension
+    @Symbol("hotSpareConfigByLabel")
+    public static class DescriptorImpl extends Descriptor<HotSpareConfigByLabel> {
+
+        /** Characters that end one term of a label expression and begin the next. */
+        private static final String LABEL_EXPRESSION_SEPARATORS = " \t&|!()->";
+
+        @Override
+        public String getDisplayName() {
+            return "Hot Spare Rule";
+        }
+
+        /**
+         * Completes the label being typed with the labels the EC2 templates on this controller
+         * carry, plus the labels Jenkins already knows about, since an expression may name anything
+         * a job could ask for.
+         */
+        public AutoCompletionCandidates doAutoCompleteLabel(@QueryParameter String value) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            AutoCompletionCandidates candidates = new AutoCompletionCandidates();
+            String typed = termBeingTyped(value);
+            for (String name : knownLabelNames()) {
+                if (name.regionMatches(true, 0, typed, 0, typed.length())) {
+                    candidates.add(name);
+                }
+            }
+            return candidates;
+        }
+
+        /**
+         * @return the part of the field the caret is in, so an expression such as
+         *     {@code linux && } completes its second operand rather than nothing.
+         */
+        private static String termBeingTyped(@CheckForNull String value) {
+            if (value == null) {
+                return "";
+            }
+            int start = 0;
+            for (int i = 0; i < value.length(); i++) {
+                if (LABEL_EXPRESSION_SEPARATORS.indexOf(value.charAt(i)) >= 0) {
+                    start = i + 1;
+                }
+            }
+            return value.substring(start);
+        }
+
+        private static Set<String> knownLabelNames() {
+            Jenkins jenkins = Jenkins.get();
+            Set<String> names = new TreeSet<>();
+            for (Cloud cloud : jenkins.clouds) {
+                if (cloud instanceof EC2Cloud ec2Cloud) {
+                    for (SlaveTemplate template : ec2Cloud.getTemplates()) {
+                        for (LabelAtom atom : template.getLabelSet()) {
+                            names.add(atom.getName());
+                        }
+                    }
+                }
+            }
+            for (LabelAtom atom : jenkins.getLabelAtoms()) {
+                names.add(atom.getName());
+            }
+            return names;
+        }
+
+        @POST
+        public FormValidation doCheckLabel(@QueryParameter String value) {
+            String label = Util.fixEmptyAndTrim(value);
+            if (label == null) {
+                return FormValidation.error("A label is required");
+            }
+            try {
+                Label.parseExpression(label);
+            } catch (IllegalArgumentException e) {
+                /*
+                 * Jenkins falls back to treating an unparseable expression as a single label atom,
+                 * which no template can carry, so the rule would quietly govern nothing.
+                 */
+                return FormValidation.error("Not a valid label or label expression: " + e.getMessage());
+            }
+            return FormValidation.ok();
+        }
+
+        @POST
+        public FormValidation doCheckScalingFactor(@QueryParameter String value) {
+            return nonNegative(value, "Hot spare step");
+        }
+
+        @POST
+        public FormValidation doCheckBaseHotSpares(@QueryParameter String value) {
+            return nonNegative(value, "Base hot spares");
+        }
+
+        @POST
+        public FormValidation doCheckMaxHotSpares(@QueryParameter String value, @QueryParameter String baseHotSpares) {
+            FormValidation nonNegative = nonNegative(value, "Maximum hot spares");
+            if (nonNegative.kind != FormValidation.Kind.OK || Util.fixEmptyAndTrim(value) == null) {
+                return nonNegative;
+            }
+            try {
+                int max = Integer.parseInt(value.trim());
+                int base = Integer.parseInt(Util.fixEmptyAndTrim(baseHotSpares) == null ? "0" : baseHotSpares.trim());
+                if (max < base) {
+                    return FormValidation.error(
+                            "Maximum hot spares must not be lower than the %d base hot spares", base);
+                }
+            } catch (NumberFormatException ignore) {
+                // The individual field validators report the malformed value.
+            }
+            return FormValidation.ok();
+        }
+
+        @POST
+        public FormValidation doCheckGracePeriodMinutes(@QueryParameter String value) {
+            return nonNegative(value, "Grace period");
+        }
+
+        @POST
+        public FormValidation doCheckIdleTimeoutMinutes(@QueryParameter String value) {
+            if (Util.fixEmptyAndTrim(value) == null) {
+                return FormValidation.ok();
+            }
+            try {
+                Integer.parseInt(value.trim());
+                return FormValidation.ok();
+            } catch (NumberFormatException ignore) {
+                return FormValidation.error("Idle timeout must be an integer");
+            }
+        }
+
+        private static FormValidation nonNegative(String value, String what) {
+            if (Util.fixEmptyAndTrim(value) == null) {
+                return FormValidation.ok();
+            }
+            try {
+                if (Integer.parseInt(value.trim()) >= 0) {
+                    return FormValidation.ok();
+                }
+            } catch (NumberFormatException ignore) {
+                // Fall through to the error below.
+            }
+            return FormValidation.error("%s must be a non-negative integer (or null)", what);
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/HotSpareDemand.java
+++ b/src/main/java/hudson/plugins/ec2/HotSpareDemand.java
@@ -1,0 +1,288 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.ec2;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.Clock;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * How many idle spares a label should be holding right now, learned from how well the spares have
+ * been keeping up.
+ *
+ * <p>A fixed number of spares is either wasted while nothing is building or exhausted the moment a
+ * burst arrives, so the number is treated as a load prediction that follows demand:
+ *
+ * <ul>
+ *   <li>an executor being taken is the signal that drives the whole thing. It says the label is in
+ *       use and that the pool just lost a spare, so the replacement is provisioned there and then
+ *       rather than at the next periodic pass. A label being used holds at least one step of
+ *       spares, which is how a label warms up from nothing without waiting for builds to pile up;
+ *   <li>every spare taken by a build is replaced, because a busy agent is not a spare. This is what
+ *       keeps a label warm for the whole of a busy period rather than for the first few builds;
+ *   <li>past that first step, the target is the work the label has in sight: the builds queued for
+ *       it plus the agents running one. A single build fanning out to 20 parallel branches asks for
+ *       20 spares at once rather than climbing there a step per minute, because the demand is
+ *       already measurable;
+ *   <li>when the pool runs dry anyway, or builds are waiting that neither the spares nor the
+ *       instances already on their way can take, the target is raised a further
+ *       {@link HotSpareConfigByLabel#getScalingFactor()} above the load, once per interval, until
+ *       the spares do keep up;
+ *   <li>the load plus one step is also the limit, so a label whose instance caps are already
+ *       reached does not accumulate a backlog it would try to launch all at once later;
+ *   <li>the target comes down a step per idle timeout, either towards the work still in sight while
+ *       the label is in use, or to {@link HotSpareConfigByLabel#getBaseHotSpares()} - zero by
+ *       default - once nothing is asking for the label at all, rather than paying for spares
+ *       nothing wants.
+ * </ul>
+ *
+ * <p>The target, not the idle timeout, is what decides how many spares a label keeps: an agent is
+ * only reclaimed once the target has come down past it. Letting the timeout reclaim a spare the
+ * target still wanted would pay for the same capacity twice, because the very next pass would
+ * provision a replacement for it.
+ *
+ * <p>The target is deliberately not persisted: after a restart the label starts from its base count
+ * and learns again within a few minutes, which is safer than restoring a number that described a
+ * load that has since gone away.
+ */
+@Restricted(NoExternalUse.class)
+public final class HotSpareDemand {
+
+    private static final Logger LOGGER = Logger.getLogger(HotSpareDemand.class.getName());
+
+    /**
+     * How long a growth step has to be given before another one is allowed. Provisioning is not
+     * instant and a check can be triggered by events rather than by the clock, so without this a
+     * single burst would step the target up several times before the first instances even boot.
+     */
+    private static final long GROWTH_INTERVAL_MS = Long.getLong("jenkins.ec2.hotSpareGrowthIntervalMs", 60_000);
+
+    private static final Map<String, HotSpareDemand> DEMANDS = new ConcurrentHashMap<>();
+
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Needs to be overridden from tests")
+    public static Clock clock = Clock.systemDefaultZone();
+
+    private int target;
+
+    private long lastGrowthMillis;
+
+    /** When the label was first seen with nothing to do, or 0 while it has work. */
+    private long quietSinceMillis;
+
+    /** When the load first came in under the target, or 0 while the target is not above it. */
+    private long overshotSinceMillis;
+
+    /** Spares taken by builds since the last pass, counted by {@link #spareConsumed}. */
+    private int consumedSinceLastPass;
+
+    private HotSpareDemand() {}
+
+    public static HotSpareDemand of(@NonNull EC2Cloud cloud, @NonNull String label) {
+        return DEMANDS.computeIfAbsent(cloud.name + '\u0000' + label, key -> new HotSpareDemand());
+    }
+
+    /**
+     * Forgets every learned target. For tests, and for callers that have to reason about a cloud
+     * whose configuration has been replaced.
+     */
+    public static void reset() {
+        DEMANDS.clear();
+    }
+
+    /**
+     * Moves the target in response to what the label looks like right now: at least one step while
+     * it is in use, the work in sight once that is larger, and a step more than that while the
+     * spares are not keeping up.
+     *
+     * @param spares idle agents of the label group that could take work immediately.
+     * @param provisioning instances of the label group on their way to becoming spares.
+     * @param queued builds waiting for the label.
+     * @param busy agents of the label group currently running a build.
+     * @return the number of idle spares the label should hold.
+     */
+    public synchronized int updateTarget(
+            @NonNull HotSpareConfigByLabel config, int spares, int provisioning, int queued, int busy) {
+        final int base = config.getBaseHotSpares();
+        final int step = growthStep(config);
+        final long now = clock.millis();
+        final int consumed = consumedSinceLastPass;
+        consumedSinceLastPass = 0;
+
+        // The work the label has in sight: what is waiting for it and what it is already running.
+        final int load = queued + busy;
+        final boolean inUse = consumed > 0 || load > 0;
+
+        /*
+         * Two things say the spares are not keeping up: builds took the last of the pool, and builds
+         * are waiting that neither the spares nor the instances already on their way can take.
+         * Counting what is in flight is what makes this settle rather than chase a queue that
+         * instances are already on their way to serve.
+         */
+        final boolean ranDry = consumed > 0 && spares == 0;
+        final boolean queueUnserved = queued > spares + provisioning;
+
+        target = Math.max(target, base);
+
+        if (inUse) {
+            quietSinceMillis = 0;
+
+            /*
+             * The load is a measurement, so it is followed at once: a build fanning out to 20
+             * branches needs 20 spares now, not in four minutes' worth of steps. The step is the
+             * floor rather than the rate, for the label that has only just been asked for anything.
+             */
+            int wanted = Math.max(step, load);
+
+            if ((ranDry || queueUnserved) && now - lastGrowthMillis >= GROWTH_INTERVAL_MS) {
+                /*
+                 * The load is being served too slowly even so, so hold a step more than the load
+                 * until it is not. One step per interval, because provisioning is not instant and a
+                 * pass runs every time a build starts.
+                 */
+                lastGrowthMillis = now;
+                wanted = Math.max(wanted, Math.min(load + step, target + step));
+            }
+
+            if (wanted > target) {
+                raiseTo(config, wanted, consumed, spares, queued);
+                overshotSinceMillis = 0;
+            } else if (wanted < target) {
+                /*
+                 * The label is still in use but with less work than the target holds, so the peak it
+                 * learned from an earlier burst has to fade. It fades a step at a time rather than
+                 * dropping to the load, because the spares above the load are what the next burst
+                 * lands on, and because the agents themselves are only worth giving up at the rate
+                 * the admin set as the idle timeout.
+                 */
+                if (overshotSinceMillis == 0) {
+                    overshotSinceMillis = now;
+                } else if (now - overshotSinceMillis >= decayIntervalMillis(config)) {
+                    overshotSinceMillis = now;
+                    stepDownTo(config, wanted, "the label has held less work than the target for a whole idle timeout");
+                }
+            } else {
+                overshotSinceMillis = 0;
+            }
+        } else {
+            if (quietSinceMillis == 0) {
+                quietSinceMillis = now;
+                overshotSinceMillis = 0;
+            } else if (now - quietSinceMillis >= decayIntervalMillis(config)) {
+                quietSinceMillis = now;
+                stepDownTo(
+                        config, config.getBaseHotSpares(), "nothing has asked for the label for a whole idle timeout");
+            }
+        }
+
+        target = Math.min(target, ceiling(config));
+        return target;
+    }
+
+    private void raiseTo(HotSpareConfigByLabel config, int wanted, int consumed, int spares, int queued) {
+        int raised = Math.min(ceiling(config), wanted);
+        if (raised > target) {
+            LOGGER.log(
+                    Level.FINE,
+                    "Raising the hot spare target for {0} from {1} to {2} ({3} taken since the last pass, "
+                            + "{4} still warm, {5} queued)",
+                    new Object[] {config.getLabel(), target, raised, consumed, spares, queued});
+            target = raised;
+        }
+    }
+
+    /**
+     * Reports that a build has taken an executor on an agent of this label, which is both the
+     * signal that the label is in use and the moment its pool of spares got one smaller.
+     *
+     * <p>Callers follow this with {@link hudson.plugins.ec2.util.MinimumInstanceChecker#scheduleCheck()}
+     * so the replacement is on its way while the build that took the spare is still starting, which
+     * is the point of the whole feature: the next build finds somewhere warm to land instead of
+     * waiting for an instance to boot.
+     */
+    public static void spareConsumed(@NonNull EC2Cloud cloud, @NonNull HotSpareConfigByLabel config) {
+        String label = config.getLabel();
+        if (label == null) {
+            return;
+        }
+        HotSpareDemand demand = of(cloud, label);
+        synchronized (demand) {
+            demand.consumedSinceLastPass++;
+            demand.quietSinceMillis = 0;
+        }
+    }
+
+    public synchronized int getTarget() {
+        return target;
+    }
+
+    /**
+     * Gives up one step of target, stopping at {@code floor} or the base count, whichever is
+     * higher. The target is what decides how many spares a label keeps, so nothing terminates an
+     * agent until this has come down past it.
+     */
+    private void stepDownTo(HotSpareConfigByLabel config, int floor, String why) {
+        int lowered = Math.max(Math.max(config.getBaseHotSpares(), floor), target - growthStep(config));
+        if (lowered != target) {
+            LOGGER.log(Level.FINE, "Lowering the hot spare target for {0} from {1} to {2}: {3}", new Object[] {
+                config.getLabel(), target, lowered, why
+            });
+            target = lowered;
+        }
+    }
+
+    /**
+     * @return the amount the target moves by. A rule configured with no step would never move, so
+     *     it still creeps by one rather than freezing at its base count.
+     */
+    private static int growthStep(HotSpareConfigByLabel config) {
+        return Math.max(1, config.getScalingFactor());
+    }
+
+    private static int ceiling(HotSpareConfigByLabel config) {
+        Integer max = config.getMaxHotSpares();
+        return max == null ? Integer.MAX_VALUE : Math.max(0, max);
+    }
+
+    /**
+     * @return how long a label has to be quiet before it gives up a step. The idle timeout is the
+     *     admin's own statement of how long an unused agent is worth keeping, so the prediction
+     *     fades at the same rate the agents behind it do.
+     */
+    private static long decayIntervalMillis(HotSpareConfigByLabel config) {
+        int minutes = Math.abs(config.getIdleTimeoutMinutes());
+        if (minutes == 0) {
+            // The agents are never idle-terminated, so there is no rate to follow. Fall back to the
+            // default idle timeout, otherwise a target raised once would never come back down.
+            minutes = HotSpareConfigByLabel.DEFAULT_IDLE_TIMEOUT_MINUTES;
+        }
+        return TimeUnit.MINUTES.toMillis(minutes);
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/HotSpareDemand.java
+++ b/src/main/java/hudson/plugins/ec2/HotSpareDemand.java
@@ -26,17 +26,24 @@ package hudson.plugins.ec2;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Clock;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * How many idle spares a label should be holding right now, learned from how well the spares have
  * been keeping up.
+ *
+ * <p>A target belongs to the label work asked for rather than to the rule that set the policy. Two
+ * labels covered by one rule scale apart: a burst of x86 builds cannot warm arm64 hardware that
+ * could never run them, even though one rule governs both.
  *
  * <p>A fixed number of spares is either wasted while nothing is building or exhausted the moment a
  * burst arrives, so the number is treated as a load prediction that follows demand:
@@ -103,10 +110,54 @@ public final class HotSpareDemand {
     /** Spares taken by builds since the last pass, counted by {@link #spareConsumed}. */
     private int consumedSinceLastPass;
 
-    private HotSpareDemand() {}
+    /** The label this target belongs to, for the logs. */
+    private final String label;
+
+    private HotSpareDemand(String label) {
+        this.label = label;
+    }
 
     public static HotSpareDemand of(@NonNull EC2Cloud cloud, @NonNull String label) {
-        return DEMANDS.computeIfAbsent(cloud.name + '\u0000' + label, key -> new HotSpareDemand());
+        return DEMANDS.computeIfAbsent(key(cloud, label), key -> new HotSpareDemand(label));
+    }
+
+    /**
+     * @return the labels of a cloud that hold a target, so a label whose work has gone away is
+     *     still visited by the next pass and fades a step at a time instead of dropping to nothing
+     *     the moment its queue empties.
+     */
+    public static Set<String> trackedLabels(@NonNull EC2Cloud cloud) {
+        String prefix = cloud.name + '\u0000';
+        return DEMANDS.keySet().stream()
+                .filter(key -> key.startsWith(prefix))
+                .map(key -> key.substring(prefix.length()))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * Drops the targets of a cloud that have faded to nothing, so a controller does not hold an
+     * entry for every label a job has ever asked for. A label that comes back is simply learned
+     * again from the work that asks for it.
+     *
+     * <p>A target above zero is kept: spares are being held for it, and it has to fade a step at a
+     * time rather than vanish. So is one with a spare taken since the last pass, which is a label
+     * about to want something even though its target has not caught up yet.
+     *
+     * @param keep labels to hold on to whatever their target, for the labels the rules name: they
+     *     are a fixed set, and their targets are where a rule's floor lives.
+     */
+    public static void forgetZeroed(@NonNull EC2Cloud cloud, @NonNull Set<String> keep) {
+        String prefix = cloud.name + '\u0000';
+        DEMANDS.entrySet().removeIf(entry -> {
+            String key = entry.getKey();
+            if (!key.startsWith(prefix) || keep.contains(key.substring(prefix.length()))) {
+                return false;
+            }
+            HotSpareDemand demand = entry.getValue();
+            synchronized (demand) {
+                return demand.target <= 0 && demand.consumedSinceLastPass == 0;
+            }
+        });
     }
 
     /**
@@ -115,6 +166,10 @@ public final class HotSpareDemand {
      */
     public static void reset() {
         DEMANDS.clear();
+    }
+
+    private static String key(@NonNull EC2Cloud cloud, @NonNull String label) {
+        return cloud.name + '\u0000' + label;
     }
 
     /**
@@ -130,7 +185,19 @@ public final class HotSpareDemand {
      */
     public synchronized int updateTarget(
             @NonNull HotSpareConfigByLabel config, int spares, int provisioning, int queued, int busy) {
-        final int base = config.getBaseHotSpares();
+        return updateTarget(config, config.getBaseHotSpares(), spares, provisioning, queued, busy);
+    }
+
+    /**
+     * The same, for a label the rule governs without naming. The count an admin asked to always be
+     * held belongs to the rule as a whole, so it is charged to the label the rule names and the
+     * labels underneath it start from nothing; charging it to each of them would multiply it by
+     * however many labels the rule happens to cover.
+     *
+     * @param base the floor this label's target may not fall below.
+     */
+    public synchronized int updateTarget(
+            @NonNull HotSpareConfigByLabel config, int base, int spares, int provisioning, int queued, int busy) {
         final int step = growthStep(config);
         final long now = clock.millis();
         final int consumed = consumedSinceLastPass;
@@ -186,7 +253,11 @@ public final class HotSpareDemand {
                     overshotSinceMillis = now;
                 } else if (now - overshotSinceMillis >= decayIntervalMillis(config)) {
                     overshotSinceMillis = now;
-                    stepDownTo(config, wanted, "the label has held less work than the target for a whole idle timeout");
+                    stepDownTo(
+                            config,
+                            base,
+                            wanted,
+                            "the label has held less work than the target for a whole idle timeout");
                 }
             } else {
                 overshotSinceMillis = 0;
@@ -197,8 +268,7 @@ public final class HotSpareDemand {
                 overshotSinceMillis = 0;
             } else if (now - quietSinceMillis >= decayIntervalMillis(config)) {
                 quietSinceMillis = now;
-                stepDownTo(
-                        config, config.getBaseHotSpares(), "nothing has asked for the label for a whole idle timeout");
+                stepDownTo(config, base, base, "nothing has asked for the label for a whole idle timeout");
             }
         }
 
@@ -213,7 +283,7 @@ public final class HotSpareDemand {
                     Level.FINE,
                     "Raising the hot spare target for {0} from {1} to {2} ({3} taken since the last pass, "
                             + "{4} still warm, {5} queued)",
-                    new Object[] {config.getLabel(), target, raised, consumed, spares, queued});
+                    new Object[] {label, target, raised, consumed, spares, queued});
             target = raised;
         }
     }
@@ -222,16 +292,16 @@ public final class HotSpareDemand {
      * Reports that a build has taken an executor on an agent of this label, which is both the
      * signal that the label is in use and the moment its pool of spares got one smaller.
      *
+     * <p>The label is the one the build asked for, not the one of the rule that governs it: a build
+     * that wanted {@code x86_64} says nothing about how warm the arm64 pool should be, even when
+     * one rule covers both.
+     *
      * <p>Callers follow this with {@link hudson.plugins.ec2.util.MinimumInstanceChecker#scheduleCheck()}
      * so the replacement is on its way while the build that took the spare is still starting, which
      * is the point of the whole feature: the next build finds somewhere warm to land instead of
      * waiting for an instance to boot.
      */
-    public static void spareConsumed(@NonNull EC2Cloud cloud, @NonNull HotSpareConfigByLabel config) {
-        String label = config.getLabel();
-        if (label == null) {
-            return;
-        }
+    public static void spareConsumed(@NonNull EC2Cloud cloud, @NonNull String label) {
         HotSpareDemand demand = of(cloud, label);
         synchronized (demand) {
             demand.consumedSinceLastPass++;
@@ -248,11 +318,11 @@ public final class HotSpareDemand {
      * higher. The target is what decides how many spares a label keeps, so nothing terminates an
      * agent until this has come down past it.
      */
-    private void stepDownTo(HotSpareConfigByLabel config, int floor, String why) {
-        int lowered = Math.max(Math.max(config.getBaseHotSpares(), floor), target - growthStep(config));
+    private void stepDownTo(HotSpareConfigByLabel config, int base, int floor, String why) {
+        int lowered = Math.max(Math.max(base, floor), target - growthStep(config));
         if (lowered != target) {
             LOGGER.log(Level.FINE, "Lowering the hot spare target for {0} from {1} to {2}: {3}", new Object[] {
-                config.getLabel(), target, lowered, why
+                label, target, lowered, why
             });
             target = lowered;
         }

--- a/src/main/java/hudson/plugins/ec2/LabelTemplateRotation.java
+++ b/src/main/java/hudson/plugins/ec2/LabelTemplateRotation.java
@@ -1,0 +1,242 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.ec2;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.util.SystemProperties;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Rotates the {@link SlaveTemplate}s of an {@link EC2Cloud} that match the same label.
+ *
+ * <p>Templates matching one label are treated as homogeneous: the admin gave them the same label,
+ * so they are interchangeable instance types for the work that label describes. Rotating between
+ * them lets provisioning fall back to different hardware immediately instead of retrying a single
+ * template that has no capacity.
+ *
+ * <p>Selection is smooth weighted round-robin (as used by nginx) over
+ * {@link SlaveTemplate#getHotSpareWeight()}: for weights 2 and 1 the leading template alternates as
+ * {@code a, a, b, a, a, b} rather than picking {@code a} twice in a row and then {@code b} twice,
+ * which is what makes the fallback fast when one instance type runs dry.
+ *
+ * <p>All of this is inert unless {@link EC2Cloud#isRoundRobinTemplatesByLabel()} is enabled.
+ */
+@Restricted(NoExternalUse.class)
+class LabelTemplateRotation {
+
+    private static final Logger LOGGER = Logger.getLogger(LabelTemplateRotation.class.getName());
+
+    /**
+     * Default period, in milliseconds, during which a template is demoted in the rotation for a
+     * label after it reported an insufficient-capacity error.
+     */
+    static final long DEFAULT_TEMPLATE_CAPACITY_COOLDOWN_MILLIS = TimeUnit.MINUTES.toMillis(5);
+
+    /**
+     * How long (ms) a template is considered capacity-unavailable after an insufficient-capacity
+     * error. Configurable via the system property
+     * {@code hudson.plugins.ec2.LabelTemplateRotation.templateCapacityCooldownMillis}. Deliberately
+     * separate from the per-subnet cooldown in {@link SlaveTemplate} so the two layers can be tuned
+     * independently, while defaulting to the same five minutes.
+     */
+    private static final long TEMPLATE_CAPACITY_COOLDOWN_MILLIS = SystemProperties.getLong(
+            LabelTemplateRotation.class.getName() + ".templateCapacityCooldownMillis",
+            DEFAULT_TEMPLATE_CAPACITY_COOLDOWN_MILLIS);
+
+    /** Smooth weighted round-robin state: label name to template key to current weight. */
+    private final ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>> currentWeights =
+            new ConcurrentHashMap<>();
+
+    /** Plain rotation cursor per label, used when every candidate has a weight of zero. */
+    private final ConcurrentHashMap<String, Integer> unweightedCursor = new ConcurrentHashMap<>();
+
+    /** Template key to the epoch-millis timestamp until which the template should be demoted. */
+    private final ConcurrentHashMap<String, Long> templateCapacityCooldownUntil = new ConcurrentHashMap<>();
+
+    private final BooleanSupplier enabled;
+
+    private Clock clock;
+
+    LabelTemplateRotation(@NonNull BooleanSupplier enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Orders the templates matching a label for provisioning. Templates currently in a capacity
+     * cooldown are moved to the end rather than dropped, so a launch is still attempted when every
+     * template is cooling down.
+     *
+     * @param labelName the label being provisioned for, or an empty string for no label
+     * @param matching the templates matching that label, in configured order
+     * @return the templates to try, best first. The configured order is returned unchanged when
+     *     rotation is disabled or only one template matches.
+     */
+    List<SlaveTemplate> order(String labelName, Collection<SlaveTemplate> matching) {
+        List<SlaveTemplate> candidates = new ArrayList<>(matching);
+        if (candidates.size() <= 1 || !enabled.getAsBoolean()) {
+            return candidates;
+        }
+
+        List<SlaveTemplate> available = new ArrayList<>(candidates.size());
+        List<SlaveTemplate> coolingDown = new ArrayList<>();
+        for (SlaveTemplate t : candidates) {
+            if (isTemplateInCooldown(t, candidates.size())) {
+                coolingDown.add(t);
+            } else {
+                available.add(t);
+            }
+        }
+
+        // Every template is cooling down: rotate over all of them rather than refuse to provision.
+        List<SlaveTemplate> pool = available.isEmpty() ? candidates : available;
+        SlaveTemplate head = selectWeighted(labelName, pool);
+
+        List<SlaveTemplate> ordered = new ArrayList<>(candidates.size());
+        int headIndex = pool.indexOf(head);
+        for (int i = 0; i < pool.size(); i++) {
+            ordered.add(pool.get((headIndex + i) % pool.size()));
+        }
+        if (pool != candidates) {
+            ordered.addAll(coolingDown);
+        }
+        return ordered;
+    }
+
+    /**
+     * Advances the rotation for a label by one pick and returns the winner.
+     */
+    private SlaveTemplate selectWeighted(String labelName, List<SlaveTemplate> pool) {
+        int totalWeight = 0;
+        for (SlaveTemplate t : pool) {
+            totalWeight += t.getHotSpareWeight();
+        }
+        if (totalWeight == 0) {
+            /*
+             * Nothing carries any weight, which only happens when an admin has set every template
+             * in the group to zero. Fall back to plain rotation so the label still provisions.
+             */
+            int cursor = unweightedCursor.merge(key(labelName), 1, Integer::sum) - 1;
+            return pool.get(Math.floorMod(cursor, pool.size()));
+        }
+
+        Map<String, Integer> current = currentWeights.computeIfAbsent(key(labelName), k -> new ConcurrentHashMap<>());
+        SlaveTemplate best = null;
+        String bestKey = null;
+        int bestCurrent = Integer.MIN_VALUE;
+        for (SlaveTemplate t : pool) {
+            String templateKey = templateKey(t);
+            int updated = current.merge(templateKey, t.getHotSpareWeight(), Integer::sum);
+            if (updated > bestCurrent) {
+                bestCurrent = updated;
+                best = t;
+                bestKey = templateKey;
+            }
+        }
+        current.merge(bestKey, -totalWeight, Integer::sum);
+        return best;
+    }
+
+    /**
+     * Marks a template as capacity-unavailable for the label group it was selected from.
+     *
+     * <p>No-op when {@code groupSize <= 1}: a label with a single template has nothing to fail over
+     * to, so it must keep retrying across its own availability zones rather than being taken out of
+     * rotation for the cooldown period.
+     */
+    void markTemplateUnavailable(SlaveTemplate t, int groupSize) {
+        if (t == null || groupSize <= 1 || !enabled.getAsBoolean()) {
+            return;
+        }
+        long until = getClock().millis() + TEMPLATE_CAPACITY_COOLDOWN_MILLIS;
+        templateCapacityCooldownUntil.put(templateKey(t), until);
+        LOGGER.log(
+                Level.FINE,
+                () -> String.format(
+                        "Demoting template %s (instance type %s) in the label rotation until %d",
+                        t.getDescription(), t.getType(), until));
+    }
+
+    /**
+     * @return {@code true} if the template is currently demoted for a capacity error. Expired
+     *     cooldowns are cleaned up as a side effect.
+     */
+    boolean isTemplateInCooldown(SlaveTemplate t, int groupSize) {
+        if (t == null || groupSize <= 1 || !enabled.getAsBoolean()) {
+            return false;
+        }
+        String templateKey = templateKey(t);
+        Long until = templateCapacityCooldownUntil.get(templateKey);
+        if (until == null) {
+            return false;
+        }
+        if (getClock().millis() >= until) {
+            templateCapacityCooldownUntil.remove(templateKey, until);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Overrides the clock used for cooldown bookkeeping. For tests only.
+     */
+    void setClock(Clock clock) {
+        synchronized (this) {
+            this.clock = clock;
+        }
+    }
+
+    private synchronized Clock getClock() {
+        if (clock == null) {
+            clock = Clock.systemUTC();
+        }
+        return clock;
+    }
+
+    private static String key(String labelName) {
+        return labelName == null ? "" : labelName;
+    }
+
+    /**
+     * Identifies a template across configuration reloads. Descriptions are unique within a cloud
+     * (see {@link EC2Cloud#addTemplate}) and are what the rest of the plugin counts instances by.
+     */
+    private static String templateKey(SlaveTemplate t) {
+        String description = t.getDescription();
+        if (description != null && !description.isBlank()) {
+            return description;
+        }
+        return t.getAmi() + "/" + t.getType();
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/LabelTemplateRotation.java
+++ b/src/main/java/hudson/plugins/ec2/LabelTemplateRotation.java
@@ -27,8 +27,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
@@ -49,7 +52,13 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * <p>Selection is smooth weighted round-robin (as used by nginx) over
  * {@link SlaveTemplate#getHotSpareWeight()}: for weights 2 and 1 the leading template alternates as
  * {@code a, a, b, a, a, b} rather than picking {@code a} twice in a row and then {@code b} twice,
- * which is what makes the fallback fast when one instance type runs dry.
+ * which is what makes the fallback fast when one instance type runs dry. A weight is therefore a
+ * share of the attempts, and every weight keeps getting some of them.
+ *
+ * <p>{@link EC2Cloud#isSaturateHighestWeightFirst()} swaps that for a hierarchy: templates sharing
+ * a weight form a band, the highest band leads every request, and a lower band is only reached once
+ * every template above it is at its instance cap or in the capacity cooldown. Templates within a
+ * band still rotate, so a band spreads over its instance types and availability zones.
  *
  * <p>All of this is inert unless {@link EC2Cloud#isRoundRobinTemplatesByLabel()} is enabled.
  */
@@ -82,15 +91,21 @@ class LabelTemplateRotation {
     /** Plain rotation cursor per label, used when every candidate has a weight of zero. */
     private final ConcurrentHashMap<String, Integer> unweightedCursor = new ConcurrentHashMap<>();
 
+    /** Rotation cursor per label and weight, used within a band when saturating the highest first. */
+    private final ConcurrentHashMap<String, Integer> bandCursor = new ConcurrentHashMap<>();
+
     /** Template key to the epoch-millis timestamp until which the template should be demoted. */
     private final ConcurrentHashMap<String, Long> templateCapacityCooldownUntil = new ConcurrentHashMap<>();
 
     private final BooleanSupplier enabled;
 
+    private final BooleanSupplier saturateHighestWeightFirst;
+
     private Clock clock;
 
-    LabelTemplateRotation(@NonNull BooleanSupplier enabled) {
+    LabelTemplateRotation(@NonNull BooleanSupplier enabled, @NonNull BooleanSupplier saturateHighestWeightFirst) {
         this.enabled = enabled;
+        this.saturateHighestWeightFirst = saturateHighestWeightFirst;
     }
 
     /**
@@ -100,8 +115,9 @@ class LabelTemplateRotation {
      *
      * @param labelName the label being provisioned for, or an empty string for no label
      * @param matching the templates matching that label, in configured order
-     * @return the templates to try, best first. The configured order is returned unchanged when
-     *     rotation is disabled or only one template matches.
+     * @return the templates to try, best first, by share of the weights or by weight band
+     *     depending on {@link EC2Cloud#isSaturateHighestWeightFirst()}. The configured order is
+     *     returned unchanged when rotation is disabled or only one template matches.
      */
     List<SlaveTemplate> order(String labelName, Collection<SlaveTemplate> matching) {
         List<SlaveTemplate> candidates = new ArrayList<>(matching);
@@ -121,15 +137,56 @@ class LabelTemplateRotation {
 
         // Every template is cooling down: rotate over all of them rather than refuse to provision.
         List<SlaveTemplate> pool = available.isEmpty() ? candidates : available;
-        SlaveTemplate head = selectWeighted(labelName, pool);
-
-        List<SlaveTemplate> ordered = new ArrayList<>(candidates.size());
-        int headIndex = pool.indexOf(head);
-        for (int i = 0; i < pool.size(); i++) {
-            ordered.add(pool.get((headIndex + i) % pool.size()));
-        }
+        List<SlaveTemplate> ordered = saturateHighestWeightFirst.getAsBoolean()
+                ? orderByWeightBand(labelName, pool)
+                : rotateAround(pool, selectWeighted(labelName, pool));
         if (pool != candidates) {
             ordered.addAll(coolingDown);
+        }
+        return ordered;
+    }
+
+    /**
+     * Orders the pool into weight bands, heaviest first, so a lighter band is only reached once
+     * every template above it has turned the request down. Cooling-down templates are already out
+     * of the pool, which is what lets a fully saturated band hand the label to the next one.
+     *
+     * <p>The heaviest band is rotated so its templates take turns leading, spreading a label over
+     * the instance types and availability zones the admin considers equivalent. Lighter bands keep
+     * their configured order: they are a fallback within this request, and they rotate in their own
+     * right once they are the heaviest band still available.
+     */
+    private List<SlaveTemplate> orderByWeightBand(String labelName, List<SlaveTemplate> pool) {
+        NavigableMap<Integer, List<SlaveTemplate>> bands = new TreeMap<>(Comparator.reverseOrder());
+        for (SlaveTemplate t : pool) {
+            bands.computeIfAbsent(t.getHotSpareWeight(), weight -> new ArrayList<>())
+                    .add(t);
+        }
+
+        List<SlaveTemplate> ordered = new ArrayList<>(pool.size());
+        boolean leading = true;
+        for (Map.Entry<Integer, List<SlaveTemplate>> band : bands.entrySet()) {
+            List<SlaveTemplate> members = band.getValue();
+            if (leading && members.size() > 1) {
+                int cursor = bandCursor.merge(key(labelName) + "/" + band.getKey(), 1, Integer::sum) - 1;
+                ordered.addAll(rotateAround(members, members.get(Math.floorMod(cursor, members.size()))));
+            } else {
+                ordered.addAll(members);
+            }
+            leading = false;
+        }
+        return ordered;
+    }
+
+    /**
+     * @return {@code pool} rotated so {@code head} leads and the templates configured before it
+     *     wrap around to the end.
+     */
+    private static List<SlaveTemplate> rotateAround(List<SlaveTemplate> pool, SlaveTemplate head) {
+        List<SlaveTemplate> ordered = new ArrayList<>(pool.size());
+        int headIndex = Math.max(0, pool.indexOf(head));
+        for (int i = 0; i < pool.size(); i++) {
+            ordered.add(pool.get((headIndex + i) % pool.size()));
         }
         return ordered;
     }

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -1988,7 +1988,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     /**
      * @return the relative weight of this template in the label rotation. Defaults to 1, giving
      *     plain round-robin. 0 excludes the template unless every other template in the group is in
-     *     a capacity cooldown.
+     *     a capacity cooldown. A weight is a share of the requests, or a rank when the cloud has
+     *     {@link EC2Cloud#isSaturateHighestWeightFirst()} enabled.
      */
     public int getHotSpareWeight() {
         return hotSpareWeight == null ? 1 : Math.max(0, hotSpareWeight);

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -3793,6 +3793,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         @POST
         public FormValidation doCheckHotSpareWeight(@QueryParameter String value, @AncestorInPath EC2Cloud cloud) {
+            // The warning below reports how the cloud is configured, so only someone who may
+            // configure it gets an answer.
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                return FormValidation.ok();
+            }
             if (value == null || value.trim().isEmpty()) {
                 return FormValidation.ok();
             }

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -80,6 +80,7 @@ import jenkins.slaves.iterators.api.NodeIterator;
 import jenkins.util.SystemProperties;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -246,6 +247,26 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     private MinimumNumberOfInstancesTimeRangeConfig minimumNumberOfInstancesTimeRangeConfig;
 
     private final int minimumNumberOfSpareInstances;
+
+    /**
+     * Relative weight of this template when several templates match the same label and the cloud
+     * has {@link EC2Cloud#isRoundRobinTemplatesByLabel()} enabled. Boxed so a configuration saved
+     * before the field existed reads as unset and defaults to 1 rather than to 0, which would mean
+     * "exclude from rotation".
+     */
+    private Integer hotSpareWeight;
+
+    /**
+     * Minutes to wait for an agent to come online after provisioning was requested. 0 disables the
+     * grace period, which is the behaviour of configurations saved before it existed.
+     */
+    private int gracePeriodMinutes;
+
+    /**
+     * Whether an agent that is still offline when the grace period expires is discarded outright
+     * rather than handed to the idle-termination clock.
+     */
+    private boolean discardAfterGracePeriod = true;
 
     public final boolean stopOnTerminate;
 
@@ -1962,6 +1983,42 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public int getMinimumNumberOfSpareInstances() {
         return minimumNumberOfSpareInstances;
+    }
+
+    /**
+     * @return the relative weight of this template in the label rotation. Defaults to 1, giving
+     *     plain round-robin. 0 excludes the template unless every other template in the group is in
+     *     a capacity cooldown.
+     */
+    public int getHotSpareWeight() {
+        return hotSpareWeight == null ? 1 : Math.max(0, hotSpareWeight);
+    }
+
+    @DataBoundSetter
+    public void setHotSpareWeight(int hotSpareWeight) {
+        this.hotSpareWeight = Math.max(0, hotSpareWeight);
+    }
+
+    /**
+     * @return minutes an agent is given to come online before the grace period expires, or 0 when
+     *     no grace period is configured on this template.
+     */
+    public int getGracePeriodMinutes() {
+        return gracePeriodMinutes;
+    }
+
+    @DataBoundSetter
+    public void setGracePeriodMinutes(int gracePeriodMinutes) {
+        this.gracePeriodMinutes = Math.max(0, gracePeriodMinutes);
+    }
+
+    public boolean isDiscardAfterGracePeriod() {
+        return discardAfterGracePeriod;
+    }
+
+    @DataBoundSetter
+    public void setDiscardAfterGracePeriod(boolean discardAfterGracePeriod) {
+        this.discardAfterGracePeriod = discardAfterGracePeriod;
     }
 
     public MinimumNumberOfInstancesTimeRangeConfig getMinimumNumberOfInstancesTimeRangeConfig() {
@@ -3732,6 +3789,27 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             } catch (NumberFormatException ignore) {
             }
             return FormValidation.error("Minimum number of spare instances must be a non-negative integer (or null)");
+        }
+
+        @POST
+        public FormValidation doCheckHotSpareWeight(@QueryParameter String value, @AncestorInPath EC2Cloud cloud) {
+            if (value == null || value.trim().isEmpty()) {
+                return FormValidation.ok();
+            }
+            int val;
+            try {
+                val = Integer.parseInt(value);
+            } catch (NumberFormatException ignore) {
+                return FormValidation.error("Hot spare weight must be a non-negative integer (or null)");
+            }
+            if (val < 0) {
+                return FormValidation.error("Hot spare weight must be a non-negative integer (or null)");
+            }
+            if (val != 1 && cloud != null && !cloud.isRoundRobinTemplatesByLabel()) {
+                return FormValidation.warning(
+                        "This weight is ignored until \"Round-robin templates matching the same label\" is enabled on the cloud.");
+            }
+            return FormValidation.ok();
         }
 
         @POST

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -2594,39 +2594,21 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             }
         }
 
-        RunInstancesRequest.Builder riRequestBuilder = riRequest.toBuilder();
-        riRequestBuilder.maxCount(number - orphansOrStopped.size());
+        int countToCreate = number - orphansOrStopped.size();
+        RunInstancesRequest.Builder riRequestBuilder = riRequest.toBuilder().maxCount(countToCreate);
 
         List<Instance> newInstances;
         if (spotWithoutBidPrice) {
-            InstanceMarketOptionsRequest.Builder instanceMarketOptionsRequestBuilder =
-                    InstanceMarketOptionsRequest.builder().marketType(MarketType.SPOT);
-            if (getSpotBlockReservationDuration() != 0) {
-                SpotMarketOptions spotOptions = SpotMarketOptions.builder()
-                        .blockDurationMinutes(getSpotBlockReservationDuration() * 60)
-                        .build();
-                instanceMarketOptionsRequestBuilder.spotOptions(spotOptions);
-            }
-            riRequestBuilder.instanceMarketOptions(instanceMarketOptionsRequestBuilder.build());
+            InstanceMarketOptionsRequest marketOptions = spotMarketOptions();
+            riRequestBuilder.instanceMarketOptions(marketOptions);
             try {
-                newInstances = new ArrayList<>(
-                        ec2.runInstances(riRequestBuilder.build()).instances());
+                newInstances =
+                        runInstancesWithSubnetFailover(ec2, image, countToCreate, riRequestBuilder, marketOptions);
             } catch (Ec2Exception e) {
-                if (fallbackSpotToOndemand
-                        && "InsufficientInstanceCapacity"
-                                .equals(e.awsErrorDetails().errorCode())) {
-                    logProvisionInfo(
-                            "There is no spot capacity available matching your request, falling back to on-demand instance.");
-                    riRequestBuilder.instanceMarketOptions(instanceMarketOptionsRequestBuilder.build());
-                    newInstances = new ArrayList<>(
-                            ec2.runInstances(riRequestBuilder.build()).instances());
-                } else {
-                    throw e;
-                }
+                newInstances = launchOndemandInstead(ec2, image, countToCreate, fallbackSpotToOndemand, e);
             }
         } else {
-            newInstances = runOndemandInstancesWithSubnetFailover(
-                    ec2, image, number - orphansOrStopped.size(), riRequestBuilder);
+            newInstances = runInstancesWithSubnetFailover(ec2, image, countToCreate, riRequestBuilder, null);
         }
         // Have to create a new instance
 
@@ -2640,66 +2622,151 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     /**
-     * Runs on-demand instances, retrying against the next subnet if the current one
-     * reports an insufficient-capacity error. The exhausted subnet is put into a
-     * cooldown so subsequent provisioning rounds skip it. Up to one attempt per
-     * configured subnet is made; if all fail with capacity errors the last exception
-     * is rethrown.
+     * Runs instances, moving to the next subnet when the one in hand cannot take the whole
+     * request, and keeping whatever each subnet did supply.
+     *
+     * <p>An instance type in one subnet is a single capacity pool. A pool can refuse a request
+     * outright, and it can also fill only part of it, because {@code RunInstances} launches as
+     * many instances as it can between {@code minCount} and {@code maxCount} rather than failing.
+     * Either way the rest of the request is asked of the next subnet, so a wide build reaches its
+     * capacity in one request instead of one availability zone's worth per provisioning round.
+     *
+     * <p>A subnet that reports insufficient capacity is also put into a cooldown, so subsequent
+     * rounds skip it. Up to one attempt per configured subnet is made. If every subnet refused and
+     * nothing at all was launched, the last capacity exception is rethrown, which is what lets the
+     * caller move the request on to the next template and demote this one.
+     *
+     * @param marketOptions the spot market options to re-apply when the request is rebuilt for the
+     *     next subnet, or {@code null} for an on-demand launch. Rebuilding is what selects the
+     *     next subnet, and it starts from a plain request, so without this a spot launch would
+     *     quietly become an on-demand one on its second subnet.
      */
-    private List<Instance> runOndemandInstancesWithSubnetFailover(
-            Ec2Client ec2, Image image, int countToCreate, RunInstancesRequest.Builder initialBuilder)
+    private List<Instance> runInstancesWithSubnetFailover(
+            Ec2Client ec2,
+            Image image,
+            int countToCreate,
+            RunInstancesRequest.Builder initialBuilder,
+            @CheckForNull InstanceMarketOptionsRequest marketOptions)
             throws IOException {
         int subnetCount = getSubnetCount();
         int maxAttempts = Math.max(1, subnetCount);
         RunInstancesRequest.Builder builder = initialBuilder;
+        List<Instance> launched = new ArrayList<>();
         Ec2Exception lastCapacityException = null;
 
         for (int attempt = 0; attempt < maxAttempts; attempt++) {
+            String attemptedSubnet = getCurrentSubnetId();
+            boolean canTryAnotherSubnet = subnetCount > 1 && attempt < maxAttempts - 1;
             try {
-                return new ArrayList<>(ec2.runInstances(builder.build()).instances());
+                int before = launched.size();
+                launched.addAll(ec2.runInstances(builder.build()).instances());
+                /*
+                 * A subnet that launched nothing at all, without saying why, is not a part-filled
+                 * pool to carry a remainder from: EC2 reports a pool it cannot draw on as an
+                 * error rather than as an empty success, so there is nothing here to react to.
+                 */
+                boolean partlyFilled = launched.size() > before;
+                if (launched.size() >= countToCreate || !partlyFilled || !canTryAnotherSubnet) {
+                    return launched;
+                }
+                logProvisionInfo(String.format(
+                        "Subnet %s supplied %d of the %d instance(s) asked for; trying the next subnet for the rest",
+                        attemptedSubnet, launched.size(), countToCreate));
             } catch (Ec2Exception e) {
                 String errorCode =
                         e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : null;
-                boolean canFailover =
-                        isInsufficientCapacityError(errorCode) && subnetCount > 1 && attempt < maxAttempts - 1;
-                if (!canFailover) {
+                if (!isInsufficientCapacityError(errorCode) || !canTryAnotherSubnet) {
+                    if (!launched.isEmpty()) {
+                        // Part of the request is in hand; let the caller place the remainder.
+                        return launched;
+                    }
                     logProvisionInfo(
                             "Jenkins attempted to reserve " + builder.build().maxCount()
                                     + " instances and received this EC2 exception: " + e.getMessage());
                     throw e;
                 }
 
-                String exhaustedSubnet = getCurrentSubnetId();
-                markSubnetUnavailable(exhaustedSubnet);
+                markSubnetUnavailable(attemptedSubnet);
                 lastCapacityException = e;
                 logProvisionInfo(String.format(
                         "Subnet %s has insufficient capacity for instance type %s (%s); trying next subnet",
-                        exhaustedSubnet, type, errorCode));
+                        attemptedSubnet, type, errorCode));
+            }
 
-                // Rebuild the request against the next subnet. This re-selects the subnet
-                // (skipping cooled-down ones) and re-resolves the VPC security groups.
-                HashMap<RunInstancesRequest, List<Filter>> retryMap =
-                        makeRunInstancesRequestAndFilters(image, countToCreate, ec2);
-                if (retryMap == null || retryMap.isEmpty()) {
-                    throw e;
-                }
-                RunInstancesRequest retryRequest =
-                        retryMap.entrySet().iterator().next().getKey();
-                builder = retryRequest.toBuilder();
-                builder.maxCount(countToCreate);
+            // Rebuild the request against the next subnet for what is still wanted. This
+            // re-selects the subnet (skipping cooled-down ones) and re-resolves the VPC
+            // security groups.
+            int remaining = countToCreate - launched.size();
+            builder = makeRunInstancesRequest(image, remaining, ec2);
+            if (builder == null) {
+                break;
+            }
+            if (marketOptions != null) {
+                builder.instanceMarketOptions(marketOptions);
+            }
 
-                // If rotation could only offer the same (exhausted) subnet, there is
-                // nothing left to try.
-                if (Objects.equals(exhaustedSubnet, getCurrentSubnetId())) {
-                    throw e;
-                }
+            // If rotation could only offer the same subnet, there is nothing left to try.
+            if (Objects.equals(attemptedSubnet, getCurrentSubnetId())) {
+                break;
             }
         }
 
-        if (lastCapacityException != null) {
+        if (launched.isEmpty() && lastCapacityException != null) {
             throw lastCapacityException;
         }
-        return new ArrayList<>();
+        return launched;
+    }
+
+    /**
+     * Answers a spot launch that no subnet would serve by launching the same instances on-demand,
+     * for a template configured to accept that. The request is built afresh so that it carries no
+     * spot market options: retrying the refused request unchanged is not a fallback.
+     *
+     * @throws Ec2Exception the original failure, if this template does not fall back, the failure
+     *     was not about capacity, or an on-demand request could not be built.
+     */
+    private List<Instance> launchOndemandInstead(
+            Ec2Client ec2, Image image, int countToCreate, boolean fallbackSpotToOndemand, Ec2Exception spotFailure)
+            throws IOException {
+        String errorCode = spotFailure.awsErrorDetails() == null
+                ? null
+                : spotFailure.awsErrorDetails().errorCode();
+        RunInstancesRequest.Builder ondemandBuilder = null;
+        if (fallbackSpotToOndemand && isInsufficientCapacityError(errorCode)) {
+            ondemandBuilder = makeRunInstancesRequest(image, countToCreate, ec2);
+        }
+        if (ondemandBuilder == null) {
+            throw spotFailure;
+        }
+
+        logProvisionInfo(
+                "No subnet has spot capacity available matching your request, falling back to on-demand instances.");
+        return runInstancesWithSubnetFailover(ec2, image, countToCreate, ondemandBuilder, null);
+    }
+
+    /**
+     * @return a request to launch {@code count} instances in the next subnet of the rotation, or
+     *     {@code null} if one could not be built.
+     */
+    @CheckForNull
+    private RunInstancesRequest.Builder makeRunInstancesRequest(Image image, int count, Ec2Client ec2)
+            throws IOException {
+        HashMap<RunInstancesRequest, List<Filter>> requestMap = makeRunInstancesRequestAndFilters(image, count, ec2);
+        if (requestMap == null || requestMap.isEmpty()) {
+            return null;
+        }
+        return requestMap.entrySet().iterator().next().getKey().toBuilder().maxCount(count);
+    }
+
+    private InstanceMarketOptionsRequest spotMarketOptions() {
+        InstanceMarketOptionsRequest.Builder marketOptionsBuilder =
+                InstanceMarketOptionsRequest.builder().marketType(MarketType.SPOT);
+        if (getSpotBlockReservationDuration() != 0) {
+            marketOptionsBuilder.spotOptions(SpotMarketOptions.builder()
+                    .blockDurationMinutes(getSpotBlockReservationDuration() * 60)
+                    .build());
+        }
+        return marketOptionsBuilder.build();
     }
 
     void wakeOrphansOrStoppedUp(Ec2Client ec2, List<Instance> orphansOrStopped) {
@@ -2907,12 +2974,18 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     /**
-     * Provision a new agent for an EC2 spot instance to call back to Jenkins
+     * Provision new agents for EC2 spot instances to call back to Jenkins
      */
     private List<EC2AbstractSlave> provisionSpot(Image image, int number, EnumSet<ProvisionOptions> provisionOptions)
             throws IOException {
         if (!spotConfig.useBidPrice) {
-            return provisionOndemand(image, 1, provisionOptions, true, spotConfig.getFallbackToOndemand());
+            /*
+             * Bidding the on-demand price launches through RunInstances with spot market options,
+             * which takes a count like any other launch. Asking for one at a time would serve a
+             * request for twenty agents one instance per provisioning pass, so a label whose
+             * cheapest hardware is spot would meet a burst on its more expensive templates.
+             */
+            return provisionOndemand(image, number, provisionOptions, true, spotConfig.getFallbackToOndemand());
         }
 
         Ec2Client ec2 = getParent().connect();

--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -535,41 +535,47 @@ public class MinimumInstanceChecker {
 
     /**
      * Spreads a shortfall over the templates of a label group, in rotation order so hot spare
-     * weights apply, and never beyond what a template's instance cap allows. A template at its cap,
-     * or outside the time range it is configured to hold instances in, is skipped for this round and
-     * its share is offered to the templates that can take it.
+     * weights apply.
+     *
+     * <p>The whole shortfall is handed to the group as one request, so what the leading template
+     * cannot supply is asked of the ones behind it before the pass gives up. That matters most for
+     * the case the spares exist for: a template is a single spot pool and EC2 fills a request for
+     * twenty with however many it has, so a burst that one pool cannot cover is met from the next
+     * one in cost order within the same pass instead of a pool's worth per minute. A template out
+     * of capacity is also put into the rotation cooldown, the same as for a label request, so the
+     * next pass leads with one that can deliver.
+     *
+     * <p>A template outside the time range it is configured to hold instances in is left out of the
+     * request altogether: its schedule is how an admin pays for capacity only when it is wanted.
      */
     private static void provisionAcrossLabelGroup(
             @NonNull EC2Cloud cloud, @NonNull Label label, @NonNull Collection<SlaveTemplate> matching, int toLaunch) {
+        List<SlaveTemplate> onDuty = new ArrayList<>();
         for (SlaveTemplate template : cloud.orderTemplatesForLabel(label, matching)) {
-            if (toLaunch <= 0) {
-                return;
-            }
-            if (!keepsWarmInstancesNow(template)) {
+            if (keepsWarmInstancesNow(template)) {
+                onDuty.add(template);
+            } else {
                 LOGGER.log(
                         Level.FINE,
                         "{0} is outside the time range it keeps instances in, offering its hot spares to the next template",
                         template);
-                continue;
             }
-            int headroom = cloud.getAvailableCapacity(template);
-            if (headroom <= 0) {
-                LOGGER.log(
-                        Level.FINE,
-                        "{0} is at its instance cap, offering its hot spares to the next template",
-                        template);
-                continue;
-            }
-            int number = Math.min(toLaunch, headroom);
-            cloud.provision(template, number);
-            toLaunch -= number;
         }
-        if (toLaunch > 0) {
+        if (onDuty.isEmpty()) {
             LOGGER.log(
                     Level.FINE,
-                    "{0} hot spare(s) for label {1} were not provisioned: every template is at its instance cap or "
-                            + "outside the time range it keeps instances in",
-                    new Object[] {toLaunch, label.getName()});
+                    "No template of label {0} is holding instances at the moment, so its {1} hot spare(s) wait",
+                    new Object[] {label.getName(), toLaunch});
+            return;
+        }
+
+        int launched = cloud.provisionAcrossGroup(onDuty, toLaunch);
+        if (launched < toLaunch) {
+            LOGGER.log(
+                    Level.FINE,
+                    "{0} of {1} hot spare(s) for label {2} were not provisioned: every template of the group is at "
+                            + "its instance cap, out of capacity, or outside the time range it keeps instances in",
+                    new Object[] {toLaunch - launched, toLaunch, label.getName()});
         }
     }
 

--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -9,20 +9,27 @@ import hudson.model.Queue;
 import hudson.plugins.ec2.EC2AbstractSlave;
 import hudson.plugins.ec2.EC2Cloud;
 import hudson.plugins.ec2.EC2Computer;
+import hudson.plugins.ec2.HotSpareConfigByLabel;
+import hudson.plugins.ec2.HotSpareDemand;
 import hudson.plugins.ec2.SlaveTemplate;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
@@ -44,11 +51,33 @@ public class MinimumInstanceChecker {
     });
 
     /**
+     * Set while a check is queued but has not started reading the state of Jenkins yet.
+     */
+    private static final AtomicBoolean CHECK_QUEUED = new AtomicBoolean();
+
+    /**
      * Schedules a minimum-instance check to run asynchronously. Use this instead of
      * {@link #checkForMinimumInstances()} when the caller must return immediately (e.g. taskAccepted).
+     *
+     * <p>Requests that arrive while one is already waiting are dropped: the queued check has not
+     * looked at Jenkins yet, so it will see everything they would have asked about. Without this, a
+     * burst of builds starting at once would queue one redundant pass per build behind the single
+     * checker thread.
      */
     public static void scheduleCheck() {
-        EXECUTOR.execute(MinimumInstanceChecker::checkForMinimumInstances);
+        if (!CHECK_QUEUED.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            EXECUTOR.execute(() -> {
+                CHECK_QUEUED.set(false);
+                checkForMinimumInstances();
+            });
+        } catch (RuntimeException e) {
+            // Jenkins is shutting down. Leaving the flag set would silence every later request.
+            CHECK_QUEUED.set(false);
+            throw e;
+        }
     }
 
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Needs to be overridden from tests")
@@ -77,10 +106,15 @@ public class MinimumInstanceChecker {
         return (int) idleAgents(agentTemplate).filter(Computer::isOnline).count();
     }
 
+    /**
+     * @return the number of agents of this template that exist but cannot take work yet. Counted
+     *     from attachment rather than from the launcher starting, for the reason given on
+     *     {@link #countCurrentNumberOfProvisioningAgentsForLabel}.
+     */
     public static int countCurrentNumberOfProvisioningAgents(@NonNull SlaveTemplate agentTemplate) {
         return (int) idleAgents(agentTemplate)
                 .filter(Computer::isOffline)
-                .filter(Computer::isConnecting)
+                .filter(computer -> !computer.isTemporarilyOffline())
                 .count();
     }
 
@@ -96,6 +130,138 @@ public class MinimumInstanceChecker {
     }
 
     /**
+     * Agents of a whole label group. A hot spare rule owns the label rather than one AMI, so its
+     * counts aggregate over every template of the cloud carrying that label instead of matching a
+     * single template description.
+     */
+    private static Stream<EC2Computer> agentsForLabel(@NonNull EC2Cloud cloud, @NonNull Label label) {
+        Set<String> descriptions = cloud.getTemplates(label).stream()
+                .map(template -> template.description)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        return Arrays.stream(Jenkins.get().getComputers())
+                .filter(EC2Computer.class::isInstance)
+                .map(EC2Computer.class::cast)
+                .filter(computer -> {
+                    SlaveTemplate computerTemplate = computer.getSlaveTemplate();
+                    return computerTemplate != null && descriptions.contains(computerTemplate.description);
+                });
+    }
+
+    public static int countCurrentNumberOfSpareAgentsForLabel(@NonNull EC2Cloud cloud, @NonNull Label label) {
+        return (int) agentsForLabel(cloud, label)
+                .filter(MinimumInstanceChecker::isSpare)
+                .count();
+    }
+
+    /**
+     * @return whether an agent is warm capacity the label can count on right now. An agent that has
+     *     drained its maximum number of uses is idle and online but stops accepting tasks, so
+     *     counting it would let a pool of agents that can never run anything satisfy the target. An
+     *     agent whose template is outside its schedule does not count either, so the label warms up
+     *     on a template that is on duty and lets this one go at its idle timeout.
+     */
+    private static boolean isSpare(@NonNull EC2Computer computer) {
+        SlaveTemplate template = computer.getSlaveTemplate();
+        return computer.isIdle()
+                && computer.isOnline()
+                && computer.isAcceptingTasks()
+                && !computer.isTemporarilyOffline()
+                && (template == null || keepsWarmInstancesNow(template));
+    }
+
+    /**
+     * @return whether a template may be holding instances nothing has asked for at this moment.
+     *     <i>Only apply minimum number of instances during specific time range</i> is how an admin
+     *     pays for warm capacity only when it is worth having, so a hot spare rule honours it
+     *     instead of quietly putting the template back on the clock around the clock. The schedule
+     *     stays a property of the template, which is what lets one label be served by a template
+     *     per shift.
+     */
+    public static boolean keepsWarmInstancesNow(@NonNull SlaveTemplate template) {
+        return minimumInstancesActive(template.getMinimumNumberOfInstancesTimeRangeConfig());
+    }
+
+    /**
+     * Whether the hot spare prediction for a label is still counting on this agent, which is the
+     * question the idle timeout has to ask before reclaiming it. Terminating a spare the target
+     * wants pays for the same capacity twice - once for the instance thrown away, again for the one
+     * the next pass launches in its place - and leaves a build waiting for the boot in between.
+     *
+     * <p>The spares are ranked by how long each has been idle and the freshest {@code target} of
+     * them are kept, so several agents asking at once agree on which are the extras and exactly the
+     * surplus is released. Releasing the longest-idle first keeps the behaviour of an idle timeout:
+     * the agent that has been sitting unused the longest is the one that goes.
+     *
+     * <p>The agent being asked about is included whether or not the counted set has caught up with
+     * it, because the comparison is meaningless if the pool it is ranked against excludes it.
+     *
+     * @return true when the label wants this agent kept warm, false when it is surplus, is not warm
+     *     capacity at all, or the label wants no spares.
+     */
+    public static boolean isSpareStillWanted(
+            @NonNull EC2Cloud cloud, @NonNull HotSpareConfigByLabel config, @NonNull EC2Computer computer) {
+        String labelName = config.getLabel();
+        if (labelName == null || labelName.isBlank()) {
+            return false;
+        }
+        int target = HotSpareDemand.of(cloud, labelName).getTarget();
+        if (target <= 0 || !isSpare(computer)) {
+            return false;
+        }
+
+        List<EC2Computer> spares = agentsForLabel(cloud, Label.get(labelName))
+                .filter(MinimumInstanceChecker::isSpare)
+                .collect(Collectors.toCollection(ArrayList::new));
+        if (spares.stream().noneMatch(spare -> spare == computer)) {
+            spares.add(computer);
+        }
+        if (spares.size() <= target) {
+            return true;
+        }
+        spares.sort(Comparator.comparingLong(Computer::getIdleStartMilliseconds).thenComparing(Computer::getName));
+        return spares.subList(spares.size() - target, spares.size()).stream().anyMatch(spare -> spare == computer);
+    }
+
+    /**
+     * @return the number of agents of the label group that exist but cannot take work yet.
+     *     <p>An agent is counted from the moment it is attached rather than from the moment its
+     *     launcher starts, because {@link Computer#isConnecting()} is false for the gap in between
+     *     and two passes falling either side of that gap would launch the same shortfall twice.
+     *     Passes are triggered by builds queueing and starting, so they do arrive in quick
+     *     succession. An agent that never comes up is dealt with by its grace period.
+     */
+    public static int countCurrentNumberOfProvisioningAgentsForLabel(@NonNull EC2Cloud cloud, @NonNull Label label) {
+        return (int) agentsForLabel(cloud, label)
+                .filter(Computer::isIdle)
+                .filter(Computer::isOffline)
+                .filter(computer -> !computer.isTemporarilyOffline())
+                .count();
+    }
+
+    /**
+     * @return the number of agents of the label group running a build. They are not spares, which
+     *     is why a spare taken by a build is replaced, but they do say the label is in use.
+     */
+    public static int countCurrentNumberOfBusyAgentsForLabel(@NonNull EC2Cloud cloud, @NonNull Label label) {
+        return (int) agentsForLabel(cloud, label)
+                .filter(computer -> !computer.isIdle())
+                .count();
+    }
+
+    /**
+     * @return the number of buildable queue items any template of the label group could serve.
+     */
+    public static int countQueueItemsForLabel(@NonNull EC2Cloud cloud, @NonNull Label label) {
+        Collection<SlaveTemplate> templates = cloud.getTemplates(label);
+        return (int) Queue.getInstance().getBuildableItems().stream()
+                .map((Queue.Item item) -> item.getAssignedLabel())
+                .filter(Objects::nonNull)
+                .filter(assigned -> templates.stream().anyMatch(template -> assigned.matches(template.getLabelSet())))
+                .count();
+    }
+
+    /**
      * Checks all EC2 cloud templates and provisions agents to meet minimum instance requirements.
      * Synchronized to prevent concurrent provisioning decisions that could lead to over-provisioning
      * when multiple agents accept tasks simultaneously.
@@ -105,16 +271,17 @@ public class MinimumInstanceChecker {
     public static synchronized void checkForMinimumInstances() {
         Jenkins jenkins = Jenkins.get();
 
-        // Early exit if no templates have minimum instance requirements
+        // Early exit if nothing asks for instances to be kept warm
         boolean hasMinimumRequirements = jenkins.clouds.stream()
                 .filter(EC2Cloud.class::isInstance)
                 .map(EC2Cloud.class::cast)
-                .flatMap(cloud -> cloud.getTemplates().stream())
-                .anyMatch(template ->
-                        template.getMinimumNumberOfInstances() > 0 || template.getMinimumNumberOfSpareInstances() > 0);
+                .anyMatch(cloud -> !cloud.getHotSpareConfigsByLabel().isEmpty()
+                        || cloud.getTemplates().stream()
+                                .anyMatch(template -> template.getMinimumNumberOfInstances() > 0
+                                        || template.getMinimumNumberOfSpareInstances() > 0));
 
         if (!hasMinimumRequirements) {
-            // No templates require minimum instances - exit immediately
+            // Neither minimum instances nor label hot spares are configured - exit immediately
             return;
         }
 
@@ -170,6 +337,105 @@ public class MinimumInstanceChecker {
                         cloud.provision(agentTemplate, numberToProvision);
                     }
                 }));
+
+        jenkins.clouds.stream()
+                .filter(EC2Cloud.class::isInstance)
+                .map(EC2Cloud.class::cast)
+                .forEach(MinimumInstanceChecker::checkForLabelHotSpares);
+    }
+
+    /**
+     * Tops up the hot spares for every label rule of a cloud. Runs inside
+     * {@link #checkForMinimumInstances()} rather than from a monitor of its own so all provisioning
+     * decisions stay behind the same lock (JENKINS-76171).
+     *
+     * <p>A rule owns the spare count for its label, so a template's
+     * {@link SlaveTemplate#getMinimumNumberOfSpareInstances()} no longer applies to the templates
+     * the rule covers. A template's time range for keeping instances is another matter and is still
+     * obeyed: outside it the template holds no spares and the label warms up on whichever of its
+     * templates is on duty, so a label can be served by a template per shift.
+     *
+     * <p>Only idle agents count towards the target, so a spare taken by a build is a shortfall to be
+     * replaced, which is what keeps a label warm for the whole of a busy period instead of draining
+     * with the first few builds. Taking an executor schedules this pass
+     * ({@link hudson.plugins.ec2.EC2RetentionStrategy#taskAccepted}), so the replacement launches
+     * while the build that took the spare is still starting. Instances already on their way are
+     * subtracted as well, otherwise every pass would re-provision the same shortfall while the
+     * previous batch is still booting. {@link HotSpareDemand} decides what the target itself
+     * should be.
+     */
+    private static void checkForLabelHotSpares(@NonNull EC2Cloud cloud) {
+        for (HotSpareConfigByLabel config : cloud.getHotSpareConfigsByLabel()) {
+            String labelName = config.getLabel();
+            if (labelName == null) {
+                continue;
+            }
+            Label label = Label.get(labelName);
+            Collection<SlaveTemplate> matching = cloud.getTemplates(label);
+            if (matching.isEmpty()) {
+                continue;
+            }
+
+            int currentSpares = countCurrentNumberOfSpareAgentsForLabel(cloud, label);
+            int currentProvisioning = countCurrentNumberOfProvisioningAgentsForLabel(cloud, label);
+            int busyAgents = countCurrentNumberOfBusyAgentsForLabel(cloud, label);
+            int queuedBuilds = countQueueItemsForLabel(cloud, label);
+
+            int target = HotSpareDemand.of(cloud, labelName)
+                    .updateTarget(config, currentSpares, currentProvisioning, queuedBuilds, busyAgents);
+            int toLaunch = target - (currentSpares + currentProvisioning);
+
+            LOGGER.log(
+                    Level.FINE,
+                    "Hot spares for label {0}: target={1}, spare={2}, provisioning={3}, busy={4}, queued={5}, toLaunch={6}",
+                    new Object[] {
+                        labelName, target, currentSpares, currentProvisioning, busyAgents, queuedBuilds, toLaunch
+                    });
+
+            if (toLaunch > 0) {
+                provisionAcrossLabelGroup(cloud, label, matching, toLaunch);
+            }
+        }
+    }
+
+    /**
+     * Spreads a shortfall over the templates of a label group, in rotation order so hot spare
+     * weights apply, and never beyond what a template's instance cap allows. A template at its cap,
+     * or outside the time range it is configured to hold instances in, is skipped for this round and
+     * its share is offered to the templates that can take it.
+     */
+    private static void provisionAcrossLabelGroup(
+            @NonNull EC2Cloud cloud, @NonNull Label label, @NonNull Collection<SlaveTemplate> matching, int toLaunch) {
+        for (SlaveTemplate template : cloud.orderTemplatesForLabel(label, matching)) {
+            if (toLaunch <= 0) {
+                return;
+            }
+            if (!keepsWarmInstancesNow(template)) {
+                LOGGER.log(
+                        Level.FINE,
+                        "{0} is outside the time range it keeps instances in, offering its hot spares to the next template",
+                        template);
+                continue;
+            }
+            int headroom = cloud.getAvailableCapacity(template);
+            if (headroom <= 0) {
+                LOGGER.log(
+                        Level.FINE,
+                        "{0} is at its instance cap, offering its hot spares to the next template",
+                        template);
+                continue;
+            }
+            int number = Math.min(toLaunch, headroom);
+            cloud.provision(template, number);
+            toLaunch -= number;
+        }
+        if (toLaunch > 0) {
+            LOGGER.log(
+                    Level.FINE,
+                    "{0} hot spare(s) for label {1} were not provisioned: every template is at its instance cap or "
+                            + "outside the time range it keeps instances in",
+                    new Object[] {toLaunch, label.getName()});
+        }
     }
 
     public static boolean minimumInstancesActive(

--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -210,7 +210,12 @@ public class MinimumInstanceChecker {
             return false;
         }
 
-        List<EC2Computer> spares = agentsForLabel(cloud, Label.get(labelName))
+        Label label = Label.get(labelName);
+        if (label == null) {
+            return false;
+        }
+
+        List<EC2Computer> spares = agentsForLabel(cloud, label)
                 .filter(MinimumInstanceChecker::isSpare)
                 .collect(Collectors.toCollection(ArrayList::new));
         if (spares.stream().noneMatch(spare -> spare == computer)) {
@@ -371,6 +376,9 @@ public class MinimumInstanceChecker {
                 continue;
             }
             Label label = Label.get(labelName);
+            if (label == null) {
+                continue;
+            }
             Collection<SlaveTemplate> matching = cloud.getTemplates(label);
             if (matching.isEmpty()) {
                 continue;

--- a/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
+++ b/src/main/java/hudson/plugins/ec2/util/MinimumInstanceChecker.java
@@ -1,11 +1,14 @@
 package hudson.plugins.ec2.util;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.init.Terminator;
 import hudson.model.Computer;
+import hudson.model.Executor;
 import hudson.model.Label;
 import hudson.model.Queue;
+import hudson.model.queue.WorkUnit;
 import hudson.plugins.ec2.EC2AbstractSlave;
 import hudson.plugins.ec2.EC2Cloud;
 import hudson.plugins.ec2.EC2Computer;
@@ -19,7 +22,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -130,12 +136,10 @@ public class MinimumInstanceChecker {
     }
 
     /**
-     * Agents of a whole label group. A hot spare rule owns the label rather than one AMI, so its
-     * counts aggregate over every template of the cloud carrying that label instead of matching a
-     * single template description.
+     * Agents of a cloud, whichever of its templates they came from.
      */
-    private static Stream<EC2Computer> agentsForLabel(@NonNull EC2Cloud cloud, @NonNull Label label) {
-        Set<String> descriptions = cloud.getTemplates(label).stream()
+    private static Stream<EC2Computer> agentsOf(@NonNull EC2Cloud cloud) {
+        Set<String> descriptions = cloud.getTemplates().stream()
                 .map(template -> template.description)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
@@ -146,6 +150,22 @@ public class MinimumInstanceChecker {
                     SlaveTemplate computerTemplate = computer.getSlaveTemplate();
                     return computerTemplate != null && descriptions.contains(computerTemplate.description);
                 });
+    }
+
+    /**
+     * Agents that could serve a label: a hot spare target is held by the label work asked for, and
+     * any template of the cloud carrying that label can hold it, not just the one an earlier agent
+     * happened to come from.
+     */
+    private static Stream<EC2Computer> agentsForLabel(@NonNull EC2Cloud cloud, @NonNull Label label) {
+        Set<String> descriptions = cloud.getTemplates(label).stream()
+                .map(template -> template.description)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        return agentsOf(cloud).filter(computer -> {
+            SlaveTemplate computerTemplate = computer.getSlaveTemplate();
+            return computerTemplate != null && descriptions.contains(computerTemplate.description);
+        });
     }
 
     public static int countCurrentNumberOfSpareAgentsForLabel(@NonNull EC2Cloud cloud, @NonNull Label label) {
@@ -196,22 +216,34 @@ public class MinimumInstanceChecker {
      * <p>The agent being asked about is included whether or not the counted set has caught up with
      * it, because the comparison is meaningless if the pool it is ranked against excludes it.
      *
-     * @return true when the label wants this agent kept warm, false when it is surplus, is not warm
-     *     capacity at all, or the label wants no spares.
+     * <p>An agent can serve several labels, each with a target of its own, so the question is asked
+     * of every label it could take work for: it is surplus only once none of them is counting on
+     * it.
+     *
+     * @return true when some label wants this agent kept warm, false when it is surplus to all of
+     *     them or is not warm capacity at all.
      */
-    public static boolean isSpareStillWanted(
-            @NonNull EC2Cloud cloud, @NonNull HotSpareConfigByLabel config, @NonNull EC2Computer computer) {
-        String labelName = config.getLabel();
-        if (labelName == null || labelName.isBlank()) {
+    public static boolean isSpareStillWanted(@NonNull EC2Cloud cloud, @NonNull EC2Computer computer) {
+        if (!isSpare(computer)) {
+            return false;
+        }
+        return HotSpareDemand.trackedLabels(cloud).stream()
+                .anyMatch(labelName -> isSpareStillWantedFor(cloud, labelName, computer));
+    }
+
+    private static boolean isSpareStillWantedFor(
+            @NonNull EC2Cloud cloud, @NonNull String labelName, @NonNull EC2Computer computer) {
+        if (labelName.isBlank()) {
             return false;
         }
         int target = HotSpareDemand.of(cloud, labelName).getTarget();
-        if (target <= 0 || !isSpare(computer)) {
+        if (target <= 0) {
             return false;
         }
 
         Label label = Label.get(labelName);
-        if (label == null) {
+        SlaveTemplate template = computer.getSlaveTemplate();
+        if (label == null || template == null || !label.matches(template.getLabelSet())) {
             return false;
         }
 
@@ -245,24 +277,28 @@ public class MinimumInstanceChecker {
     }
 
     /**
-     * @return the number of agents of the label group running a build. They are not spares, which
-     *     is why a spare taken by a build is replaced, but they do say the label is in use.
+     * @return the number of agents running a build that asked for this label. They are not spares,
+     *     which is why a spare taken by a build is replaced, but they do say the label is in use.
+     *     <p>What the build asked for is the measure, not what the agent happens to be able to run:
+     *     an agent serving a branch build on a template that also carries the pull request label
+     *     says nothing about how much pull request capacity to keep warm.
      */
-    public static int countCurrentNumberOfBusyAgentsForLabel(@NonNull EC2Cloud cloud, @NonNull Label label) {
+    public static int countAgentsRunningWorkFor(@NonNull EC2Cloud cloud, @NonNull Label label) {
         return (int) agentsForLabel(cloud, label)
                 .filter(computer -> !computer.isIdle())
+                .filter(computer ->
+                        computer.getExecutors().stream().anyMatch(executor -> isAssignedTo(executor, label)))
                 .count();
     }
 
     /**
-     * @return the number of buildable queue items any template of the label group could serve.
+     * @return the number of buildable queue items waiting for exactly this label. An item waiting
+     *     for a different label is another label's demand, even when one template could serve both.
      */
-    public static int countQueueItemsForLabel(@NonNull EC2Cloud cloud, @NonNull Label label) {
-        Collection<SlaveTemplate> templates = cloud.getTemplates(label);
+    public static int countQueueItemsRequesting(@NonNull Label label) {
         return (int) Queue.getInstance().getBuildableItems().stream()
                 .map((Queue.Item item) -> item.getAssignedLabel())
-                .filter(Objects::nonNull)
-                .filter(assigned -> templates.stream().anyMatch(template -> assigned.matches(template.getLabelSet())))
+                .filter(assigned -> isSameLabel(label, assigned))
                 .count();
     }
 
@@ -350,9 +386,15 @@ public class MinimumInstanceChecker {
     }
 
     /**
-     * Tops up the hot spares for every label rule of a cloud. Runs inside
+     * Tops up the hot spares of a cloud, one label at a time. Runs inside
      * {@link #checkForMinimumInstances()} rather than from a monitor of its own so all provisioning
      * decisions stay behind the same lock (JENKINS-76171).
+     *
+     * <p>A rule sets the policy; the label a job asked for is what scales. A rule covering
+     * {@code x86_64_medium || arm64_medium} says how both should behave, but each keeps a target of
+     * its own, so a run of x86 builds warms x86 hardware and leaves the arm64 pool cold. Only the
+     * count an admin asked to be held at all times belongs to the rule as a whole, and it is held
+     * by the label the rule names.
      *
      * <p>A rule owns the spare count for its label, so a template's
      * {@link SlaveTemplate#getMinimumNumberOfSpareInstances()} no longer applies to the templates
@@ -370,11 +412,11 @@ public class MinimumInstanceChecker {
      * should be.
      */
     private static void checkForLabelHotSpares(@NonNull EC2Cloud cloud) {
-        for (HotSpareConfigByLabel config : cloud.getHotSpareConfigsByLabel()) {
-            String labelName = config.getLabel();
-            if (labelName == null) {
-                continue;
-            }
+        Map<String, HotSpareConfigByLabel> tracked = trackedLabels(cloud);
+        Set<String> namedByRules = new LinkedHashSet<>();
+        for (Map.Entry<String, HotSpareConfigByLabel> entry : tracked.entrySet()) {
+            String labelName = entry.getKey();
+            HotSpareConfigByLabel config = entry.getValue();
             Label label = Label.get(labelName);
             if (label == null) {
                 continue;
@@ -386,11 +428,18 @@ public class MinimumInstanceChecker {
 
             int currentSpares = countCurrentNumberOfSpareAgentsForLabel(cloud, label);
             int currentProvisioning = countCurrentNumberOfProvisioningAgentsForLabel(cloud, label);
-            int busyAgents = countCurrentNumberOfBusyAgentsForLabel(cloud, label);
-            int queuedBuilds = countQueueItemsForLabel(cloud, label);
+            int busyAgents = countAgentsRunningWorkFor(cloud, label);
+            int queuedBuilds = countQueueItemsRequesting(label);
+            // The rule's floor is held by the label the rule names, so the labels it covers scale
+            // from nothing rather than each claiming a floor of their own.
+            boolean namedByRule = labelName.equals(config.getLabel());
+            int base = namedByRule ? config.getBaseHotSpares() : 0;
+            if (namedByRule) {
+                namedByRules.add(labelName);
+            }
 
             int target = HotSpareDemand.of(cloud, labelName)
-                    .updateTarget(config, currentSpares, currentProvisioning, queuedBuilds, busyAgents);
+                    .updateTarget(config, base, currentSpares, currentProvisioning, queuedBuilds, busyAgents);
             int toLaunch = target - (currentSpares + currentProvisioning);
 
             LOGGER.log(
@@ -404,6 +453,84 @@ public class MinimumInstanceChecker {
                 provisionAcrossLabelGroup(cloud, label, matching, toLaunch);
             }
         }
+        HotSpareDemand.forgetZeroed(cloud, namedByRules);
+    }
+
+    /**
+     * The labels of a cloud that have a hot spare target this pass, each with the rule that governs
+     * it. A label is tracked because a rule names it, because work is waiting for it, because work
+     * is running on it, or because it still holds a target from earlier and has to fade rather than
+     * drop.
+     *
+     * <p>A label a rule only covers is governed by the first rule in configuration order that
+     * covers a template able to serve it, which is the same order the rest of the plugin resolves a
+     * label's settings in.
+     *
+     * <p>Insertion ordered so a pass is reproducible, with the labels the rules name first: those
+     * carry the floors, and holding them first means the labels underneath find them already warm.
+     */
+    private static Map<String, HotSpareConfigByLabel> trackedLabels(@NonNull EC2Cloud cloud) {
+        Map<String, HotSpareConfigByLabel> tracked = new LinkedHashMap<>();
+        for (HotSpareConfigByLabel config : cloud.getHotSpareConfigsByLabel()) {
+            String labelName = config.getLabel();
+            if (labelName != null && !labelName.isBlank()) {
+                tracked.putIfAbsent(labelName, config);
+            }
+        }
+        Stream.of(
+                        HotSpareDemand.trackedLabels(cloud).stream(),
+                        Queue.getInstance().getBuildableItems().stream()
+                                .map(Queue.Item::getAssignedLabel)
+                                .filter(Objects::nonNull)
+                                .map(Label::getName),
+                        labelsOfRunningWork(cloud))
+                .flatMap(labels -> labels)
+                .distinct()
+                .filter(labelName -> !tracked.containsKey(labelName))
+                .forEach(labelName -> {
+                    Label label = Label.get(labelName);
+                    HotSpareConfigByLabel governing = label == null ? null : cloud.getHotSpareConfigForLabel(label);
+                    if (governing != null) {
+                        tracked.put(labelName, governing);
+                    }
+                });
+        return tracked;
+    }
+
+    /**
+     * @return the labels the builds running on this cloud's agents asked for. Work already running
+     *     is part of how busy a label is, so its label keeps a prediction alive even once the queue
+     *     has drained.
+     */
+    private static Stream<String> labelsOfRunningWork(@NonNull EC2Cloud cloud) {
+        return agentsOf(cloud)
+                .flatMap(computer -> computer.getExecutors().stream())
+                .map(MinimumInstanceChecker::assignedLabelOf)
+                .filter(Objects::nonNull)
+                .map(Label::getName);
+    }
+
+    /**
+     * @return the label the work on an executor asked for, or {@code null} if the executor is free
+     *     or its work carries no label. Work with no label of its own raises no target: it could
+     *     have run anywhere, so it says nothing about which hardware to keep warm.
+     */
+    @CheckForNull
+    private static Label assignedLabelOf(@NonNull Executor executor) {
+        WorkUnit workUnit = executor.getCurrentWorkUnit();
+        return workUnit == null || workUnit.work == null ? null : workUnit.work.getAssignedLabel();
+    }
+
+    private static boolean isAssignedTo(@NonNull Executor executor, @NonNull Label label) {
+        return isSameLabel(label, assignedLabelOf(executor));
+    }
+
+    /**
+     * Labels are compared by name because that is what a target is keyed by, so an expression is
+     * the same demand however it reached the checker.
+     */
+    private static boolean isSameLabel(@NonNull Label label, @CheckForNull Label other) {
+        return other != null && label.getName().equals(other.getName());
     }
 
     /**

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/config-entries.jelly
@@ -46,6 +46,9 @@ THE SOFTWARE.
     <f:entry title="${%No delay provisioning}" field="noDelayProvisioning">
       <f:checkbox/>
     </f:entry>
+    <f:entry title="${%Round-robin templates matching the same label}" field="roundRobinTemplatesByLabel">
+      <f:checkbox/>
+    </f:entry>
     <f:entry title="${%Arn Role}" field="roleArn">
       <f:textbox />
     </f:entry>

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/config-entries.jelly
@@ -49,6 +49,9 @@ THE SOFTWARE.
     <f:entry title="${%Round-robin templates matching the same label}" field="roundRobinTemplatesByLabel">
       <f:checkbox/>
     </f:entry>
+    <f:entry title="${%Saturate the highest weight before using a lower one}" field="saturateHighestWeightFirst">
+      <f:checkbox/>
+    </f:entry>
     <f:entry title="${%Arn Role}" field="roleArn">
       <f:textbox />
     </f:entry>

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/config.jelly
@@ -25,6 +25,17 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:include class="${descriptor.clazz}" page="config-entries.jelly" />
 
+  <f:entry title="${%Hot spares by label}" description="${%Idle agents to keep warm for a label, across every AMI that carries it}"
+           help="/descriptor/hudson.plugins.ec2.EC2Cloud/help/hotSpareConfigsByLabel">
+    <f:repeatableProperty field="hotSpareConfigsByLabel" add="${%Add hot spare rule}">
+      <f:block>
+        <div align="right">
+          <f:repeatableDeleteButton />
+        </div>
+      </f:block>
+    </f:repeatableProperty>
+  </f:entry>
+
   <f:entry title="${%AMIs}" description="${%List of AMIs to be launched as agents}">
     <f:repeatable field="templates">
       <st:include page="config.jelly" class="${descriptor.clazz}" />

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-hotSpareConfigsByLabel.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-hotSpareConfigsByLabel.html
@@ -8,6 +8,21 @@
     uses &mdash; so with <i>Round-robin templates matching the same label</i> enabled, their <i>Hot
     spare weight</i> applies here too.</p>
 
+    <p>A rule's label may be an expression, in which case the rule sets the policy for every label
+    it covers while each of them is kept warm on its own account. A rule for
+    <code>x86_64 || arm64</code> says how both should behave, but a run of builds asking for
+    <code>x86_64</code> warms x86 hardware only: the arm64 instances could never have taken that
+    work. The label a job asks for is the unit throughout &mdash; the builds queued for it, the
+    builds running on its agents, and the spares it takes are all counted against that label, and a
+    job asking for <code>x86_64 &amp;&amp; gpu</code> is a third thing again, warmed on the AMIs
+    carrying both.</p>
+
+    <p>Scaling apart is not the same as having separate machines. An idle agent counts as a spare
+    for every label it could serve, so where one AMI carries several labels they draw on the same
+    warm agents rather than each paying for a set. The base number of spares belongs to the rule as
+    a whole rather than to each label it covers, so a rule over four labels with a base of two holds
+    two agents and not eight.</p>
+
     <p>The number of spares is a prediction rather than a fixed setting, and it is revisited as soon
     as a build is queued for the label or takes an executor on one of its agents, rather than on a
     timer. A build queued for a label with nothing warm has its spares requested immediately, and
@@ -19,7 +34,8 @@
     the instant they appear, the target is given one step of cover above that load. It shrinks by
     the step once per idle termination time, towards the work still in sight while the label is
     busy and to the base count once nothing is asking for the label, so a label with a base count of
-    zero scales to nothing when Jenkins is idle and warms itself back up as work arrives.</p>
+    zero scales to nothing when Jenkins is idle and warms itself back up as work arrives. A label a
+    rule covers without naming fades all the way to nothing, since the base count is the rule's.</p>
 
     <p>The prediction, not the idle termination time, is what decides how many agents a label keeps:
     an agent is reclaimed only once the number of spares has faded past it. A pool that is holding

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-hotSpareConfigsByLabel.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-hotSpareConfigsByLabel.html
@@ -1,0 +1,42 @@
+<div>
+    <p>Keeps a number of idle agents warm per Jenkins label instead of per AMI, so a label that is
+    served by several AMIs is treated as one pool of interchangeable hardware.</p>
+
+    <p>Each rule names a label, a base number of spares to hold at all times, and the step by which
+    the number of spares grows and shrinks, with an optional ceiling. The counts cover every AMI
+    that carries the label, and the spares are spread over those AMIs in the same order provisioning
+    uses &mdash; so with <i>Round-robin templates matching the same label</i> enabled, their <i>Hot
+    spare weight</i> applies here too.</p>
+
+    <p>The number of spares is a prediction rather than a fixed setting, and it is revisited as soon
+    as a build is queued for the label or takes an executor on one of its agents, rather than on a
+    timer. A build queued for a label with nothing warm has its spares requested immediately, and
+    starts on whichever of them comes up first. A spare taken by a build is replaced as its executor
+    is taken, so the next spare is booting while that build runs and the label stays warm for the
+    whole of a busy period instead of draining. Beyond the first step, the
+    number follows the work in sight: the builds queued for the label plus the agents running one, so
+    a build fanning out to 20 branches warms 20 spares at once. If the spares are still being taken
+    the instant they appear, the target is given one step of cover above that load. It shrinks by
+    the step once per idle termination time, towards the work still in sight while the label is
+    busy and to the base count once nothing is asking for the label, so a label with a base count of
+    zero scales to nothing when Jenkins is idle and warms itself back up as work arrives.</p>
+
+    <p>The prediction, not the idle termination time, is what decides how many agents a label keeps:
+    an agent is reclaimed only once the number of spares has faded past it. A pool that is holding
+    exactly what the prediction asks for is left alone, rather than being recycled by the idle
+    timeout and immediately provisioned again.</p>
+
+    <p>A rule takes over the spare count of the AMIs it matches: their <i>Minimum number of spare
+    instances</i> is ignored while it does. <i>Minimum number of instances</i> is unaffected and
+    still provisions its floor per AMI. Each AMI's <i>Instance Cap</i> and the cloud-wide cap remain
+    hard limits that a rule can only stay under.</p>
+
+    <p>An AMI configured with <i>Only apply minimum number of instances during specific time
+    range</i> holds spares only inside that range, and releases the ones it is holding at their idle
+    termination time when the range closes. The label keeps its spares on whichever of its AMIs is
+    on duty, so one AMI per shift adds up to a single pool that follows the schedule.</p>
+
+    <p>A rule can also own the idle termination time and grace period of the agents for its label,
+    so a label behaves consistently across instance types; see the settings under <i>Advanced</i> on
+    each rule.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-roundRobinTemplatesByLabel.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-roundRobinTemplatesByLabel.html
@@ -1,0 +1,20 @@
+<div>
+    <p>Controls how a template is picked when several AMI configurations in this cloud match the
+    same label.</p>
+
+    <p>Unticked (the default), the templates are tried in the order they are configured, which is
+    the historical behaviour. If the first one cannot provision, the next one is tried for that
+    request, but the next request starts from the first template again.</p>
+
+    <p>Ticked, all templates matching a label are treated as interchangeable hardware &mdash; the
+    admin gave them the same label, so any of them can run that work &mdash; and Jenkins rotates
+    between them. The rotation honours each template's <i>Hot spare weight</i>, so a spot template
+    with weight 3 is attempted three times as often as an equivalent on-demand template with
+    weight 1, while still falling back to on-demand immediately when spot capacity is
+    unavailable.</p>
+
+    <p>With rotation enabled, a template that reports insufficient capacity is also demoted for a
+    few minutes so subsequent requests for that label go straight to a template that can supply
+    the instance type. This demotion never applies to a label served by a single template, which
+    keeps retrying across its own availability zones.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-roundRobinTemplatesByLabel.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-roundRobinTemplatesByLabel.html
@@ -17,4 +17,8 @@
     few minutes so subsequent requests for that label go straight to a template that can supply
     the instance type. This demotion never applies to a label served by a single template, which
     keeps retrying across its own availability zones.</p>
+
+    <p>Weights are shares of the requests, so every weight keeps receiving some of the work. If
+    they should instead rank the templates, so that a lower weight is only used once the higher
+    one is exhausted, see <i>Saturate the highest weight before using a lower one</i>.</p>
 </div>

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-saturateHighestWeightFirst.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-saturateHighestWeightFirst.html
@@ -1,4 +1,9 @@
 <div>
+    <p><b>When to enable this option?</b> When the templates of a cloud are weighted by cost, with
+    the least expensive option carrying the highest weight. The highest weight is always
+    prioritized, so the least expensive provisioning is always prioritized, and a more expensive
+    template is only reached once the cheaper ones cannot supply an instance.</p>
+
     <p>Changes what a template's <i>Hot spare weight</i> means when several AMI configurations in
     this cloud match the same label. Requires <i>Round-robin templates matching the same label</i>
     to be enabled; without it, templates are tried in configured order and weights are ignored.</p>

--- a/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-saturateHighestWeightFirst.html
+++ b/src/main/resources/hudson/plugins/ec2/EC2Cloud/help-saturateHighestWeightFirst.html
@@ -1,0 +1,30 @@
+<div>
+    <p>Changes what a template's <i>Hot spare weight</i> means when several AMI configurations in
+    this cloud match the same label. Requires <i>Round-robin templates matching the same label</i>
+    to be enabled; without it, templates are tried in configured order and weights are ignored.</p>
+
+    <p><b>Unticked (the default) &mdash; weighted capacity.</b> A weight is a share of the
+    provisioning requests, distributed by smooth weighted round-robin, the algorithm nginx uses to
+    balance load across servers. A spot template with weight 3 against an on-demand template with
+    weight 1 leads three requests out of four, and the on-demand template leads the fourth, evenly
+    spaced rather than in bursts. Every weight keeps receiving a share of the work whether or not
+    the heavier template has capacity, so the label runs on a deliberate mix of instance types.</p>
+
+    <p><b>Ticked &mdash; saturate the highest weight first.</b> A weight becomes a rank. Templates
+    sharing a weight form a band, and every request is offered to the highest band first; a lower
+    band is only used once every template above it is at its instance cap or has been demoted for
+    reporting insufficient capacity. Templates within a band still take turns leading, so a band
+    spreads across the instance types and availability zones it contains instead of concentrating
+    on one. Falling back costs nothing extra: the next band is tried inside the same provisioning
+    request, and the demotion lasts a few minutes so following requests go straight to a template
+    that can supply an instance.</p>
+
+    <p>Tick this when the weights express cost or preference rather than a mix &mdash; for example
+    spot templates above their on-demand equivalents, so a label only pays the on-demand price once
+    spot capacity is genuinely exhausted. Give equally-preferred templates the same weight to keep
+    spreading over them. Leave it unticked when you want a predictable proportion of each instance
+    type regardless of availability.</p>
+
+    <p>In both cases a weight of 0 keeps its meaning: the template is a last resort, used only when
+    every other template matching the label is in a capacity cooldown.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/config.jelly
@@ -1,0 +1,40 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Label}" field="label">
+    <f:textbox autoCompleteDelimChar=" " />
+  </f:entry>
+
+  <f:entry title="${%Base hot spares}" field="baseHotSpares">
+    <f:textbox default="0" />
+  </f:entry>
+
+  <f:entry title="${%Hot spare step}" field="scalingFactor">
+    <f:textbox default="5" />
+  </f:entry>
+
+  <f:entry title="${%Maximum hot spares}" field="maxHotSpares">
+    <f:textbox />
+  </f:entry>
+
+  <f:advanced>
+    <f:entry title="${%Idle termination time (minutes)}" field="idleTimeoutMinutes">
+      <f:textbox default="15" />
+    </f:entry>
+
+    <f:entry title="${%Let a template override the idle termination time}" field="allowTemplateIdleTimeoutOverride">
+      <f:checkbox />
+    </f:entry>
+
+    <f:entry title="${%Provisioning grace period (minutes)}" field="gracePeriodMinutes">
+      <f:textbox default="0" />
+    </f:entry>
+
+    <f:entry title="${%Discard agents that never come online}" field="discardAfterGracePeriod">
+      <f:checkbox default="true" />
+    </f:entry>
+
+    <f:entry title="${%Let a template override the grace period}" field="allowTemplateGracePeriodOverride">
+      <f:checkbox />
+    </f:entry>
+  </f:advanced>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-allowTemplateGracePeriodOverride.html
+++ b/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-allowTemplateGracePeriodOverride.html
@@ -1,0 +1,8 @@
+<div>
+    <p>By default this rule owns the provisioning grace period of every AMI it matches.</p>
+
+    <p>Tick this to give precedence back to an AMI that configures a grace period of its own. An AMI
+    that leaves its grace period at 0 still follows the rule, so this only affects the AMIs where a
+    grace period was set deliberately &mdash; useful when one instance type in the group is known to
+    boot much more slowly than the rest.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-allowTemplateIdleTimeoutOverride.html
+++ b/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-allowTemplateIdleTimeoutOverride.html
@@ -1,0 +1,8 @@
+<div>
+    <p>By default this rule owns the idle termination time of every AMI it matches, so a label
+    behaves the same no matter which instance type served it.</p>
+
+    <p>Tick this to give precedence back to an AMI that sets its own <i>Idle termination time</i>.
+    An AMI that leaves that field blank still follows the rule, so this only affects the AMIs where
+    the value was set deliberately.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-baseHotSpares.html
+++ b/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-baseHotSpares.html
@@ -1,0 +1,13 @@
+<div>
+    <p>How many idle agents to keep for this label at all times, including while nothing is queued.
+    This is what makes them <i>hot</i> spares: they are paid for while idle so that the next build
+    for the label starts without waiting for an instance to boot.</p>
+
+    <p>It is also the floor the spare target decays to once the label goes quiet, so it is the
+    standing cost of the label.</p>
+
+    <p>0 lets the label scale all the way to nothing when it is idle. The first build after a quiet
+    period still has to wait for an instance, but queueing it asks for a whole <i>Hot spare step</i>
+    of agents there and then, so it starts on whichever of them comes up first and the builds behind
+    it find the rest already waiting.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-discardAfterGracePeriod.html
+++ b/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-discardAfterGracePeriod.html
@@ -1,0 +1,12 @@
+<div>
+    <p>What to do with an agent of this label that is still offline when the grace period expires.</p>
+
+    <p>When checked (the default), the instance is terminated straight away and the reason is logged
+    distinctly from a launch timeout. When unchecked, the instance is kept and the idle termination
+    clock starts from the grace deadline, so a slow but still expected agent gets its full idle
+    window before being reclaimed.</p>
+
+    <p>This follows whichever grace period applies: if a template overrides the rule's grace period,
+    the template's discard setting is used with it. It has no effect unless a grace period is
+    configured.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-gracePeriodMinutes.html
+++ b/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-gracePeriodMinutes.html
@@ -1,0 +1,14 @@
+<div>
+    <p>Minutes an agent of this label is given to come online, counted from the moment provisioning
+    was requested rather than from the moment EC2 reported the instance as launched.</p>
+
+    <p>0 disables the grace period, which is how configurations behaved before this setting
+    existed. When the period expires with the agent still offline, <i>Discard agents that never come
+    online</i> decides whether the instance is terminated at once or kept with the idle termination
+    clock started from the grace deadline.</p>
+
+    <p>This wins over the <i>Provisioning grace period</i> of the templates the rule matches unless
+    <i>Let a template override the grace period</i> is ticked. It is also independent of the launch
+    timeout: whichever of the two expires first wins, so a grace period longer than the launch
+    timeout does not keep the instance alive past it.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-idleTimeoutMinutes.html
+++ b/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-idleTimeoutMinutes.html
@@ -1,0 +1,21 @@
+<div>
+    <p>Idle termination time for the agents of this label, in minutes, counted from the moment the
+    agent came online rather than from the moment EC2 launched the instance.</p>
+
+    <p>The value means the same as the <i>Idle termination time</i> of an AMI: 0 never stops an idle
+    agent, a positive value is a plain timeout, and a negative value times the agent out within that
+    many minutes of the end of an hourly EC2 billing period.</p>
+
+    <p>This wins over the <i>Idle termination time</i> of the templates the rule matches unless
+    <i>Let a template override the idle termination time</i> is ticked.</p>
+
+    <p>It is also the rate at which the spare target fades: once per idle termination time the
+    target gives up one <i>Hot spare step</i>, towards the work the label still has in sight while
+    it is in use, or to <i>Hot spares</i> once nothing is asking for the label at all. When idle
+    termination is off, the default of 15 minutes is used for the fade, otherwise a target raised
+    once would never come back down.</p>
+
+    <p>An agent is only reclaimed once the target has faded past it, so a spare the label is still
+    counting on outlives this timeout. Reclaiming it would pay for the same capacity twice, because
+    the next pass would immediately provision a replacement, and a build would wait for that boot.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-label.html
+++ b/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-label.html
@@ -1,0 +1,10 @@
+<div>
+    <p>The label this rule keeps spares for. Any label a job could ask for works here, including a
+    label expression such as <code>linux &amp;&amp; gpu</code>. The field completes labels as you
+    type, offering the labels the AMIs of this cloud carry as well as the labels Jenkins already
+    knows about. The rule applies to every AMI whose labels the expression matches.</p>
+
+    <p>Because the templates sharing a label are treated as interchangeable hardware, all the numbers
+    in this rule are counted across that whole group rather than per template. A template's own
+    <i>Minimum number of spare instances</i> is ignored while a rule matches it.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-maxHotSpares.html
+++ b/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-maxHotSpares.html
@@ -1,0 +1,13 @@
+<div>
+    <p>Ceiling on the spares held for this label, and therefore on how far the spare target can
+    climb while the label cannot keep up. It applies to the label group as a whole, so a maximum of
+    3 means three spares spread over every AMI carrying the label, not three per AMI.</p>
+
+    <p>Leave blank for no ceiling, in which case the target follows the label's load however large
+    that grows, limited only by the instance caps. Set it if the cost of a wide parallel build
+    warming an equally wide pool of spares is a concern.</p>
+
+    <p>This can only lower the number of spares, never raise it: each AMI's <i>Instance Cap</i> and
+    the cloud-wide cap still apply, so a template already at its cap is skipped even when this
+    maximum is higher.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-scalingFactor.html
+++ b/src/main/resources/hudson/plugins/ec2/HotSpareConfigByLabel/help-scalingFactor.html
@@ -1,0 +1,31 @@
+<div>
+    <p>The smallest pool the label holds while it is in use, and the amount of cover it is given on
+    top of its load. Jenkins does not hold a fixed number of spares for the label; it holds however
+    many the work in sight calls for, and this setting is what it starts from.</p>
+
+    <p>With a step of 5, the first build to take an executor for the label brings the target to 5
+    spares, so a label that has only just been asked for anything still warms up. After that the
+    target follows the load itself: the builds queued for the label plus the agents running one. A
+    build fanning out to 20 parallel branches takes the target to 20 straight away, because that
+    demand is already measurable &mdash; it does not climb there five at a time.</p>
+
+    <p>If the spares are still being taken the instant they appear, or builds are waiting that
+    neither the spares nor the instances already booting can take, the target is raised one step
+    above the load, and no further while the load stands still. So a label running 5 builds that
+    keeps emptying its pool settles at 10, and one running 20 settles at 25.</p>
+
+    <p>The target comes back down by the same step, once per <i>Idle termination time</i>: towards
+    the work still in sight while the label is in use, so the peak learned from a burst does not
+    outlive it, and to <i>Base hot spares</i> &mdash; zero by default &mdash; once nothing at all is
+    asking for the label, so an idle Jenkins pays for nothing. Agents are reclaimed as the target
+    passes them, which means a pool holding exactly what the target asks for is never recycled just
+    to be provisioned again.</p>
+
+    <p>A spare taken by a build is replaced the moment its executor is taken, because a busy agent
+    is not a spare: the replacement boots while that build runs, which is what keeps the label warm
+    for the build behind it. Instances already booting count towards the target, so a growing queue
+    does not provision the same shortfall repeatedly.</p>
+
+    <p><i>Maximum hot spares</i> caps how far the target can grow and is the setting to use if the
+    cost of an unexpected burst matters.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -158,6 +158,18 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
 
+    <f:entry title="${%Hot spare weight}" field="hotSpareWeight">
+      <f:textbox default="1" />
+    </f:entry>
+
+    <f:entry title="${%Provisioning grace period (minutes)}" field="gracePeriodMinutes">
+      <f:textbox default="0" />
+    </f:entry>
+
+    <f:entry title="${%Discard agents that never come online}" field="discardAfterGracePeriod">
+      <f:checkbox default="true" />
+    </f:entry>
+
     <f:optionalBlock name="minimumNumberOfInstancesTimeRangeConfig"
                      title="${%Only apply minimum number of instances during specific time range}" checked="${instance.minimumNumberOfInstancesTimeRangeConfig != null}"
         help="/descriptor/hudson.plugins.ec2.SlaveTemplate/help/minimumNumberOfInstancesTimeRangeConfig" >

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-discardAfterGracePeriod.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-discardAfterGracePeriod.html
@@ -1,0 +1,13 @@
+<div>
+    <p>What to do with an agent that is still offline when the provisioning grace period expires.</p>
+
+    <p>When checked (the default), the instance is terminated straight away and the reason is
+    logged distinctly from a launch timeout.</p>
+
+    <p>When unchecked, the instance is kept and the idle termination clock starts from the grace
+    deadline instead, so the agent is only terminated once the idle termination time has also
+    passed. Use this when agents legitimately take a long time to connect and you would rather
+    pay for the extra idle window than lose the instance.</p>
+
+    <p>This setting has no effect unless a grace period is configured.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-gracePeriodMinutes.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-gracePeriodMinutes.html
@@ -1,0 +1,16 @@
+<div>
+    <p>Minutes an agent is given to come online, counted from the moment provisioning was
+    requested rather than from the moment EC2 reported the instance as launched.</p>
+
+    <p>Leave this at 0 to disable the grace period, which is how configurations behaved before
+    this setting existed.</p>
+
+    <p>When the grace period expires and the agent still has not connected, the outcome depends
+    on <i>Discard agents that never come online</i>: either the instance is terminated
+    immediately, or the idle termination clock starts running from the grace deadline so that a
+    slow but still expected agent gets its full idle window.</p>
+
+    <p>This timer is independent of the launch timeout, and whichever of the two expires first
+    wins. Setting a grace period longer than the launch timeout will not extend the launch
+    timeout: the instance is terminated as soon as the launch timeout expires.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-hotSpareWeight.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-hotSpareWeight.html
@@ -1,0 +1,18 @@
+<div>
+    <p>Relative weight used when several templates in this cloud match the same label. Requires
+    <i>Round-robin templates matching the same label</i> to be enabled on the cloud; without it,
+    templates are tried in configured order and this weight is ignored.</p>
+
+    <p>When rotation is enabled, Jenkins treats all templates matching a label as interchangeable
+    hardware and rotates between them so an instance for that label provisions as fast as
+    possible. A template with a higher weight is chosen proportionally more often &mdash; for
+    example, weight 3 on a spot template and weight 1 on an equivalent on-demand template attempts
+    spot three times as often, while still falling back to on-demand immediately if spot capacity
+    is unavailable.</p>
+
+    <p>The default of 1 gives plain round-robin. A weight of 0 excludes the template from normal
+    rotation; it is only used when every other template in the group is in a capacity cooldown.</p>
+
+    <p>This setting affects provisioning from hot spares by label as well as ordinary label-driven
+    provisioning.</p>
+</div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-hotSpareWeight.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-hotSpareWeight.html
@@ -10,6 +10,11 @@
     spot three times as often, while still falling back to on-demand immediately if spot capacity
     is unavailable.</p>
 
+    <p>If the cloud has <i>Saturate the highest weight before using a lower one</i> enabled, the
+    weight is a rank instead of a share: the same example attempts spot for every request, and the
+    on-demand template is only used once spot is at its instance cap or has been demoted for
+    reporting insufficient capacity. Templates sharing a weight still take turns.</p>
+
     <p>The default of 1 gives plain round-robin. A weight of 0 excludes the template from normal
     rotation; it is only used when every other template in the group is in a capacity cooldown.</p>
 

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-minimumNumberOfInstancesTimeRangeConfig.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-minimumNumberOfInstancesTimeRangeConfig.html
@@ -2,4 +2,9 @@
     Choose the timespan and on which days a minimum number of instances should be kept alive. If the To-time is before the From-time, the time range will wrap around to the next day.
 
     E.g. From 23:00 to 06:00 with Monday selected would mean that the instance(s) would be kept up from 23:00 on Monday evening until 06:00 Tuesday morning.
+
+    <p>A cloud-level <i>Hot spares by label</i> rule obeys this too: outside the time range this AMI
+    holds no hot spares, and any it is holding are released at their idle termination time. A label
+    served by several AMIs keeps its spares on whichever of them is inside its own time range, so a
+    label can be covered by one AMI per shift.</p>
 </div>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-minimumNumberOfSpareInstances.html
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-minimumNumberOfSpareInstances.html
@@ -13,4 +13,9 @@
     have a high rate of incoming builds this value can be set higher.</p>
 
    <p>Note that value is local to this specific AMI and associated configurations.</p>
+
+   <p>This setting is ignored while a cloud-level <i>Hot spares by label</i> rule matches one of the
+    labels of this AMI, because such a rule owns the spare count for its whole label group. The
+    minimum number of instances above is unaffected, and so is its time range: a rule holds no
+    spares on this AMI outside the hours it is configured to keep instances in.</p>
 </div>

--- a/src/test/java/hudson/plugins/ec2/ConfigurationAsCodeTest.java
+++ b/src/test/java/hudson/plugins/ec2/ConfigurationAsCodeTest.java
@@ -249,6 +249,58 @@ class ConfigurationAsCodeTest {
     }
 
     @Test
+    @ConfiguredWithCode("Unix-withHotSparesByLabel.yml")
+    void testConfigAsCodeWithHotSparesByLabel(JenkinsConfiguredWithCodeRule j) {
+        final EC2Cloud ec2Cloud = (EC2Cloud) Jenkins.get().getCloud("hotSpares");
+        assertNotNull(ec2Cloud);
+        assertTrue(ec2Cloud.isRoundRobinTemplatesByLabel());
+
+        final List<HotSpareConfigByLabel> rules = ec2Cloud.getHotSpareConfigsByLabel();
+        assertEquals(1, rules.size());
+        final HotSpareConfigByLabel rule = rules.get(0);
+        assertEquals("linux", rule.getLabel());
+        assertEquals(2, rule.getBaseHotSpares());
+        assertEquals(3, rule.getScalingFactor());
+        assertEquals(Integer.valueOf(6), rule.getMaxHotSpares());
+        assertEquals(20, rule.getIdleTimeoutMinutes());
+        assertEquals(7, rule.getGracePeriodMinutes());
+        assertFalse(rule.isDiscardAfterGracePeriod());
+        assertTrue(rule.isAllowTemplateIdleTimeoutOverride());
+        assertTrue(rule.isAllowTemplateGracePeriodOverride());
+
+        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        assertEquals(2, templates.size());
+
+        final SlaveTemplate spot = templates.get(0);
+        assertEquals(3, spot.getHotSpareWeight());
+        assertEquals(4, spot.getGracePeriodMinutes());
+        assertFalse(spot.isDiscardAfterGracePeriod());
+
+        final SlaveTemplate onDemand = templates.get(1);
+        assertEquals(1, onDemand.getHotSpareWeight());
+        assertEquals(0, onDemand.getGracePeriodMinutes());
+        assertTrue(onDemand.isDiscardAfterGracePeriod());
+    }
+
+    /**
+     * A configuration written before these settings existed must keep working, with the defaults
+     * that preserve the old behaviour.
+     */
+    @Test
+    @ConfiguredWithCode("Unix.yml")
+    void testConfigAsCodeWithoutHotSparesByLabel(JenkinsConfiguredWithCodeRule j) {
+        final EC2Cloud ec2Cloud = (EC2Cloud) Jenkins.get().getCloud("staging");
+        assertNotNull(ec2Cloud);
+        assertFalse(ec2Cloud.isRoundRobinTemplatesByLabel());
+        assertTrue(ec2Cloud.getHotSpareConfigsByLabel().isEmpty());
+
+        final SlaveTemplate slaveTemplate = ec2Cloud.getTemplates().get(0);
+        assertEquals(1, slaveTemplate.getHotSpareWeight());
+        assertEquals(0, slaveTemplate.getGracePeriodMinutes());
+        assertTrue(slaveTemplate.isDiscardAfterGracePeriod());
+    }
+
+    @Test
     @ConfiguredWithCode("Ami.yml")
     void testAmi(JenkinsConfiguredWithCodeRule j) {
         final EC2Cloud ec2Cloud = (EC2Cloud) Jenkins.get().getCloud("test");

--- a/src/test/java/hudson/plugins/ec2/ConfigurationAsCodeTest.java
+++ b/src/test/java/hudson/plugins/ec2/ConfigurationAsCodeTest.java
@@ -254,6 +254,7 @@ class ConfigurationAsCodeTest {
         final EC2Cloud ec2Cloud = (EC2Cloud) Jenkins.get().getCloud("hotSpares");
         assertNotNull(ec2Cloud);
         assertTrue(ec2Cloud.isRoundRobinTemplatesByLabel());
+        assertTrue(ec2Cloud.isSaturateHighestWeightFirst());
 
         final List<HotSpareConfigByLabel> rules = ec2Cloud.getHotSpareConfigsByLabel();
         assertEquals(1, rules.size());
@@ -292,6 +293,7 @@ class ConfigurationAsCodeTest {
         final EC2Cloud ec2Cloud = (EC2Cloud) Jenkins.get().getCloud("staging");
         assertNotNull(ec2Cloud);
         assertFalse(ec2Cloud.isRoundRobinTemplatesByLabel());
+        assertFalse(ec2Cloud.isSaturateHighestWeightFirst());
         assertTrue(ec2Cloud.getHotSpareConfigsByLabel().isEmpty());
 
         final SlaveTemplate slaveTemplate = ec2Cloud.getTemplates().get(0);

--- a/src/test/java/hudson/plugins/ec2/EC2CloudBatchProvisionTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudBatchProvisionTest.java
@@ -1,0 +1,563 @@
+package hudson.plugins.ec2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.plugins.ec2.util.AmazonEC2FactoryMockImpl;
+import hudson.plugins.ec2.util.MinimumInstanceChecker;
+import hudson.plugins.ec2.util.SSHCredentialHelper;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.mockito.Mockito;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.ec2.model.Ec2Exception;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
+import software.amazon.awssdk.services.ec2.model.RunInstancesRequest;
+
+/**
+ * A request for several agents has to launch several instances, whichever market it is served from.
+ *
+ * <p>Every launch the plugin makes is a {@code RunInstances} call carrying the number asked for, a
+ * spot template bidding the on-demand price included, so a request for twenty is one call for
+ * twenty instances rather than twenty requests for one. An instance type in one subnet is also a
+ * single capacity pool that EC2 fills as far as it can rather than refusing what it cannot cover,
+ * so what one pool comes up short on has to be asked of the pools behind it while the request is
+ * still in hand.
+ *
+ * <p>Both of those are the difference between a wide build finding its capacity at once and
+ * trickling in a pool's worth per provisioning pass, which for a label whose cheapest hardware is
+ * spot means a fan-out is served by its more expensive templates, or waits minutes for capacity
+ * that was asked for all at once.
+ */
+@WithJenkins
+class EC2CloudBatchProvisionTest {
+
+    private static final String LABEL = "linux";
+
+    private JenkinsRule r;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        r = rule;
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        AmazonEC2FactoryMockImpl.mock = AmazonEC2FactoryMockImpl.createAmazonEC2Mock();
+        HotSpareDemand.reset();
+    }
+
+    /**
+     * Bidding the on-demand price is the spot configuration with no bid price of its own, and the
+     * one the plugin serves through {@code RunInstances}.
+     */
+    @Test
+    void testASpotTemplateBiddingTheOndemandPriceLaunchesEveryInstanceRequested() throws Exception {
+        EC2Cloud cloud = cloud(template("spot", 20, spotBiddingTheOndemandPrice()));
+
+        cloud.provision(cloud.getTemplates().get(0), 5);
+
+        awaitInstanceCount(5);
+        assertThat(instanceCount(), equalTo(5));
+    }
+
+    /**
+     * The same through a label request rather than a direct one, since that is the path Jenkins
+     * itself provisions on.
+     */
+    @Test
+    void testALabelRequestForSeveralAgentsFillsTheSpotTemplate() throws Exception {
+        EC2Cloud cloud = cloud(template("spot", 20, spotBiddingTheOndemandPrice()));
+
+        cloud.provision(Label.get(LABEL), 5);
+
+        awaitInstanceCount(5);
+        assertThat(instanceCount(), equalTo(5));
+    }
+
+    /**
+     * The reported case: a label whose hot spares are held on spot hardware has to reach its
+     * target in one pass. Trickling one instance per pass leaves a twenty-branch build waiting
+     * minutes for capacity that was asked for all at once.
+     */
+    @Test
+    void testHotSparesOnASpotTemplateReachTheirTargetInOnePass() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setBaseHotSpares(20);
+        rule.setScalingFactor(5);
+        EC2Cloud cloud = cloud(rule, template("spot", 30, spotBiddingTheOndemandPrice()));
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        awaitInstanceCount(20);
+        assertThat(HotSpareDemand.of(cloud, LABEL).getTarget(), equalTo(20));
+        assertThat(agentsByTemplate(), equalTo(Map.of("spot", 20L)));
+    }
+
+    /**
+     * A cheaper spot template leading the label must take the whole request, or the templates
+     * behind it pick up work the admin ranked as more expensive.
+     */
+    @Test
+    void testTheLeadingSpotTemplateTakesTheWholeRequestBeforeTheDearerOne() throws Exception {
+        SlaveTemplate spot = template("spot", 30, spotBiddingTheOndemandPrice());
+        spot.setHotSpareWeight(10);
+        SlaveTemplate demand = template("demand", 30, null);
+        demand.setHotSpareWeight(1);
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setBaseHotSpares(20);
+        rankedCloud(rule, spot, demand);
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        awaitInstanceCount(20);
+        assertThat(agentsByTemplate(), equalTo(Map.of("spot", 20L)));
+    }
+
+    /**
+     * A template is one spot pool, and EC2 fills a request with however much of it that pool has
+     * rather than refusing what it cannot cover in full. The rest of the request has to come from
+     * the pools behind it in the same pass, or a wide build is served a pool at a time.
+     */
+    @Test
+    void testARequestIsSatisfiedAcrossSeveralSpotPools() throws Exception {
+        // Three pools of the same label, each able to supply part of a request for twelve.
+        SlaveTemplate first = template("first", 30, spotBiddingTheOndemandPrice(), InstanceType.M1_LARGE);
+        SlaveTemplate second = template("second", 30, spotBiddingTheOndemandPrice(), InstanceType.M1_XLARGE);
+        SlaveTemplate third = template("third", 30, spotBiddingTheOndemandPrice(), InstanceType.M2_XLARGE);
+        limitRunInstancesFor(InstanceType.M1_LARGE, 3);
+        limitRunInstancesFor(InstanceType.M1_XLARGE, 4);
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setBaseHotSpares(12);
+        EC2Cloud cloud = cloud(rule, first, second, third);
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        awaitInstanceCount(12);
+        assertThat(
+                "the pools that could only part-fill the request handed the rest on",
+                instanceTypeCounts(),
+                equalTo(Map.of(
+                        InstanceType.M1_LARGE.toString(),
+                        3L,
+                        InstanceType.M1_XLARGE.toString(),
+                        4L,
+                        InstanceType.M2_XLARGE.toString(),
+                        5L)));
+        assertThat(HotSpareDemand.of(cloud, LABEL).getTarget(), equalTo(12));
+    }
+
+    /**
+     * A pool with no capacity at all is the other half of that, and it also has to be demoted, so
+     * the next pass leads with a pool that can deliver rather than asking the empty one first.
+     */
+    @Test
+    void testAPoolOutOfCapacityHandsTheWholeRequestOnAndIsCooledDown() throws Exception {
+        failRunInstancesFor(InstanceType.M1_LARGE);
+        SlaveTemplate empty = template("empty", 30, spotBiddingTheOndemandPrice(), InstanceType.M1_LARGE);
+        empty.setHotSpareWeight(10);
+        SlaveTemplate available = template("available", 30, spotBiddingTheOndemandPrice(), InstanceType.M1_XLARGE);
+        available.setHotSpareWeight(1);
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setBaseHotSpares(6);
+        EC2Cloud cloud = rankedCloud(rule, empty, available);
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        awaitInstanceCount(6);
+        assertThat(agentsByTemplate(), equalTo(Map.of("available", 6L)));
+        assertThat(
+                "a pool that reported no capacity should be demoted for the next pass",
+                cloud.getRotation().isTemplateInCooldown(empty, 2),
+                equalTo(true));
+    }
+
+    /**
+     * On-demand launches take the count through a different branch of the same method, so the
+     * plainest case is worth stating on its own: nothing along the way may substitute a count of
+     * its own for the one the caller asked for.
+     */
+    @Test
+    void testAnOndemandTemplateLaunchesEveryInstanceRequested() throws Exception {
+        EC2Cloud cloud = cloud(template("demand", 20, null));
+
+        cloud.provision(cloud.getTemplates().get(0), 5);
+
+        awaitInstanceCount(5);
+        assertThat(instanceCount(), equalTo(5));
+    }
+
+    /**
+     * On-demand capacity is per instance type and subnet as well, so a request that one template
+     * can only part-fill has to be finished off by the templates behind it here too.
+     */
+    @Test
+    void testAnOndemandRequestIsSatisfiedAcrossSeveralTemplates() throws Exception {
+        SlaveTemplate first = template("first", 30, null, InstanceType.M1_LARGE);
+        SlaveTemplate second = template("second", 30, null, InstanceType.M1_XLARGE);
+        SlaveTemplate third = template("third", 30, null, InstanceType.M2_XLARGE);
+        limitRunInstancesFor(InstanceType.M1_LARGE, 3);
+        limitRunInstancesFor(InstanceType.M1_XLARGE, 4);
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setBaseHotSpares(12);
+        cloud(rule, first, second, third);
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        awaitInstanceCount(12);
+        assertThat(
+                instanceTypeCounts(),
+                equalTo(Map.of(
+                        InstanceType.M1_LARGE.toString(),
+                        3L,
+                        InstanceType.M1_XLARGE.toString(),
+                        4L,
+                        InstanceType.M2_XLARGE.toString(),
+                        5L)));
+    }
+
+    /**
+     * The subnet failover an on-demand launch has of its own rebuilds the request against the next
+     * subnet, which has to carry the same count: a request for five that the first subnet cannot
+     * take is five instances in the second, not one.
+     */
+    @Test
+    void testSubnetFailoverKeepsTheWholeCountOfAnOndemandRequest() throws Exception {
+        AtomicInteger refusals = refuseSubnet("subnet-exhausted");
+        EC2Cloud cloud = cloud(
+                template("two-subnets", 30, null, InstanceType.M1_LARGE, "subnet-exhausted subnet-with-capacity"));
+
+        cloud.provision(cloud.getTemplates().get(0), 5);
+
+        awaitInstanceCount(5);
+        assertThat(instanceCount(), equalTo(5));
+        assertThat(
+                "the first subnet should have been tried, so this is a failover rather than a lucky first choice",
+                refusals.get(),
+                greaterThanOrEqualTo(1));
+    }
+
+    /**
+     * A spot pool is an instance type in one availability zone, so the zones of a template are the
+     * first place to look for what a zone came up short on. A request must walk all of them before
+     * the label moves on to hardware the admin ranked as more expensive.
+     */
+    @Test
+    void testASpotRequestFallsThroughEveryAvailabilityZone() throws Exception {
+        AtomicInteger refusals = new AtomicInteger();
+        for (int zone = 1; zone <= 4; zone++) {
+            refuseSubnet("subnet-zone-" + zone, refusals);
+        }
+        EC2Cloud cloud = cloud(template(
+                "five-zones",
+                30,
+                spotBiddingTheOndemandPrice(),
+                InstanceType.M1_LARGE,
+                "subnet-zone-1 subnet-zone-2 subnet-zone-3 subnet-zone-4 subnet-zone-5"));
+
+        cloud.provision(cloud.getTemplates().get(0), 5);
+
+        awaitInstanceCount(5);
+        assertThat(instanceCount(), equalTo(5));
+        assertThat(
+                "all four exhausted zones should have been tried before the fifth served the request",
+                refusals.get(),
+                greaterThanOrEqualTo(4));
+    }
+
+    /**
+     * Zones that can each supply part of a spot request have to be added up, in the same request.
+     * Spot capacity is thin per pool by nature, so this is the usual case for a wide build rather
+     * than an unusual one.
+     */
+    @Test
+    void testASpotRequestIsSatisfiedAcrossSeveralAvailabilityZones() throws Exception {
+        limitSubnet("subnet-zone-1", 3);
+        limitSubnet("subnet-zone-2", 3);
+        limitSubnet("subnet-zone-3", 3);
+        EC2Cloud cloud = cloud(template(
+                "three-zones",
+                30,
+                spotBiddingTheOndemandPrice(),
+                InstanceType.M1_LARGE,
+                "subnet-zone-1 subnet-zone-2 subnet-zone-3"));
+
+        cloud.provision(cloud.getTemplates().get(0), 9);
+
+        awaitInstanceCount(9);
+        assertThat(instanceCount(), equalTo(9));
+    }
+
+    /**
+     * Zones first, then templates: only once every zone of the cheapest instance type is out of
+     * capacity does the label fall back to the next template, and all inside one request.
+     */
+    @Test
+    void testZonesAreExhaustedBeforeTheRequestMovesToTheNextTemplate() throws Exception {
+        AtomicInteger refusals = new AtomicInteger();
+        refuseSubnet("subnet-zone-1", refusals);
+        refuseSubnet("subnet-zone-2", refusals);
+        SlaveTemplate cheapest = template(
+                "cheapest", 30, spotBiddingTheOndemandPrice(), InstanceType.M1_LARGE, "subnet-zone-1 subnet-zone-2");
+        cheapest.setHotSpareWeight(10);
+        SlaveTemplate dearer = template("dearer", 30, spotBiddingTheOndemandPrice(), InstanceType.M1_XLARGE);
+        dearer.setHotSpareWeight(1);
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setBaseHotSpares(5);
+        EC2Cloud cloud = rankedCloud(rule, cheapest, dearer);
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        awaitInstanceCount(5);
+        assertThat(agentsByTemplate(), equalTo(Map.of("dearer", 5L)));
+        assertThat("both zones of the cheapest template should have been tried", refusals.get(), equalTo(2));
+        assertThat(
+                "a template with no capacity in any of its zones should be demoted",
+                cloud.getRotation().isTemplateInCooldown(cheapest, 2),
+                equalTo(true));
+    }
+
+    /**
+     * The zone walk is not spot-specific, so an on-demand request adds up its zones too.
+     */
+    @Test
+    void testAnOndemandRequestIsSatisfiedAcrossSeveralAvailabilityZones() throws Exception {
+        limitSubnet("subnet-zone-1", 2);
+        limitSubnet("subnet-zone-2", 2);
+        EC2Cloud cloud = cloud(
+                template("three-zones", 30, null, InstanceType.M1_LARGE, "subnet-zone-1 subnet-zone-2 subnet-zone-3"));
+
+        cloud.provision(cloud.getTemplates().get(0), 6);
+
+        awaitInstanceCount(6);
+        assertThat(instanceCount(), equalTo(6));
+    }
+
+    /**
+     * Stubs the factory so one instance type launches at most {@code limit} instances per request,
+     * which is how EC2 answers a request for more than a pool can supply.
+     */
+    private void limitRunInstancesFor(InstanceType type, int limit) {
+        Mockito.doAnswer(invocation -> {
+                    RunInstancesRequest request = invocation.getArgument(0);
+                    RunInstancesRequest capped = request.toBuilder()
+                            .maxCount(Math.min(request.maxCount(), limit))
+                            .build();
+                    return AmazonEC2FactoryMockImpl.launchInstances(capped);
+                })
+                .when(AmazonEC2FactoryMockImpl.mock)
+                .runInstances(Mockito.<RunInstancesRequest>argThat(
+                        request -> request != null && type.toString().equals(request.instanceTypeAsString())));
+    }
+
+    /** Stubs the factory so one instance type has no capacity at all. */
+    private void failRunInstancesFor(InstanceType type) {
+        Mockito.doAnswer(invocation -> {
+                    throw capacityException();
+                })
+                .when(AmazonEC2FactoryMockImpl.mock)
+                .runInstances(Mockito.<RunInstancesRequest>argThat(
+                        request -> request != null && type.toString().equals(request.instanceTypeAsString())));
+    }
+
+    /**
+     * Stubs the factory so one subnet has no capacity.
+     *
+     * @return how many launches that subnet has refused.
+     */
+    private AtomicInteger refuseSubnet(String subnetId) {
+        return refuseSubnet(subnetId, new AtomicInteger());
+    }
+
+    /** As above, counting the refusals of several subnets together. */
+    private AtomicInteger refuseSubnet(String subnetId, AtomicInteger refusals) {
+        Mockito.doAnswer(invocation -> {
+                    refusals.incrementAndGet();
+                    throw capacityException();
+                })
+                .when(AmazonEC2FactoryMockImpl.mock)
+                .runInstances(Mockito.<RunInstancesRequest>argThat(request -> inSubnet(request, subnetId)));
+        return refusals;
+    }
+
+    /** Stubs the factory so one subnet can only part-fill a request, as a thin pool does. */
+    private void limitSubnet(String subnetId, int limit) {
+        Mockito.doAnswer(invocation -> {
+                    RunInstancesRequest request = invocation.getArgument(0);
+                    return AmazonEC2FactoryMockImpl.launchInstances(request.toBuilder()
+                            .maxCount(Math.min(request.maxCount(), limit))
+                            .build());
+                })
+                .when(AmazonEC2FactoryMockImpl.mock)
+                .runInstances(Mockito.<RunInstancesRequest>argThat(request -> inSubnet(request, subnetId)));
+    }
+
+    private static boolean inSubnet(RunInstancesRequest request, String subnetId) {
+        return request != null && request.networkInterfaces().stream().anyMatch(net -> subnetId.equals(net.subnetId()));
+    }
+
+    private static Ec2Exception capacityException() {
+        return (Ec2Exception) Ec2Exception.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("InsufficientInstanceCapacity")
+                        .build())
+                .message("InsufficientInstanceCapacity")
+                .build();
+    }
+
+    private static Map<String, Long> instanceTypeCounts() {
+        return AmazonEC2FactoryMockImpl.instances.stream()
+                .collect(Collectors.groupingBy(instance -> instance.instanceTypeAsString(), Collectors.counting()));
+    }
+
+    private static SpotConfiguration spotBiddingTheOndemandPrice() {
+        SpotConfiguration spotConfig = new SpotConfiguration(false);
+        spotConfig.setSpotMaxBidPrice("");
+        spotConfig.setFallbackToOndemand(false);
+        return spotConfig;
+    }
+
+    private static int instanceCount() {
+        return AmazonEC2FactoryMockImpl.instances.size();
+    }
+
+    private Map<String, Long> agentsByTemplate() {
+        return r.jenkins.getNodes().stream()
+                .filter(EC2AbstractSlave.class::isInstance)
+                .map(EC2AbstractSlave.class::cast)
+                .collect(Collectors.groupingBy(node -> node.templateDescription, Collectors.counting()));
+    }
+
+    private static void awaitInstanceCount(int expected) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        while (System.currentTimeMillis() < deadline) {
+            if (AmazonEC2FactoryMockImpl.instances.size() >= expected) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        fail("only " + AmazonEC2FactoryMockImpl.instances.size() + " of " + expected + " instances were launched");
+    }
+
+    private EC2Cloud cloud(SlaveTemplate... templates) throws Exception {
+        return cloud(null, templates);
+    }
+
+    /**
+     * A cloud reading hot spare weights as a ranking, configured before it is added: the rotation
+     * asks the cloud whether it is enabled, and adding a cloud saves Jenkins, which runs a hot
+     * spare pass of its own before any later setting could be seen.
+     */
+    private EC2Cloud rankedCloud(HotSpareConfigByLabel rule, SlaveTemplate... templates) throws Exception {
+        return cloud(
+                rule,
+                cloud -> {
+                    cloud.setRoundRobinTemplatesByLabel(true);
+                    cloud.setSaturateHighestWeightFirst(true);
+                },
+                templates);
+    }
+
+    private EC2Cloud cloud(HotSpareConfigByLabel rule, SlaveTemplate... templates) throws Exception {
+        return cloud(rule, cloud -> {}, templates);
+    }
+
+    private EC2Cloud cloud(HotSpareConfigByLabel rule, Consumer<EC2Cloud> configure, SlaveTemplate... templates)
+            throws Exception {
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        // A mutable list: Jenkins refuses to marshal the immutable one List.of returns beyond two
+        // elements, and a cloud is saved as soon as it is added.
+        EC2Cloud cloud = new EC2Cloud(
+                "test-cloud",
+                true,
+                "abc",
+                "us-east-1",
+                null,
+                "ghi",
+                "100",
+                new ArrayList<>(List.of(templates)),
+                null,
+                null);
+        if (rule != null) {
+            cloud.setHotSpareConfigsByLabel(List.of(rule));
+        }
+        configure.accept(cloud);
+        r.jenkins.clouds.add(cloud);
+        return cloud;
+    }
+
+    private static SlaveTemplate template(String description, int instanceCap, SpotConfiguration spotConfig) {
+        return template(description, instanceCap, spotConfig, InstanceType.M1_LARGE);
+    }
+
+    private static SlaveTemplate template(
+            String description, int instanceCap, SpotConfiguration spotConfig, InstanceType type) {
+        return template(description, instanceCap, spotConfig, type, null);
+    }
+
+    private static SlaveTemplate template(
+            String description, int instanceCap, SpotConfiguration spotConfig, InstanceType type, String subnetId) {
+        SlaveTemplate template = new SlaveTemplate(
+                "ami-" + description,
+                EC2AbstractSlave.TEST_ZONE,
+                spotConfig,
+                "default",
+                "/tmp/jenkins",
+                type.toString(),
+                false,
+                LABEL,
+                Node.Mode.NORMAL,
+                description,
+                "",
+                "",
+                "",
+                "1",
+                "",
+                null,
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "",
+                false,
+                subnetId,
+                null,
+                null,
+                0,
+                0,
+                String.valueOf(instanceCap),
+                null,
+                false,
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                false,
+                ConnectionStrategy.PRIVATE_IP,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
+                EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED);
+        // The mocked describe-instances ignores filters, so a request would otherwise find the
+        // instances an earlier one launched and adopt them instead of launching.
+        template.setAvoidUsingOrphanedNodes(true);
+        return template;
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/EC2CloudConcurrentProvisionTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudConcurrentProvisionTest.java
@@ -1,0 +1,156 @@
+package hudson.plugins.ec2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.plugins.ec2.util.AmazonEC2FactoryMockImpl;
+import hudson.plugins.ec2.util.SSHCredentialHelper;
+import java.security.Security;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
+
+/**
+ * Instance caps under concurrent provisioning requests. Requests that arrive within the instance
+ * count cache window must not each be told there is room for the last instance.
+ *
+ * @see <a href="https://github.com/jenkinsci/ec2-plugin/issues/2030">ec2-plugin issue 2030</a>
+ */
+@WithJenkins
+class EC2CloudConcurrentProvisionTest {
+
+    private static final String LABEL = "linux";
+
+    private JenkinsRule r;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        r = rule;
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        AmazonEC2FactoryMockImpl.mock = AmazonEC2FactoryMockImpl.createAmazonEC2Mock();
+    }
+
+    @Test
+    @Issue("2030")
+    void testConcurrentRequestsDoNotExceedATemplateInstanceCap() throws Exception {
+        EC2Cloud cloud = cloud("20", template("only", InstanceType.T2_MICRO, 1));
+
+        provisionConcurrently(cloud, 4);
+
+        assertThat("a cap of one instance must hold however many requests arrive at once", instanceCount(), equalTo(1));
+    }
+
+    @Test
+    @Issue("2030")
+    void testConcurrentRequestsDoNotExceedTheCloudWideInstanceCap() throws Exception {
+        EC2Cloud cloud =
+                cloud("2", template("first", InstanceType.T2_MICRO, 10), template("second", InstanceType.M1_LARGE, 10));
+
+        provisionConcurrently(cloud, 4);
+
+        assertThat("the templates had headroom, but the cloud did not", instanceCount(), equalTo(2));
+    }
+
+    /**
+     * Fires {@code requests} label requests at once, then waits long enough for anything they
+     * launched to appear.
+     */
+    private static void provisionConcurrently(EC2Cloud cloud, int requests) throws InterruptedException {
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch finished = new CountDownLatch(requests);
+        for (int i = 0; i < requests; i++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    start.await();
+                    cloud.provision(Label.get(LABEL), 1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    finished.countDown();
+                }
+            });
+            thread.setDaemon(true);
+            thread.start();
+        }
+        start.countDown();
+        finished.await(30, TimeUnit.SECONDS);
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+    }
+
+    private static int instanceCount() {
+        return AmazonEC2FactoryMockImpl.instances.size();
+    }
+
+    private EC2Cloud cloud(String instanceCap, SlaveTemplate... templates) throws Exception {
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        EC2Cloud cloud = new EC2Cloud(
+                "test-cloud", true, "abc", "us-east-1", null, "ghi", instanceCap, List.of(templates), null, null);
+        r.jenkins.clouds.add(cloud);
+        return cloud;
+    }
+
+    private static SlaveTemplate template(String description, InstanceType type, int instanceCap) {
+        SlaveTemplate template = new SlaveTemplate(
+                "ami-" + description,
+                EC2AbstractSlave.TEST_ZONE,
+                null,
+                "default",
+                "/tmp/jenkins",
+                type.toString(),
+                false,
+                LABEL,
+                Node.Mode.NORMAL,
+                description,
+                "",
+                "",
+                "",
+                "1",
+                "",
+                null,
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "",
+                false,
+                null,
+                null,
+                null,
+                0,
+                0,
+                String.valueOf(instanceCap),
+                null,
+                false,
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                false,
+                ConnectionStrategy.PRIVATE_IP,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
+                EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED);
+        /*
+         * The mocked describe-instances ignores filters, so without this a request would find the
+         * instance another one launched, treat it as an orphan and reuse it rather than testing the
+         * cap accounting.
+         */
+        template.setAvoidUsingOrphanedNodes(true);
+        return template;
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/EC2CloudInstanceCapTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudInstanceCapTest.java
@@ -1,0 +1,328 @@
+package hudson.plugins.ec2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.plugins.ec2.util.AmazonEC2FactoryMockImpl;
+import hudson.plugins.ec2.util.MinimumInstanceChecker;
+import hudson.plugins.ec2.util.SSHCredentialHelper;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import jenkins.model.Jenkins;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
+
+/**
+ * A {@link SlaveTemplate}'s instance cap, and the cloud-wide cap, are hard ceilings. Label hot
+ * spare numbers and label-driven provisioning can only stay under them: they must never be read as
+ * permission to launch more instances from a template that is already full.
+ */
+@WithJenkins
+class EC2CloudInstanceCapTest {
+
+    private static final String LABEL = "linux";
+    private static final InstanceType FIRST_TYPE = InstanceType.T2_MICRO;
+    private static final InstanceType SECOND_TYPE = InstanceType.M1_LARGE;
+
+    private JenkinsRule r;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        r = rule;
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        AmazonEC2FactoryMockImpl.mock = AmazonEC2FactoryMockImpl.createAmazonEC2Mock();
+    }
+
+    /**
+     * A rule asking for more spares than a template may hold gets what the cap allows and nothing
+     * more, however often the check runs.
+     */
+    @Test
+    void testHotSpareNumbersCannotExceedATemplateInstanceCap() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setBaseHotSpares(5);
+        rule.setMaxHotSpares(10);
+        EC2Cloud cloud = cloud(false, rule, template("only", FIRST_TYPE, 1, 1));
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(agentsByTemplate(), equalTo(Map.of("only", 1L)));
+        assertThat(cloud.getAvailableCapacity(cloud.getTemplates().get(0)), equalTo(0));
+    }
+
+    /**
+     * The shortfall a full template cannot take is offered to the templates that still have room,
+     * so the group reaches the requested number as long as the caps allow it in total.
+     */
+    @Test
+    void testGroupShortfallIsRedistributedToTemplatesWithHeadroom() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setBaseHotSpares(4);
+        cloud(false, rule, template("small", FIRST_TYPE, 1, 1), template("large", SECOND_TYPE, 3, 1));
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(agentsByTemplate(), equalTo(Map.of("small", 1L, "large", 3L)));
+    }
+
+    /**
+     * A weight only decides who is asked first. Once that template is full, the rest of the group
+     * supplies the spares rather than the label going short.
+     */
+    @Test
+    void testPreferredTemplateAtItsCapYieldsToLowerWeightedOnes() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setBaseHotSpares(4);
+        SlaveTemplate preferred = template("preferred", FIRST_TYPE, 1, 3);
+        SlaveTemplate fallback = template("fallback", SECOND_TYPE, 5, 1);
+        EC2Cloud cloud = cloud(true, rule, preferred, fallback);
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(agentsByTemplate(), equalTo(Map.of("preferred", 1L, "fallback", 3L)));
+        assertFalse(
+                cloud.getRotation().isTemplateInCooldown(preferred, 2),
+                "a full template is not an exhausted instance type, so it must not be demoted");
+    }
+
+    /**
+     * Sequential label requests must each see the instances the previous one launched, otherwise
+     * the 30 second instance count cache would let a template be filled past its cap.
+     */
+    @Test
+    void testSequentialLabelRequestsStopAtTheTemplateCap() throws Exception {
+        SlaveTemplate first = template("first", FIRST_TYPE, 1, 1);
+        SlaveTemplate second = template("second", SECOND_TYPE, 1, 1);
+        cloud(false, null, first, second);
+        EC2Cloud cloud = r.jenkins.clouds.get(EC2Cloud.class);
+
+        cloud.provision(Label.get(LABEL), 1);
+        awaitInstanceCount(1);
+        cloud.provision(Label.get(LABEL), 1);
+        awaitInstanceCount(2);
+        cloud.provision(Label.get(LABEL), 1);
+
+        assertThat(
+                "both templates were at their cap of one, so the third request has nowhere to go",
+                settledInstanceCount(),
+                equalTo(2));
+        assertThat(instanceTypeCounts(), equalTo(Map.of(FIRST_TYPE.toString(), 1L, SECOND_TYPE.toString(), 1L)));
+    }
+
+    /**
+     * A launch counts against the headroom as soon as it happens, even though the instance count
+     * cache still holds the count from before it and EC2 may not report it yet. That is what keeps
+     * requests arriving inside the cache window from filling a template past its cap.
+     */
+    @Test
+    void testHeadroomReflectsALabelRequestWithoutWaitingForTheCacheToExpire() throws Exception {
+        SlaveTemplate template = template("only", FIRST_TYPE, 2, 1);
+        EC2Cloud cloud = cloud(false, null, template);
+        assertThat(cloud.getAvailableCapacity(cloud.getTemplates().get(0)), equalTo(2));
+
+        cloud.provision(Label.get(LABEL), 1);
+        awaitInstanceCount(1);
+
+        // Well inside the cache TTL, so a stale count on its own would still report two.
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        while (cloud.getAvailableCapacity(cloud.getTemplates().get(0)) == 2 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(100);
+        }
+        assertThat(cloud.getAvailableCapacity(cloud.getTemplates().get(0)), equalTo(1));
+    }
+
+    /**
+     * Picking up an orphaned instance is not a new launch. Once EC2 reports that instance, counting
+     * it again as in flight would charge one instance twice and starve the cloud of headroom it
+     * still has.
+     */
+    @Test
+    void testReusedInstanceIsNotCountedTwice() throws Exception {
+        SlaveTemplate reusing = template("reusing", FIRST_TYPE, 5, 1);
+        reusing.setAvoidUsingOrphanedNodes(false);
+        SlaveTemplate other = template("other", SECOND_TYPE, 5, 1);
+        EC2Cloud cloud = cloud("2", false, null, reusing, other);
+
+        cloud.provision(cloud.getTemplates().get(0), 1);
+        assertThat(instanceCount(), equalTo(1));
+
+        // Orphan it: the instance keeps running, but Jenkins no longer has a node for it.
+        for (Node node : new ArrayList<>(r.jenkins.getNodes())) {
+            r.jenkins.removeNode(node);
+        }
+        // Counting the second template is a cache miss, so this reads the instance back from EC2.
+        assertThat(cloud.getAvailableCapacity(cloud.getTemplates().get(1)), equalTo(1));
+
+        cloud.provision(cloud.getTemplates().get(0), 1);
+
+        assertThat("the orphan should have been adopted rather than replaced", instanceCount(), equalTo(1));
+        assertThat(
+                "one running instance against a cloud cap of two leaves one",
+                cloud.getAvailableCapacity(cloud.getTemplates().get(0)),
+                equalTo(1));
+    }
+
+    /**
+     * The cloud-wide cap is the other ceiling a label cannot lift, even with templates that still
+     * have headroom of their own.
+     */
+    @Test
+    void testSequentialLabelRequestsStopAtTheCloudWideCap() throws Exception {
+        cloud("2", false, null, template("first", FIRST_TYPE, 10, 1), template("second", SECOND_TYPE, 10, 1));
+        EC2Cloud cloud = r.jenkins.clouds.get(EC2Cloud.class);
+
+        cloud.provision(Label.get(LABEL), 1);
+        awaitInstanceCount(1);
+        cloud.provision(Label.get(LABEL), 1);
+        awaitInstanceCount(2);
+        cloud.provision(Label.get(LABEL), 1);
+
+        assertThat("the cloud instance cap of two must hold", settledInstanceCount(), equalTo(2));
+    }
+
+    /**
+     * A request for more agents than the group can hold is served up to the caps instead of being
+     * refused or overshooting.
+     */
+    @Test
+    void testOneLabelRequestForMoreThanTheCapsAllowIsClampedToTheCaps() throws Exception {
+        cloud(false, null, template("first", FIRST_TYPE, 1, 1), template("second", SECOND_TYPE, 2, 1));
+        EC2Cloud cloud = r.jenkins.clouds.get(EC2Cloud.class);
+
+        cloud.provision(Label.get(LABEL), 5);
+
+        awaitInstanceCount(3);
+        assertThat(settledInstanceCount(), equalTo(3));
+        assertThat(instanceTypeCounts(), equalTo(Map.of(FIRST_TYPE.toString(), 1L, SECOND_TYPE.toString(), 2L)));
+    }
+
+    private static Map<String, Long> agentsByTemplate() {
+        return Arrays.stream(Jenkins.get().getComputers())
+                .filter(EC2Computer.class::isInstance)
+                .map(EC2Computer.class::cast)
+                .map(EC2Computer::getNode)
+                .filter(node -> node != null)
+                .collect(Collectors.groupingBy(node -> node.templateDescription, Collectors.counting()));
+    }
+
+    private static int instanceCount() {
+        return AmazonEC2FactoryMockImpl.instances.size();
+    }
+
+    private static Map<String, Long> instanceTypeCounts() {
+        return AmazonEC2FactoryMockImpl.instances.stream()
+                .collect(Collectors.groupingBy(instance -> instance.instanceTypeAsString(), Collectors.counting()));
+    }
+
+    private static void awaitInstanceCount(int expected) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        while (System.currentTimeMillis() < deadline) {
+            if (AmazonEC2FactoryMockImpl.instances.size() >= expected) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        fail("only " + AmazonEC2FactoryMockImpl.instances.size() + " of " + expected + " instances were launched");
+    }
+
+    /**
+     * @return the instance count once provisioning has had time to launch anything it was going to.
+     *     Asserting that nothing was launched needs a wait, not just a read.
+     */
+    private static int settledInstanceCount() throws InterruptedException {
+        Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+        return AmazonEC2FactoryMockImpl.instances.size();
+    }
+
+    private EC2Cloud cloud(boolean roundRobin, HotSpareConfigByLabel rule, SlaveTemplate... templates)
+            throws Exception {
+        return cloud("20", roundRobin, rule, templates);
+    }
+
+    private EC2Cloud cloud(
+            String instanceCap, boolean roundRobin, HotSpareConfigByLabel rule, SlaveTemplate... templates)
+            throws Exception {
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        EC2Cloud cloud = new EC2Cloud(
+                "test-cloud", true, "abc", "us-east-1", null, "ghi", instanceCap, List.of(templates), null, null);
+        cloud.setRoundRobinTemplatesByLabel(roundRobin);
+        if (rule != null) {
+            cloud.setHotSpareConfigsByLabel(List.of(rule));
+        }
+        r.jenkins.clouds.add(cloud);
+        return cloud;
+    }
+
+    private static SlaveTemplate template(String description, InstanceType type, int instanceCap, int hotSpareWeight) {
+        SlaveTemplate template = new SlaveTemplate(
+                "ami-" + description,
+                EC2AbstractSlave.TEST_ZONE,
+                null,
+                "default",
+                "/tmp/jenkins",
+                type.toString(),
+                false,
+                LABEL,
+                Node.Mode.NORMAL,
+                description,
+                "",
+                "",
+                "",
+                "1",
+                "",
+                null,
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "",
+                false,
+                null,
+                null,
+                null,
+                0,
+                0,
+                String.valueOf(instanceCap),
+                null,
+                false,
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                false,
+                ConnectionStrategy.PRIVATE_IP,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
+                EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED);
+        template.setHotSpareWeight(hotSpareWeight);
+        /*
+         * The mocked describe-instances ignores filters, so without this a request would find the
+         * instance a previous one launched, treat it as an orphan and reuse it instead of testing
+         * the cap of the template it was aimed at.
+         */
+        template.setAvoidUsingOrphanedNodes(true);
+        return template;
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/EC2CloudLabelRotationTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudLabelRotationTest.java
@@ -9,8 +9,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import hudson.model.Label;
 import hudson.model.Node;
+import hudson.model.User;
 import hudson.plugins.ec2.util.AmazonEC2FactoryMockImpl;
 import hudson.plugins.ec2.util.SSHCredentialHelper;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.util.FormValidation;
 import java.security.Security;
 import java.util.ArrayList;
@@ -18,9 +21,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import jenkins.model.Jenkins;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.mockito.Mockito;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
@@ -239,6 +244,27 @@ class EC2CloudLabelRotationTest {
 
         cloud.setRoundRobinTemplatesByLabel(true);
         assertThat(descriptor.doCheckHotSpareWeight("3", cloud).kind, equalTo(FormValidation.Kind.OK));
+    }
+
+    /**
+     * That warning reports how the cloud is configured, so the validation answers nothing at all to
+     * someone who may not configure it.
+     */
+    @Test
+    void testHotSpareWeightValidationTellsNonAdministratorsNothing() throws Exception {
+        SlaveTemplate template = template("first", FIRST_TYPE, 10);
+        EC2Cloud cloud = cloud(false, template);
+        SlaveTemplate.DescriptorImpl descriptor = r.jenkins.getDescriptorByType(SlaveTemplate.DescriptorImpl.class);
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        r.jenkins.setAuthorizationStrategy(
+                new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().to("reader"));
+
+        try (ACLContext ignored = ACL.as2(User.getById("reader", true).impersonate2())) {
+            assertThat(
+                    "an administrator gets a warning here",
+                    descriptor.doCheckHotSpareWeight("3", cloud).kind,
+                    equalTo(FormValidation.Kind.OK));
+        }
     }
 
     /**

--- a/src/test/java/hudson/plugins/ec2/EC2CloudLabelRotationTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudLabelRotationTest.java
@@ -91,6 +91,51 @@ class EC2CloudLabelRotationTest {
     }
 
     /**
+     * Saturating the highest weight first sends every request to the heavier template. Under the
+     * default proportional rotation the lighter one would have led the third of these four
+     * requests.
+     */
+    @Test
+    void testSaturatingHighestWeightSendsEveryRequestToTheHeavierTemplate() throws Exception {
+        SlaveTemplate preferred = template("preferred", FIRST_TYPE, 10);
+        preferred.setHotSpareWeight(3);
+        SlaveTemplate fallback = template("fallback", SECOND_TYPE, 10);
+        fallback.setHotSpareWeight(1);
+        EC2Cloud cloud = cloud(true, preferred, fallback);
+        cloud.setSaturateHighestWeightFirst(true);
+
+        for (int i = 0; i < 4; i++) {
+            cloud.provision(Label.get(LABEL), 1);
+        }
+
+        assertThat(
+                awaitInstanceTypes(4),
+                contains(FIRST_TYPE.toString(), FIRST_TYPE.toString(), FIRST_TYPE.toString(), FIRST_TYPE.toString()));
+    }
+
+    /**
+     * ... and the lighter template is what the label falls back to once the heavier one can no
+     * longer supply an instance.
+     */
+    @Test
+    void testSaturatingHighestWeightFallsBackOnceTheHeavierTemplateIsExhausted() throws Exception {
+        SlaveTemplate preferred = template("preferred", FIRST_TYPE, 1);
+        preferred.setHotSpareWeight(3);
+        SlaveTemplate fallback = template("fallback", SECOND_TYPE, 10);
+        fallback.setHotSpareWeight(1);
+        EC2Cloud cloud = cloud(true, preferred, fallback);
+        cloud.setSaturateHighestWeightFirst(true);
+
+        // Synchronous, so the cap is genuinely reached before the label request below.
+        cloud.provision(preferred, 1);
+        assertThat(cloud.getAvailableCapacity(preferred), equalTo(0));
+
+        cloud.provision(Label.get(LABEL), 1);
+
+        assertThat(awaitInstanceTypes(2), contains(FIRST_TYPE.toString(), SECOND_TYPE.toString()));
+    }
+
+    /**
      * A rule for a label none of these templates carries must not disturb their provisioning.
      */
     @Test

--- a/src/test/java/hudson/plugins/ec2/EC2CloudLabelRotationTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudLabelRotationTest.java
@@ -1,0 +1,328 @@
+package hudson.plugins.ec2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.plugins.ec2.util.AmazonEC2FactoryMockImpl;
+import hudson.plugins.ec2.util.SSHCredentialHelper;
+import hudson.util.FormValidation;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.mockito.Mockito;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.ec2.model.Ec2Exception;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
+import software.amazon.awssdk.services.ec2.model.RunInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.RunInstancesResponse;
+
+/**
+ * Label rotation and next-template fallback driven purely by {@code provision(Label, int)}, with no
+ * hot spare rule configured. Rotating the templates of a label and falling back to the next one are
+ * meant to work for ordinary label-driven provisioning, not only for hot spares.
+ */
+@WithJenkins
+class EC2CloudLabelRotationTest {
+
+    private static final String LABEL = "linux";
+    private static final InstanceType FIRST_TYPE = InstanceType.T2_MICRO;
+    private static final InstanceType SECOND_TYPE = InstanceType.M1_LARGE;
+
+    private JenkinsRule r;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        r = rule;
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        AmazonEC2FactoryMockImpl.mock = AmazonEC2FactoryMockImpl.createAmazonEC2Mock();
+    }
+
+    /**
+     * With rotation enabled, consecutive requests for the same label use different templates even
+     * though the first one could have served both.
+     */
+    @Test
+    void testConsecutiveRequestsRotateAcrossTheTemplatesOfALabel() throws Exception {
+        SlaveTemplate first = template("first", FIRST_TYPE, 10);
+        SlaveTemplate second = template("second", SECOND_TYPE, 10);
+        EC2Cloud cloud = cloud(true, first, second);
+        assertThat("no hot spare rule is needed for rotation", cloud.getHotSpareConfigsByLabel(), equalTo(List.of()));
+
+        cloud.provision(Label.get(LABEL), 1);
+        cloud.provision(Label.get(LABEL), 1);
+
+        assertThat(awaitInstanceTypes(2), containsInAnyOrder(FIRST_TYPE.toString(), SECOND_TYPE.toString()));
+    }
+
+    /**
+     * The flag is what changes the order, so with it off the configured order is used for every
+     * request, as it was before rotation existed.
+     */
+    @Test
+    void testRotationDisabledKeepsTheConfiguredOrderForEveryRequest() throws Exception {
+        SlaveTemplate first = template("first", FIRST_TYPE, 10);
+        SlaveTemplate second = template("second", SECOND_TYPE, 10);
+        EC2Cloud cloud = cloud(false, first, second);
+
+        cloud.provision(Label.get(LABEL), 1);
+        cloud.provision(Label.get(LABEL), 1);
+
+        assertThat(awaitInstanceTypes(2), contains(FIRST_TYPE.toString(), FIRST_TYPE.toString()));
+        assertThat(cloud.orderTemplatesForLabel(Label.get(LABEL), List.of(first, second)), contains(first, second));
+    }
+
+    /**
+     * A rule for a label none of these templates carries must not disturb their provisioning.
+     */
+    @Test
+    void testRuleForAnUnrelatedLabelDoesNotAffectRotation() throws Exception {
+        SlaveTemplate first = template("first", FIRST_TYPE, 10);
+        SlaveTemplate second = template("second", SECOND_TYPE, 10);
+        EC2Cloud cloud = cloud(true, first, second);
+        cloud.setHotSpareConfigsByLabel(List.of(new HotSpareConfigByLabel("windows")));
+
+        cloud.provision(Label.get(LABEL), 1);
+        cloud.provision(Label.get(LABEL), 1);
+
+        assertThat(awaitInstanceTypes(2), containsInAnyOrder(FIRST_TYPE.toString(), SECOND_TYPE.toString()));
+    }
+
+    /**
+     * A template at its instance cap is skipped in favour of the next one in the same request. This
+     * is the fallback that commit 05176793 introduced, and reaching the cap must not be mistaken
+     * for a capacity shortage in EC2.
+     */
+    @Test
+    void testTemplateAtItsInstanceCapFallsBackWithoutCoolingDown() throws Exception {
+        SlaveTemplate first = template("first", FIRST_TYPE, 1);
+        SlaveTemplate second = template("second", SECOND_TYPE, 10);
+        EC2Cloud cloud = cloud(true, first, second);
+
+        // Synchronous, so the cap is genuinely reached before the label request below.
+        cloud.provision(first, 1);
+        assertThat(cloud.getAvailableCapacity(first), equalTo(0));
+
+        cloud.provision(Label.get(LABEL), 1);
+
+        assertThat(awaitInstanceTypes(2), contains(FIRST_TYPE.toString(), SECOND_TYPE.toString()));
+        assertFalse(
+                cloud.getRotation().isTemplateInCooldown(first, 2),
+                "an instance cap is a local limit, not a capacity shortage, so it must not demote the template");
+    }
+
+    /**
+     * A launch that comes back with no instances is a failure like any other: move on to the next
+     * template, but do not blame EC2 capacity for it.
+     */
+    @Test
+    void testEmptyLaunchResultFallsBackWithoutCoolingDown() throws Exception {
+        Mockito.doReturn(RunInstancesResponse.builder()
+                        .instances(Collections.emptyList())
+                        .build())
+                .when(AmazonEC2FactoryMockImpl.mock)
+                .runInstances(Mockito.<RunInstancesRequest>argThat(
+                        request -> request != null && FIRST_TYPE.toString().equals(request.instanceTypeAsString())));
+        SlaveTemplate first = template("first", FIRST_TYPE, 10);
+        SlaveTemplate second = template("second", SECOND_TYPE, 10);
+        EC2Cloud cloud = cloud(true, first, second);
+
+        cloud.provision(Label.get(LABEL), 1);
+
+        assertThat(awaitInstanceTypes(1), contains(SECOND_TYPE.toString()));
+        assertFalse(
+                cloud.getRotation().isTemplateInCooldown(first, 2),
+                "only an insufficient-capacity error should demote a template");
+    }
+
+    /**
+     * A client-side SDK failure carries no AWS error code, so it can only mean "try the next
+     * template" &mdash; never "this instance type is exhausted".
+     */
+    @Test
+    void testClientSideSdkFailureFallsBackWithoutCoolingDown() throws Exception {
+        Mockito.doThrow(SdkClientException.create("no route to EC2"))
+                .when(AmazonEC2FactoryMockImpl.mock)
+                .runInstances(Mockito.<RunInstancesRequest>argThat(
+                        request -> request != null && FIRST_TYPE.toString().equals(request.instanceTypeAsString())));
+        SlaveTemplate first = template("first", FIRST_TYPE, 10);
+        SlaveTemplate second = template("second", SECOND_TYPE, 10);
+        EC2Cloud cloud = cloud(true, first, second);
+
+        cloud.provision(Label.get(LABEL), 1);
+
+        assertThat(awaitInstanceTypes(1), contains(SECOND_TYPE.toString()));
+        assertFalse(
+                cloud.getRotation().isTemplateInCooldown(first, 2),
+                "only an insufficient-capacity error should demote a template");
+    }
+
+    /**
+     * The cooldown outlives the request that recorded it, otherwise the next request would run into
+     * the same exhausted instance type again.
+     */
+    @Test
+    void testCooldownFromACapacityErrorMovesLaterRequestsToTheOtherTemplate() throws Exception {
+        Mockito.doAnswer(invocation -> {
+                    throw Ec2Exception.builder()
+                            .awsErrorDetails(AwsErrorDetails.builder()
+                                    .errorCode("InsufficientInstanceCapacity")
+                                    .build())
+                            .message("InsufficientInstanceCapacity")
+                            .build();
+                })
+                .when(AmazonEC2FactoryMockImpl.mock)
+                .runInstances(Mockito.<RunInstancesRequest>argThat(
+                        request -> request != null && FIRST_TYPE.toString().equals(request.instanceTypeAsString())));
+        SlaveTemplate first = template("first", FIRST_TYPE, 10);
+        SlaveTemplate second = template("second", SECOND_TYPE, 10);
+        EC2Cloud cloud = cloud(true, first, second);
+
+        cloud.provision(Label.get(LABEL), 1);
+        awaitInstanceTypes(1);
+
+        assertThat(
+                "the next request should start from the template that can still deliver",
+                cloud.orderTemplatesForLabel(Label.get(LABEL), List.of(first, second)),
+                contains(second, first));
+    }
+
+    /**
+     * A label served by a single template has nowhere to fail over to, so demoting it would only
+     * stop it retrying across its own availability zones.
+     */
+    @Test
+    void testSingleTemplateLabelIsNeverCooledDown() throws Exception {
+        Mockito.doAnswer(invocation -> {
+                    throw Ec2Exception.builder()
+                            .awsErrorDetails(AwsErrorDetails.builder()
+                                    .errorCode("InsufficientInstanceCapacity")
+                                    .build())
+                            .message("InsufficientInstanceCapacity")
+                            .build();
+                })
+                .when(AmazonEC2FactoryMockImpl.mock)
+                .runInstances(Mockito.any(RunInstancesRequest.class));
+        SlaveTemplate only = template("only", FIRST_TYPE, 10);
+        EC2Cloud cloud = cloud(true, only);
+
+        cloud.provision(Label.get(LABEL), 1);
+
+        assertFalse(cloud.getRotation().isTemplateInCooldown(only, 1), "a lone template must keep being tried");
+    }
+
+    /**
+     * A weight is only meaningful once rotation is enabled, so the form says so rather than letting
+     * an admin believe a weight is being honoured.
+     */
+    @Test
+    void testHotSpareWeightWarnsWhileRotationIsDisabled() throws Exception {
+        SlaveTemplate template = template("first", FIRST_TYPE, 10);
+        EC2Cloud cloud = cloud(false, template);
+        SlaveTemplate.DescriptorImpl descriptor = r.jenkins.getDescriptorByType(SlaveTemplate.DescriptorImpl.class);
+
+        assertThat(descriptor.doCheckHotSpareWeight("3", cloud).kind, equalTo(FormValidation.Kind.WARNING));
+        assertThat(descriptor.doCheckHotSpareWeight("1", cloud).kind, equalTo(FormValidation.Kind.OK));
+
+        cloud.setRoundRobinTemplatesByLabel(true);
+        assertThat(descriptor.doCheckHotSpareWeight("3", cloud).kind, equalTo(FormValidation.Kind.OK));
+    }
+
+    /**
+     * @return the instance types launched so far, in launch order, once {@code expected} instances
+     *     exist. Provisioning finishes on another thread, so the count is what tells us the
+     *     requests are done.
+     */
+    private List<String> awaitInstanceTypes(int expected) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        while (System.currentTimeMillis() < deadline) {
+            List<String> types = new ArrayList<>(AmazonEC2FactoryMockImpl.instances.stream()
+                    .map(instance -> instance.instanceTypeAsString())
+                    .collect(Collectors.toList()));
+            if (types.size() >= expected) {
+                return types;
+            }
+            Thread.sleep(100);
+        }
+        return fail("only " + AmazonEC2FactoryMockImpl.instances.size() + " of " + expected
+                + " expected instances were launched");
+    }
+
+    private EC2Cloud cloud(boolean roundRobinTemplatesByLabel, SlaveTemplate... templates) throws Exception {
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        EC2Cloud cloud =
+                new EC2Cloud("test-cloud", true, "abc", "us-east-1", null, "ghi", "20", List.of(templates), null, null);
+        cloud.setRoundRobinTemplatesByLabel(roundRobinTemplatesByLabel);
+        r.jenkins.clouds.add(cloud);
+        return cloud;
+    }
+
+    private static SlaveTemplate template(String description, InstanceType type, int instanceCap) {
+        SlaveTemplate template = new SlaveTemplate(
+                "ami-" + description,
+                EC2AbstractSlave.TEST_ZONE,
+                null,
+                "default",
+                "/tmp/jenkins",
+                type.toString(),
+                false,
+                LABEL,
+                Node.Mode.NORMAL,
+                description,
+                "",
+                "",
+                "",
+                "1",
+                "",
+                null,
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "",
+                false,
+                null,
+                null,
+                null,
+                0,
+                0,
+                String.valueOf(instanceCap),
+                null,
+                false,
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                false,
+                ConnectionStrategy.PRIVATE_IP,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
+                EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED);
+        /*
+         * The mocked describe-instances ignores filters, so without this every request would find
+         * the instance the previous one launched, treat it as an orphan and reuse it instead of
+         * launching from the template being tested.
+         */
+        template.setAvoidUsingOrphanedNodes(true);
+        return template;
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/EC2CloudProvisionFailoverTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2CloudProvisionFailoverTest.java
@@ -1,0 +1,251 @@
+package hudson.plugins.ec2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.plugins.ec2.util.AmazonEC2FactoryMockImpl;
+import hudson.plugins.ec2.util.SSHCredentialHelper;
+import java.security.Security;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.mockito.Mockito;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.ec2.model.Ec2Exception;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
+import software.amazon.awssdk.services.ec2.model.RunInstancesRequest;
+
+/**
+ * Failover between the templates matching one label. The group is homogeneous by definition, so a
+ * template that cannot deliver must hand over to the next one inside the same provisioning request
+ * instead of costing a whole {@link hudson.slaves.NodeProvisioner} cycle.
+ *
+ * @see <a href="https://github.com/jenkinsci/ec2-plugin/issues/2033">ec2-plugin issue 2033</a>
+ */
+@WithJenkins
+class EC2CloudProvisionFailoverTest {
+
+    private static final String LABEL = "linux";
+    private static final InstanceType FIRST_TYPE = InstanceType.T2_MICRO;
+    private static final InstanceType SECOND_TYPE = InstanceType.M1_LARGE;
+
+    private JenkinsRule r;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        r = rule;
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        AmazonEC2FactoryMockImpl.mock = AmazonEC2FactoryMockImpl.createAmazonEC2Mock();
+    }
+
+    /**
+     * An insufficient-capacity error on the first template must be recovered from within the same
+     * call by launching from the second, and the exhausted template is demoted for a while.
+     */
+    @Test
+    @Issue("2033")
+    void testCapacityErrorFailsOverToNextTemplateAndCoolsDownTheFirst() throws Exception {
+        failRunInstancesFor(FIRST_TYPE, () -> capacityException("InsufficientInstanceCapacity"));
+        SlaveTemplate first = template("first", FIRST_TYPE);
+        SlaveTemplate second = template("second", SECOND_TYPE);
+        EC2Cloud cloud = cloud(true, first, second);
+
+        assertFalse(cloud.provision(Label.get(LABEL), 1).isEmpty(), "a node should have been planned");
+
+        awaitInstanceOfType(SECOND_TYPE);
+        assertThat(
+                "the exhausted template should have been demoted in the rotation",
+                cloud.getRotation().isTemplateInCooldown(first, 2),
+                equalTo(true));
+    }
+
+    /**
+     * The fallback is not gated on the rotation flag: it only takes effect after a template has
+     * already failed, so it applies to the default configured order too. The cooldown, which does
+     * reorder later requests, stays off.
+     */
+    @Test
+    @Issue("2033")
+    void testCapacityErrorFailsOverWithRotationDisabledButRecordsNoCooldown() throws Exception {
+        failRunInstancesFor(FIRST_TYPE, () -> capacityException("InsufficientInstanceCapacity"));
+        SlaveTemplate first = template("first", FIRST_TYPE);
+        SlaveTemplate second = template("second", SECOND_TYPE);
+        EC2Cloud cloud = cloud(false, first, second);
+
+        assertFalse(cloud.provision(Label.get(LABEL), 1).isEmpty(), "a node should have been planned");
+
+        awaitInstanceOfType(SECOND_TYPE);
+        assertFalse(
+                cloud.getRotation().isTemplateInCooldown(first, 2),
+                "no cooldown should be recorded while rotation is disabled");
+    }
+
+    /**
+     * With the default configuration the exhausted template is tried first on every cycle, since
+     * nothing demotes it. Each cycle must still end with an instance from the second template
+     * rather than looping on the first one.
+     */
+    @Test
+    @Issue("2033")
+    void testEveryRequestStillDeliversWhileTheFirstTemplateKeepsFailing() throws Exception {
+        failRunInstancesFor(FIRST_TYPE, () -> capacityException("InsufficientInstanceCapacity"));
+        SlaveTemplate first = template("first", FIRST_TYPE);
+        SlaveTemplate second = template("second", SECOND_TYPE);
+        EC2Cloud cloud = cloud(false, first, second);
+
+        cloud.provision(Label.get(LABEL), 1);
+        awaitInstanceCount(1);
+        cloud.provision(Label.get(LABEL), 1);
+        awaitInstanceCount(2);
+
+        assertThat(
+                AmazonEC2FactoryMockImpl.instances.stream()
+                        .map(instance -> instance.instanceTypeAsString())
+                        .collect(Collectors.toList()),
+                equalTo(List.of(SECOND_TYPE.toString(), SECOND_TYPE.toString())));
+        assertThat(
+                "the configured order is unchanged, so the exhausted template leads again",
+                cloud.orderTemplatesForLabel(Label.get(LABEL), List.of(first, second)),
+                equalTo(List.of(first, second)));
+    }
+
+    /**
+     * A failure that is not about capacity also falls over to the next template, but must not put
+     * the first one into a capacity cooldown.
+     */
+    @Test
+    @Issue("2033")
+    void testNonCapacityErrorFailsOverWithoutCooldown() throws Exception {
+        failRunInstancesFor(FIRST_TYPE, () -> capacityException("UnauthorizedOperation"));
+        SlaveTemplate first = template("first", FIRST_TYPE);
+        SlaveTemplate second = template("second", SECOND_TYPE);
+        EC2Cloud cloud = cloud(true, first, second);
+
+        assertFalse(cloud.provision(Label.get(LABEL), 1).isEmpty(), "a node should have been planned");
+
+        awaitInstanceOfType(SECOND_TYPE);
+        assertFalse(
+                cloud.getRotation().isTemplateInCooldown(first, 2), "only capacity errors should demote a template");
+    }
+
+    /*
+     * Narrows the factory's default runInstances behaviour to fail for one instance type only. The
+     * later, more specific stub wins for that type while every other request keeps launching.
+     */
+    private void failRunInstancesFor(InstanceType type, Supplier<RuntimeException> failure) {
+        Mockito.doAnswer(invocation -> {
+                    throw failure.get();
+                })
+                .when(AmazonEC2FactoryMockImpl.mock)
+                .runInstances(Mockito.<RunInstancesRequest>argThat(
+                        request -> request != null && type.toString().equals(request.instanceTypeAsString())));
+    }
+
+    private static Ec2Exception capacityException(String errorCode) {
+        return (Ec2Exception) Ec2Exception.builder()
+                .awsErrorDetails(AwsErrorDetails.builder().errorCode(errorCode).build())
+                .message(errorCode)
+                .build();
+    }
+
+    private void awaitInstanceCount(int expected) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        while (System.currentTimeMillis() < deadline) {
+            if (AmazonEC2FactoryMockImpl.instances.size() >= expected) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        assertTrue(
+                false,
+                "only " + AmazonEC2FactoryMockImpl.instances.size() + " of " + expected + " instances were launched");
+    }
+
+    private void awaitInstanceOfType(InstanceType type) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        while (System.currentTimeMillis() < deadline) {
+            if (AmazonEC2FactoryMockImpl.instances.stream()
+                    .anyMatch(instance -> type.toString().equals(instance.instanceTypeAsString()))) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        assertTrue(false, "no instance of type " + type + " was launched");
+    }
+
+    private EC2Cloud cloud(boolean roundRobinTemplatesByLabel, SlaveTemplate... templates) throws Exception {
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        EC2Cloud cloud =
+                new EC2Cloud("test-cloud", true, "abc", "us-east-1", null, "ghi", "20", List.of(templates), null, null);
+        cloud.setRoundRobinTemplatesByLabel(roundRobinTemplatesByLabel);
+        r.jenkins.clouds.add(cloud);
+        return cloud;
+    }
+
+    private static SlaveTemplate template(String description, InstanceType type) {
+        SlaveTemplate template = new SlaveTemplate(
+                "ami-" + description,
+                EC2AbstractSlave.TEST_ZONE,
+                null,
+                "default",
+                "/tmp/jenkins",
+                type.toString(),
+                false,
+                LABEL,
+                Node.Mode.NORMAL,
+                description,
+                "",
+                "",
+                "",
+                "1",
+                "",
+                null,
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "",
+                false,
+                null,
+                null,
+                null,
+                0,
+                0,
+                "10",
+                null,
+                false,
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                false,
+                ConnectionStrategy.PRIVATE_IP,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
+                EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED);
+        /*
+         * The mocked describe-instances ignores filters, so without this a later request would find
+         * the instance an earlier one launched, treat it as an orphan and reuse it instead of
+         * exercising the failover.
+         */
+        template.setAvoidUsingOrphanedNodes(true);
+        return template;
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/EC2QueueMaintenanceLatencyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2QueueMaintenanceLatencyTest.java
@@ -1,0 +1,262 @@
+package hudson.plugins.ec2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.plugins.ec2.util.AmazonEC2FactoryMockImpl;
+import hudson.plugins.ec2.util.MinimumInstanceChecker;
+import hudson.plugins.ec2.util.SSHCredentialHelper;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import jenkins.model.Jenkins;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
+import software.amazon.awssdk.services.ec2.model.DescribeSpotInstanceRequestsRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeSpotInstanceRequestsResponse;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
+import software.amazon.awssdk.services.ec2.model.RunInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.RunInstancesResponse;
+
+/**
+ * Queue maintenance must never wait on EC2. {@code Queue.maintain()} runs under the Queue lock and
+ * calls into this plugin through {@link EC2RetentionStrategy#check} and
+ * {@link EC2Cloud#canProvision}, so any EC2 call reached from there stalls the whole controller.
+ * Making that path non-blocking is what took queue maintenance from tens of seconds back to
+ * milliseconds.
+ *
+ * <p>Every EC2 call in these tests takes five seconds, so anything that reached one would blow the
+ * budget by an order of magnitude rather than merely being slow.
+ *
+ * @see <a href="https://github.com/jenkinsci/ec2-plugin/pull/2000">ec2-plugin PR 2000</a>
+ */
+@WithJenkins
+class EC2QueueMaintenanceLatencyTest {
+
+    private static final String LABEL = "linux";
+    private static final long EC2_CALL_DELAY_MS = TimeUnit.SECONDS.toMillis(5);
+    private static final long BUDGET_MS = TimeUnit.SECONDS.toMillis(2);
+
+    private JenkinsRule r;
+    private EC2Cloud cloud;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        r = rule;
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        AmazonEC2FactoryMockImpl.mock = AmazonEC2FactoryMockImpl.createAmazonEC2Mock();
+
+        HotSpareConfigByLabel rule2 = new HotSpareConfigByLabel(LABEL);
+        rule2.setBaseHotSpares(1);
+        rule2.setGracePeriodMinutes(5);
+        cloud = cloud(rule2, template("first", InstanceType.T2_MICRO), template("second", InstanceType.M1_LARGE));
+
+        // An agent, provisioned while EC2 is still quick to answer.
+        cloud.provision(cloud.getTemplates().get(0), 1);
+        slowDownEveryEc2Call();
+
+        // A queued build, so maintenance has something to think about. Everything the queue sets
+        // off from here on, including a hot spare pass, meets the slowed down EC2.
+        FreeStyleProject project = r.createFreeStyleProject();
+        project.setAssignedLabel(Label.get(LABEL));
+        project.scheduleBuild2(0);
+    }
+
+    @Test
+    void testQueueMaintenanceDoesNotWaitOnEc2() {
+        for (int pass = 0; pass < 3; pass++) {
+            long elapsed = timed(() -> Jenkins.get().getQueue().maintain());
+            assertThat(
+                    "queue maintenance pass " + pass + " took " + elapsed + "ms, so it reached an EC2 call",
+                    elapsed,
+                    lessThan(BUDGET_MS));
+        }
+    }
+
+    /**
+     * The retention strategy is called for every agent on that same locked path, so it has to hand
+     * its EC2 work to another thread and return.
+     */
+    @Test
+    void testRetentionStrategyCheckDoesNotWaitOnEc2() {
+        EC2Computer computer = anEc2Computer();
+        long elapsed = timed(() -> new EC2RetentionStrategy("1").check(computer));
+
+        assertThat(
+                "the retention check took " + elapsed + "ms, so it waited on EC2 under the Queue lock",
+                elapsed,
+                lessThan(BUDGET_MS));
+    }
+
+    /**
+     * Hot spare scaling, including the label rules, provisions from its own executor. The listeners
+     * that ask for a check run on the locked path, so they must only schedule it.
+     */
+    @Test
+    void testSchedulingAHotSpareCheckDoesNotWaitOnEc2() {
+        long elapsed = timed(MinimumInstanceChecker::scheduleCheck);
+
+        assertThat(
+                "scheduling a hot spare check took " + elapsed + "ms, so it ran the check inline",
+                elapsed,
+                lessThan(BUDGET_MS));
+    }
+
+    /**
+     * Maintenance asks every cloud whether it could serve a label, once per queued item.
+     */
+    @Test
+    void testCanProvisionDoesNotWaitOnEc2() {
+        long elapsed = timed(() -> cloud.canProvision(Label.get(LABEL)));
+
+        assertThat(
+                "canProvision took " + elapsed + "ms, so it consulted EC2 rather than the configuration",
+                elapsed,
+                lessThan(BUDGET_MS));
+    }
+
+    /**
+     * Control for the four budget assertions above: a call that is meant to reach EC2 does pay the
+     * five seconds, so those measurements really would have caught a blocking call.
+     */
+    @Test
+    void testTheSlowedDownEc2CallsAreReachableAtAll() {
+        long elapsed = timed(() -> {
+            try {
+                cloud.provision(cloud.getTemplates().get(0), 1);
+            } catch (Exception e) {
+                // The stubbed response is empty, which is fine: only the time spent matters.
+            }
+        });
+
+        assertThat(
+                "provisioning did not reach a slowed down EC2 call, so the budgets prove nothing",
+                elapsed,
+                greaterThanOrEqualTo(EC2_CALL_DELAY_MS));
+    }
+
+    private static long timed(Runnable work) {
+        long startedAt = System.nanoTime();
+        work.run();
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+    }
+
+    private EC2Computer anEc2Computer() {
+        EC2Computer computer = Arrays.stream(Jenkins.get().getComputers())
+                .filter(EC2Computer.class::isInstance)
+                .map(EC2Computer.class::cast)
+                .findFirst()
+                .orElse(null);
+        assertNotNull(computer, "the setup should have provisioned an agent");
+        return computer;
+    }
+
+    /**
+     * Turns every EC2 call the counting and provisioning code uses into a five second call, so a
+     * blocking one is unmistakable in the measurements.
+     */
+    /**
+     * Turns every EC2 call the counting and provisioning code uses into a five second call, so a
+     * blocking one is unmistakable in the measurements.
+     *
+     * <p>Called from the setup, before anything is queued, and never again: the client has to be the
+     * one the cloud already holds, and stubbing a client another thread is calling is a race in
+     * Mockito itself. A call arriving from the hot spare checker between a {@code doAnswer} and its
+     * {@code when} leaves Mockito complaining about unfinished stubbing.
+     */
+    private static void slowDownEveryEc2Call() {
+        Ec2Client inUse = AmazonEC2FactoryMockImpl.mock;
+        Mockito.doAnswer(invocation -> {
+                    Thread.sleep(EC2_CALL_DELAY_MS);
+                    return DescribeInstancesResponse.builder().build();
+                })
+                .when(inUse)
+                .describeInstances(Mockito.any(DescribeInstancesRequest.class));
+        Mockito.doAnswer(invocation -> {
+                    Thread.sleep(EC2_CALL_DELAY_MS);
+                    return DescribeSpotInstanceRequestsResponse.builder().build();
+                })
+                .when(inUse)
+                .describeSpotInstanceRequests(Mockito.any(DescribeSpotInstanceRequestsRequest.class));
+        Mockito.doAnswer(invocation -> {
+                    Thread.sleep(EC2_CALL_DELAY_MS);
+                    return RunInstancesResponse.builder().build();
+                })
+                .when(inUse)
+                .runInstances(Mockito.any(RunInstancesRequest.class));
+    }
+
+    private EC2Cloud cloud(HotSpareConfigByLabel rule, SlaveTemplate... templates) throws Exception {
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        // Caps well clear of anything these tests provision: a cap reached would let provisioning
+        // return without an EC2 call, and the control below needs it to make one.
+        EC2Cloud cloud = new EC2Cloud(
+                "test-cloud", true, "abc", "us-east-1", null, "ghi", "100", List.of(templates), null, null);
+        cloud.setRoundRobinTemplatesByLabel(true);
+        cloud.setHotSpareConfigsByLabel(List.of(rule));
+        r.jenkins.clouds.add(cloud);
+        return cloud;
+    }
+
+    private static SlaveTemplate template(String description, InstanceType type) {
+        return new SlaveTemplate(
+                "ami-" + description,
+                EC2AbstractSlave.TEST_ZONE,
+                null,
+                "default",
+                "/tmp/jenkins",
+                type.toString(),
+                false,
+                LABEL,
+                Node.Mode.NORMAL,
+                description,
+                "",
+                "",
+                "",
+                "1",
+                "",
+                null,
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "",
+                false,
+                null,
+                null,
+                null,
+                0,
+                0,
+                "50",
+                null,
+                false,
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                false,
+                ConnectionStrategy.PRIVATE_IP,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
+                EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED);
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/EC2QueueMaintenanceLatencyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2QueueMaintenanceLatencyTest.java
@@ -16,20 +16,19 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import jenkins.model.Jenkins;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.mockito.AdditionalAnswers;
 import org.mockito.Mockito;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
-import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
 import software.amazon.awssdk.services.ec2.model.DescribeSpotInstanceRequestsRequest;
-import software.amazon.awssdk.services.ec2.model.DescribeSpotInstanceRequestsResponse;
 import software.amazon.awssdk.services.ec2.model.InstanceType;
 import software.amazon.awssdk.services.ec2.model.RunInstancesRequest;
-import software.amazon.awssdk.services.ec2.model.RunInstancesResponse;
 
 /**
  * Queue maintenance must never wait on EC2. {@code Queue.maintain()} runs under the Queue lock and
@@ -50,6 +49,9 @@ class EC2QueueMaintenanceLatencyTest {
     private static final long EC2_CALL_DELAY_MS = TimeUnit.SECONDS.toMillis(5);
     private static final long BUDGET_MS = TimeUnit.SECONDS.toMillis(2);
 
+    /** Whether the EC2 client is currently answering slowly. Flipped once the setup is done. */
+    private static final AtomicBoolean SLOWED = new AtomicBoolean();
+
     private JenkinsRule r;
     private EC2Cloud cloud;
 
@@ -57,7 +59,8 @@ class EC2QueueMaintenanceLatencyTest {
     void setUp(JenkinsRule rule) throws Exception {
         r = rule;
         Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
-        AmazonEC2FactoryMockImpl.mock = AmazonEC2FactoryMockImpl.createAmazonEC2Mock();
+        SLOWED.set(false);
+        AmazonEC2FactoryMockImpl.mock = slowableEc2Client();
 
         HotSpareConfigByLabel rule2 = new HotSpareConfigByLabel(LABEL);
         rule2.setBaseHotSpares(1);
@@ -66,7 +69,7 @@ class EC2QueueMaintenanceLatencyTest {
 
         // An agent, provisioned while EC2 is still quick to answer.
         cloud.provision(cloud.getTemplates().get(0), 1);
-        slowDownEveryEc2Call();
+        SLOWED.set(true);
 
         // A queued build, so maintenance has something to think about. Everything the queue sets
         // off from here on, including a hot spare pass, meets the slowed down EC2.
@@ -165,38 +168,45 @@ class EC2QueueMaintenanceLatencyTest {
     }
 
     /**
-     * Turns every EC2 call the counting and provisioning code uses into a five second call, so a
-     * blocking one is unmistakable in the measurements.
-     */
-    /**
-     * Turns every EC2 call the counting and provisioning code uses into a five second call, so a
-     * blocking one is unmistakable in the measurements.
+     * An EC2 client whose calls can be made to take five seconds each, so a blocking one is
+     * unmistakable in the measurements.
      *
-     * <p>Called from the setup, before anything is queued, and never again: the client has to be the
-     * one the cloud already holds, and stubbing a client another thread is calling is a race in
-     * Mockito itself. A call arriving from the hot spare checker between a {@code doAnswer} and its
-     * {@code when} leaves Mockito complaining about unfinished stubbing.
+     * <p>The delay is a switch rather than a later round of stubbing, because a mock cannot be
+     * stubbed once other threads can call it: {@code doAnswer(...).when(mock)} parks the answers in
+     * the mock's invocation container, and an agent launching or a hot spare pass calling the same
+     * client takes them instead of the stubbed method, which surfaces as Mockito complaining about
+     * unfinished stubbing. Here everything is stubbed before the client is published, and the tests
+     * only flip a boolean afterwards.
      */
-    private static void slowDownEveryEc2Call() {
-        Ec2Client inUse = AmazonEC2FactoryMockImpl.mock;
+    private static Ec2Client slowableEc2Client() {
+        Ec2Client real = AmazonEC2FactoryMockImpl.createAmazonEC2Mock();
+        Ec2Client slowable = Mockito.mock(Ec2Client.class, AdditionalAnswers.delegatesTo(real));
         Mockito.doAnswer(invocation -> {
-                    Thread.sleep(EC2_CALL_DELAY_MS);
-                    return DescribeInstancesResponse.builder().build();
+                    pauseIfSlowed();
+                    return real.describeInstances((DescribeInstancesRequest) invocation.getArgument(0));
                 })
-                .when(inUse)
+                .when(slowable)
                 .describeInstances(Mockito.any(DescribeInstancesRequest.class));
         Mockito.doAnswer(invocation -> {
-                    Thread.sleep(EC2_CALL_DELAY_MS);
-                    return DescribeSpotInstanceRequestsResponse.builder().build();
+                    pauseIfSlowed();
+                    return real.describeSpotInstanceRequests(
+                            (DescribeSpotInstanceRequestsRequest) invocation.getArgument(0));
                 })
-                .when(inUse)
+                .when(slowable)
                 .describeSpotInstanceRequests(Mockito.any(DescribeSpotInstanceRequestsRequest.class));
         Mockito.doAnswer(invocation -> {
-                    Thread.sleep(EC2_CALL_DELAY_MS);
-                    return RunInstancesResponse.builder().build();
+                    pauseIfSlowed();
+                    return real.runInstances((RunInstancesRequest) invocation.getArgument(0));
                 })
-                .when(inUse)
+                .when(slowable)
                 .runInstances(Mockito.any(RunInstancesRequest.class));
+        return slowable;
+    }
+
+    private static void pauseIfSlowed() throws InterruptedException {
+        if (SLOWED.get()) {
+            Thread.sleep(EC2_CALL_DELAY_MS);
+        }
     }
 
     private EC2Cloud cloud(HotSpareConfigByLabel rule, SlaveTemplate... templates) throws Exception {

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -566,6 +566,10 @@ class EC2RetentionStrategyTest {
      * as a template saved without an explicit idle termination time would be.
      */
     private static SlaveTemplate templateWithIdleTermination(String idleTerminationMinutes) {
+        return templateWithIdleTermination(idleTerminationMinutes, "ttt");
+    }
+
+    private static SlaveTemplate templateWithIdleTermination(String idleTerminationMinutes, String labels) {
         return new SlaveTemplate(
                 "ami-123",
                 EC2AbstractSlave.TEST_ZONE,
@@ -574,7 +578,7 @@ class EC2RetentionStrategyTest {
                 "foo",
                 InstanceType.M1_LARGE.toString(),
                 false,
-                "ttt",
+                labels,
                 Node.Mode.NORMAL,
                 "AMI description",
                 "bar",
@@ -985,6 +989,76 @@ class EC2RetentionStrategyTest {
                 .check(computerWithUpTime(20, 0, false, false, readyAt.toEpochMilli()));
 
         assertThat("the surplus spare should have been reclaimed", idleTimeoutCalled.get(), equalTo(true));
+    }
+
+    /**
+     * A template carrying several labels can be covered by a rule for each of them, and they will
+     * not agree about how many spares are wanted. The agent is kept while any of them is still
+     * counting on it, so a small rule cannot take away what a bigger one is holding.
+     */
+    @Test
+    void testASpareOneRuleStillWantsIsKeptFromARuleThatHasGivenUp() throws Exception {
+        final int RETENTION_MINUTES = 5;
+        // Listed first, so the rule that has given up is also the one the idle timeout comes from.
+        HotSpareConfigByLabel small = hotSpareRule("other", RETENTION_MINUTES);
+        HotSpareConfigByLabel big = hotSpareRule("ttt", RETENTION_MINUTES);
+        EC2Cloud cloud = cloudWithHotSpareRules(List.of(small, big));
+        assertThat(HotSpareDemand.of(cloud, "other").updateTarget(small, 1, 0, 0, 0), equalTo(0));
+        assertThat(HotSpareDemand.of(cloud, "ttt").updateTarget(big, 0, 0, 5, 0), equalTo(5));
+
+        checkASpare(RETENTION_MINUTES, templateWithIdleTermination(null, "ttt other"));
+
+        assertThat(
+                "the label still counting on the spare should have kept it", idleTimeoutCalled.get(), equalTo(false));
+    }
+
+    /**
+     * The other side of that: being covered by several rules is not itself a reason to keep an
+     * agent, so once every one of them has given up it goes.
+     */
+    @Test
+    void testASpareIsReclaimedOnceEveryRuleCoveringItHasGivenUp() throws Exception {
+        final int RETENTION_MINUTES = 5;
+        HotSpareConfigByLabel small = hotSpareRule("other", RETENTION_MINUTES);
+        HotSpareConfigByLabel big = hotSpareRule("ttt", RETENTION_MINUTES);
+        EC2Cloud cloud = cloudWithHotSpareRules(List.of(small, big));
+        assertThat(HotSpareDemand.of(cloud, "other").updateTarget(small, 1, 0, 0, 0), equalTo(0));
+        assertThat(HotSpareDemand.of(cloud, "ttt").updateTarget(big, 1, 0, 0, 0), equalTo(0));
+
+        checkASpare(RETENTION_MINUTES, templateWithIdleTermination(null, "ttt other"));
+
+        assertThat("no rule wants the spare any more", idleTimeoutCalled.get(), equalTo(true));
+    }
+
+    private static HotSpareConfigByLabel hotSpareRule(String label, int idleTimeoutMinutes) {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(label);
+        rule.setScalingFactor(5);
+        rule.setIdleTimeoutMinutes(idleTimeoutMinutes);
+        return rule;
+    }
+
+    /** The mock agents report cloudName "cloud", which is how the strategy finds the rules. */
+    private EC2Cloud cloudWithHotSpareRules(List<HotSpareConfigByLabel> rules) {
+        EC2Cloud cloud =
+                new EC2Cloud("cloud", true, "abc", "us-east-1", null, "ghi", "20", Collections.emptyList(), null, null);
+        cloud.setHotSpareConfigsByLabel(rules);
+        r.jenkins.clouds.add(cloud);
+        HotSpareDemand.reset();
+        return cloud;
+    }
+
+    /** Runs a retention check on an agent that has been idle well past its termination time. */
+    private void checkASpare(int retentionMinutes, SlaveTemplate template) throws Exception {
+        final int BOOT_MINUTES = 5;
+        final Instant readyAt = Instant.now().plus(Duration.ofMinutes(BOOT_MINUTES));
+        final Instant checkTime = Instant.now().plus(Duration.ofMinutes(BOOT_MINUTES + retentionMinutes + 1));
+
+        new EC2RetentionStrategy(
+                        String.format("%d", retentionMinutes),
+                        Clock.fixed(checkTime.plusSeconds(1), zoneId),
+                        checkTime.toEpochMilli())
+                .check(computerWithUpTime(
+                        20, 0, false, false, readyAt.toEpochMilli(), 0L, Integer.MAX_VALUE, template));
     }
 
     /**

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -60,6 +60,8 @@ import software.amazon.awssdk.services.ec2.model.InstanceType;
 class EC2RetentionStrategyTest {
 
     private final AtomicBoolean idleTimeoutCalled = new AtomicBoolean(false);
+    private final AtomicBoolean graceTimeoutCalled = new AtomicBoolean(false);
+    private final AtomicBoolean launchTimeoutCalled = new AtomicBoolean(false);
     private final AtomicBoolean terminateCalled = new AtomicBoolean(false);
     private static final ZoneId zoneId = ZoneId.systemDefault();
 
@@ -107,6 +109,7 @@ class EC2RetentionStrategyTest {
     @org.junit.jupiter.api.AfterEach
     void tearDown() {
         EC2RetentionStrategy.HEAVY_WORK_EXECUTOR = originalExecutor;
+        MinimumInstanceChecker.clock = Clock.systemDefaultZone();
     }
 
     @Test
@@ -410,7 +413,43 @@ class EC2RetentionStrategyTest {
     private EC2Computer computerWithUpTime(
             final int minutes, final int seconds, final Boolean isOffline, final Boolean isConnecting)
             throws Exception {
+        return computerWithUpTime(minutes, seconds, isOffline, isConnecting, 0L);
+    }
+
+    /*
+     * As above, but additionally fixes the epoch-millis at which the agent came online. Pass 0 to model
+     * an agent that has never connected.
+     */
+    private EC2Computer computerWithUpTime(
+            final int minutes,
+            final int seconds,
+            final Boolean isOffline,
+            final Boolean isConnecting,
+            final long onlineSinceMillis)
+            throws Exception {
+        return computerWithUpTime(
+                minutes, seconds, isOffline, isConnecting, onlineSinceMillis, 0L, Integer.MAX_VALUE, null);
+    }
+
+    /*
+     * As above, but additionally fixes the epoch-millis at which provisioning was requested, the node's
+     * launch timeout in seconds, and the template the computer reports. Pass 0 for
+     * provisionRequestedAtMillis to model a node whose timestamp was lost, and null for the template to
+     * get the default one.
+     */
+    private EC2Computer computerWithUpTime(
+            final int minutes,
+            final int seconds,
+            final Boolean isOffline,
+            final Boolean isConnecting,
+            final long onlineSinceMillis,
+            final long provisionRequestedAtMillis,
+            final int launchTimeoutSeconds,
+            final SlaveTemplate slaveTemplate)
+            throws Exception {
         idleTimeoutCalled.set(false);
+        graceTimeoutCalled.set(false);
+        launchTimeoutCalled.set(false);
         final EC2AbstractSlave slave =
                 new EC2AbstractSlave(
                         "name",
@@ -432,7 +471,7 @@ class EC2RetentionStrategyTest {
                         "idle",
                         null,
                         "cloud",
-                        Integer.MAX_VALUE,
+                        launchTimeoutSeconds,
                         null,
                         ConnectionStrategy.PRIVATE_IP,
                         -1,
@@ -456,6 +495,16 @@ class EC2RetentionStrategyTest {
                     void idleTimeout() {
                         idleTimeoutCalled.set(true);
                     }
+
+                    @Override
+                    void graceTimeout() {
+                        graceTimeoutCalled.set(true);
+                    }
+
+                    @Override
+                    void launchTimeout() {
+                        launchTimeoutCalled.set(true);
+                    }
                 };
         EC2Computer computer = new EC2Computer(slave) {
             private final Instant launchedAt = Instant.now().minus(Duration.ofSeconds(minutes * 60L + seconds));
@@ -476,6 +525,18 @@ class EC2RetentionStrategyTest {
             }
 
             @Override
+            public long getOnlineSinceMillis() {
+                return onlineSinceMillis;
+            }
+
+            @Override
+            public long getProvisionRequestedAtMillis() {
+                return provisionRequestedAtMillis == 0
+                        ? super.getProvisionRequestedAtMillis()
+                        : provisionRequestedAtMillis;
+            }
+
+            @Override
             public boolean isOffline() {
                 return isOffline == null ? super.isOffline() : isOffline;
             }
@@ -487,52 +548,7 @@ class EC2RetentionStrategyTest {
 
             @Override
             public SlaveTemplate getSlaveTemplate() {
-                return new SlaveTemplate(
-                        "ami-123",
-                        EC2AbstractSlave.TEST_ZONE,
-                        null,
-                        "default",
-                        "foo",
-                        InstanceType.M1_LARGE.toString(),
-                        false,
-                        "ttt",
-                        Node.Mode.NORMAL,
-                        "AMI description",
-                        "bar",
-                        "bbb",
-                        "aaa",
-                        "10",
-                        "fff",
-                        null,
-                        EC2AbstractSlave.DEFAULT_JAVA_PATH,
-                        "-Xmx1g",
-                        false,
-                        "subnet-123 subnet-456",
-                        null,
-                        null,
-                        0,
-                        0,
-                        null,
-                        "",
-                        false,
-                        false,
-                        "",
-                        false,
-                        "",
-                        false,
-                        false,
-                        false,
-                        ConnectionStrategy.PRIVATE_DNS,
-                        -1,
-                        Collections.emptyList(),
-                        null,
-                        Tenancy.Default,
-                        EbsEncryptRootVolume.DEFAULT,
-                        EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
-                        EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
-                        EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
-                        EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
-                        EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED);
+                return slaveTemplate == null ? templateWithIdleTermination(null) : slaveTemplate;
             }
 
             @Override
@@ -543,6 +559,66 @@ class EC2RetentionStrategyTest {
         assertTrue(computer.isIdle());
         assertTrue(isOffline == null || computer.isOffline() == isOffline);
         return computer;
+    }
+
+    /*
+     * The template the mock computers report. Pass null for idleTerminationMinutes to leave it unset,
+     * as a template saved without an explicit idle termination time would be.
+     */
+    private static SlaveTemplate templateWithIdleTermination(String idleTerminationMinutes) {
+        return new SlaveTemplate(
+                "ami-123",
+                EC2AbstractSlave.TEST_ZONE,
+                null,
+                "default",
+                "foo",
+                InstanceType.M1_LARGE.toString(),
+                false,
+                "ttt",
+                Node.Mode.NORMAL,
+                "AMI description",
+                "bar",
+                "bbb",
+                "aaa",
+                "10",
+                "fff",
+                null,
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "-Xmx1g",
+                false,
+                "subnet-123 subnet-456",
+                null,
+                idleTerminationMinutes,
+                0,
+                0,
+                null,
+                "",
+                false,
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                false,
+                ConnectionStrategy.PRIVATE_DNS,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
+                EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED);
+    }
+
+    private static SlaveTemplate templateWithGracePeriod(int gracePeriodMinutes, boolean discardAfterGracePeriod) {
+        SlaveTemplate template = templateWithIdleTermination(null);
+        template.setGracePeriodMinutes(gracePeriodMinutes);
+        template.setDiscardAfterGracePeriod(discardAfterGracePeriod);
+        return template;
     }
 
     @Test
@@ -781,6 +857,385 @@ class EC2RetentionStrategyTest {
                 hasItem(
                         containsString(
                                 "offline but not connecting, will check if it should be terminated because of the idle time configured")));
+    }
+
+    /**
+     * Idle time must be counted from the moment the agent became usable, not from when the EC2
+     * instance was launched. An instance that spent a long time running a user data or init script
+     * would otherwise arrive with part of its idle budget already spent.
+     * <p>
+     * As explained on {@link #testDoNotTerminateInstancesJustBooted()}, the mock computer always
+     * reports its creation time as the idle start time, so the readiness timestamp is placed in the
+     * future to model an agent whose idle clock started before it finished coming online.
+     */
+    @Test
+    @Issue("JENKINS-23792")
+    void testIdleTimeoutMeasuredFromAgentReadyNotInstanceLaunch() throws Exception {
+        final int COMPUTER_UPTIME_MINUTES = 20;
+        final int BOOT_MINUTES = 5;
+        final int RETENTION_MINUTES = 5;
+        // Late enough that the launch time baseline would terminate, early enough that the
+        // readiness baseline leaves a minute of the idle budget.
+        final int CHECK_TIME_MINUTES = BOOT_MINUTES + RETENTION_MINUTES - 1;
+        final Instant readyAt = Instant.now().plus(Duration.ofMinutes(BOOT_MINUTES));
+        final Instant checkTime = Instant.now().plus(Duration.ofMinutes(CHECK_TIME_MINUTES));
+
+        new EC2RetentionStrategy(
+                        String.format("%d", RETENTION_MINUTES),
+                        Clock.fixed(checkTime.plusSeconds(1), zoneId),
+                        checkTime.toEpochMilli())
+                .check(computerWithUpTime(COMPUTER_UPTIME_MINUTES, 0, false, false, readyAt.toEpochMilli()));
+
+        assertThat(
+                "The computer was idle-terminated using the EC2 launch time rather than the time it became ready",
+                idleTimeoutCalled.get(),
+                equalTo(false));
+    }
+
+    /**
+     * The counterpart to the above: once the agent really has been idle past the timeout, measured
+     * from when it came online, it must still be terminated.
+     */
+    @Test
+    @Issue("JENKINS-23792")
+    void testIdleTimeoutStillFiresOnceReadyAgentExceedsTimeout() throws Exception {
+        final int COMPUTER_UPTIME_MINUTES = 20;
+        final int BOOT_MINUTES = 5;
+        final int RETENTION_MINUTES = 5;
+        final int CHECK_TIME_MINUTES = BOOT_MINUTES + RETENTION_MINUTES + 1;
+        final Instant readyAt = Instant.now().plus(Duration.ofMinutes(BOOT_MINUTES));
+        final Instant checkTime = Instant.now().plus(Duration.ofMinutes(CHECK_TIME_MINUTES));
+
+        new EC2RetentionStrategy(
+                        String.format("%d", RETENTION_MINUTES),
+                        Clock.fixed(checkTime.plusSeconds(1), zoneId),
+                        checkTime.toEpochMilli())
+                .check(computerWithUpTime(COMPUTER_UPTIME_MINUTES, 0, false, false, readyAt.toEpochMilli()));
+
+        assertThat("The computer is not terminated, but should be", idleTimeoutCalled.get(), equalTo(true));
+    }
+
+    /**
+     * A spare the label's target is still counting on outlives its idle timeout. Reclaiming it
+     * would pay for the same capacity twice, once for the instance thrown away and again for the
+     * one the very next pass provisions in its place, and leave a build waiting for the boot in
+     * between.
+     */
+    @Test
+    void testAnIdleSpareTheTargetStillWantsIsNotReclaimed() throws Exception {
+        final int RETENTION_MINUTES = 5;
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel("ttt");
+        rule.setScalingFactor(5);
+        rule.setIdleTimeoutMinutes(RETENTION_MINUTES);
+        // The mock agents report cloudName "cloud", which is how the strategy finds the rule.
+        EC2Cloud cloud =
+                new EC2Cloud("cloud", true, "abc", "us-east-1", null, "ghi", "20", Collections.emptyList(), null, null);
+        cloud.setHotSpareConfigsByLabel(List.of(rule));
+        r.jenkins.clouds.add(cloud);
+        HotSpareDemand.reset();
+        assertThat(HotSpareDemand.of(cloud, "ttt").updateTarget(rule, 0, 0, 5, 0), equalTo(5));
+
+        final int BOOT_MINUTES = 5;
+        final Instant readyAt = Instant.now().plus(Duration.ofMinutes(BOOT_MINUTES));
+        final Instant checkTime = Instant.now().plus(Duration.ofMinutes(BOOT_MINUTES + RETENTION_MINUTES + 1));
+
+        new EC2RetentionStrategy(
+                        String.format("%d", RETENTION_MINUTES),
+                        Clock.fixed(checkTime.plusSeconds(1), zoneId),
+                        checkTime.toEpochMilli())
+                .check(computerWithUpTime(20, 0, false, false, readyAt.toEpochMilli()));
+
+        assertThat(
+                "the spare should have been kept for the label that is still counting on it",
+                idleTimeoutCalled.get(),
+                equalTo(false));
+        assertThat(
+                "keeping a wanted spare should not move the target",
+                HotSpareDemand.of(cloud, "ttt").getTarget(),
+                equalTo(5));
+    }
+
+    /**
+     * Once the target has faded below the number of spares on hand, the extras are exactly what the
+     * idle timeout is for. This is what lets a label scale to nothing: the target reaches its base
+     * count and every spare above it is released.
+     */
+    @Test
+    void testAnIdleSpareTheTargetHasGivenUpOnIsReclaimed() throws Exception {
+        final int RETENTION_MINUTES = 5;
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel("ttt");
+        rule.setScalingFactor(5);
+        rule.setIdleTimeoutMinutes(RETENTION_MINUTES);
+        EC2Cloud cloud =
+                new EC2Cloud("cloud", true, "abc", "us-east-1", null, "ghi", "20", Collections.emptyList(), null, null);
+        cloud.setHotSpareConfigsByLabel(List.of(rule));
+        r.jenkins.clouds.add(cloud);
+        HotSpareDemand.reset();
+        // Quiet label, base count of zero: the prediction wants nothing kept warm.
+        assertThat(HotSpareDemand.of(cloud, "ttt").updateTarget(rule, 1, 0, 0, 0), equalTo(0));
+
+        final int BOOT_MINUTES = 5;
+        final Instant readyAt = Instant.now().plus(Duration.ofMinutes(BOOT_MINUTES));
+        final Instant checkTime = Instant.now().plus(Duration.ofMinutes(BOOT_MINUTES + RETENTION_MINUTES + 1));
+
+        new EC2RetentionStrategy(
+                        String.format("%d", RETENTION_MINUTES),
+                        Clock.fixed(checkTime.plusSeconds(1), zoneId),
+                        checkTime.toEpochMilli())
+                .check(computerWithUpTime(20, 0, false, false, readyAt.toEpochMilli()));
+
+        assertThat("the surplus spare should have been reclaimed", idleTimeoutCalled.get(), equalTo(true));
+    }
+
+    /**
+     * A template that only keeps instances during a time range stops being warm capacity outside
+     * it, whatever the label's target says. Otherwise a rule would hold the agent around the clock
+     * and undo the schedule the admin configured to avoid paying for it.
+     */
+    @Test
+    void testAnIdleSpareIsReclaimedOnceItsTemplateScheduleCloses() throws Exception {
+        final int RETENTION_MINUTES = 5;
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel("ttt");
+        rule.setScalingFactor(5);
+        rule.setIdleTimeoutMinutes(RETENTION_MINUTES);
+        EC2Cloud cloud =
+                new EC2Cloud("cloud", true, "abc", "us-east-1", null, "ghi", "20", Collections.emptyList(), null, null);
+        cloud.setHotSpareConfigsByLabel(List.of(rule));
+        r.jenkins.clouds.add(cloud);
+        HotSpareDemand.reset();
+        assertThat(
+                "the label wants spares", HotSpareDemand.of(cloud, "ttt").updateTarget(rule, 0, 0, 5, 0), equalTo(5));
+
+        MinimumNumberOfInstancesTimeRangeConfig window = new MinimumNumberOfInstancesTimeRangeConfig();
+        window.setMinimumNoInstancesActiveTimeRangeFrom("11:00");
+        window.setMinimumNoInstancesActiveTimeRangeTo("15:00");
+        window.setTuesday(true);
+        SlaveTemplate template = templateWithIdleTermination(null);
+        template.setMinimumNumberOfInstancesTimeRangeConfig(window);
+        // Tuesday evening: the template is past the hours it keeps instances for.
+        LocalDateTime outsideTheWindow = LocalDateTime.of(2019, Month.SEPTEMBER, 24, 18, 0);
+        MinimumInstanceChecker.clock =
+                Clock.fixed(outsideTheWindow.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+
+        final int BOOT_MINUTES = 5;
+        final Instant readyAt = Instant.now().plus(Duration.ofMinutes(BOOT_MINUTES));
+        final Instant checkTime = Instant.now().plus(Duration.ofMinutes(BOOT_MINUTES + RETENTION_MINUTES + 1));
+
+        new EC2RetentionStrategy(
+                        String.format("%d", RETENTION_MINUTES),
+                        Clock.fixed(checkTime.plusSeconds(1), zoneId),
+                        checkTime.toEpochMilli())
+                .check(computerWithUpTime(
+                        20, 0, false, false, readyAt.toEpochMilli(), 0L, Integer.MAX_VALUE, template));
+
+        assertThat(
+                "the spare should have been reclaimed once its template went off schedule",
+                idleTimeoutCalled.get(),
+                equalTo(true));
+    }
+
+    /**
+     * An agent that has not connected yet is left alone until its grace period expires.
+     */
+    @Test
+    void testGracePeriodNotExpiredLeavesOfflineAgentAlone() throws Exception {
+        final int GRACE_MINUTES = 10;
+        final Instant provisionedAt = Instant.now();
+        final Instant checkTime = provisionedAt.plus(Duration.ofMinutes(GRACE_MINUTES - 5));
+
+        new EC2RetentionStrategy("30", Clock.fixed(checkTime.plusSeconds(1), zoneId), checkTime.toEpochMilli())
+                .check(computerWithUpTime(
+                        5,
+                        0,
+                        true,
+                        false,
+                        0L,
+                        provisionedAt.toEpochMilli(),
+                        Integer.MAX_VALUE,
+                        templateWithGracePeriod(GRACE_MINUTES, true)));
+
+        assertThat("The agent was discarded inside its grace period", graceTimeoutCalled.get(), equalTo(false));
+        assertThat("The agent was idle-terminated inside its grace period", idleTimeoutCalled.get(), equalTo(false));
+    }
+
+    /**
+     * Grace period expired with discarding enabled: the instance goes away, and the log names the
+     * grace period rather than the launch timeout as the reason.
+     */
+    @Test
+    void testGracePeriodExpiredDiscardsAgentThatNeverCameOnline() throws Exception {
+        final int GRACE_MINUTES = 10;
+        final Instant provisionedAt = Instant.now();
+        final Instant checkTime = provisionedAt.plus(Duration.ofMinutes(GRACE_MINUTES + 1));
+
+        new EC2RetentionStrategy("30", Clock.fixed(checkTime.plusSeconds(1), zoneId), checkTime.toEpochMilli())
+                .check(computerWithUpTime(
+                        GRACE_MINUTES + 1,
+                        0,
+                        true,
+                        false,
+                        0L,
+                        provisionedAt.toEpochMilli(),
+                        Integer.MAX_VALUE,
+                        templateWithGracePeriod(GRACE_MINUTES, true)));
+
+        assertThat(
+                "The agent never came online and was not discarded at the grace deadline",
+                graceTimeoutCalled.get(),
+                equalTo(true));
+    }
+
+    /**
+     * Grace period expired with discarding disabled: the idle clock starts at the grace deadline,
+     * so the agent survives until the idle termination time has also elapsed.
+     */
+    @Test
+    void testGracePeriodExpiredWithoutDiscardStartsIdleClock() throws Exception {
+        final int GRACE_MINUTES = 10;
+        final int RETENTION_MINUTES = 5;
+        final Instant provisionedAt = Instant.now();
+
+        final Instant beforeIdleTimeout = provisionedAt.plus(Duration.ofMinutes(GRACE_MINUTES + 1));
+        new EC2RetentionStrategy(
+                        String.format("%d", RETENTION_MINUTES),
+                        Clock.fixed(beforeIdleTimeout.plusSeconds(1), zoneId),
+                        beforeIdleTimeout.toEpochMilli())
+                .check(computerWithUpTime(
+                        GRACE_MINUTES + 1,
+                        0,
+                        true,
+                        false,
+                        0L,
+                        provisionedAt.toEpochMilli(),
+                        Integer.MAX_VALUE,
+                        templateWithGracePeriod(GRACE_MINUTES, false)));
+        assertThat("The agent was discarded although discarding is disabled", graceTimeoutCalled.get(), equalTo(false));
+        assertThat("The idle clock did not restart at the grace deadline", idleTimeoutCalled.get(), equalTo(false));
+
+        final Instant afterIdleTimeout = provisionedAt.plus(Duration.ofMinutes(GRACE_MINUTES + RETENTION_MINUTES + 1));
+        new EC2RetentionStrategy(
+                        String.format("%d", RETENTION_MINUTES),
+                        Clock.fixed(afterIdleTimeout.plusSeconds(1), zoneId),
+                        afterIdleTimeout.toEpochMilli())
+                .check(computerWithUpTime(
+                        GRACE_MINUTES + RETENTION_MINUTES + 1,
+                        0,
+                        true,
+                        false,
+                        0L,
+                        provisionedAt.toEpochMilli(),
+                        Integer.MAX_VALUE,
+                        templateWithGracePeriod(GRACE_MINUTES, false)));
+        assertThat(
+                "The agent was not idle-terminated after the grace period plus the idle timeout",
+                idleTimeoutCalled.get(),
+                equalTo(true));
+    }
+
+    /**
+     * Regression guard for the relocated early return: a template configured never to idle-terminate
+     * must still have its grace period enforced.
+     */
+    @Test
+    void testGracePeriodEnforcedWhenIdleTerminationIsDisabled() throws Exception {
+        final int GRACE_MINUTES = 10;
+        final Instant provisionedAt = Instant.now();
+        final Instant checkTime = provisionedAt.plus(Duration.ofMinutes(GRACE_MINUTES + 1));
+
+        new EC2RetentionStrategy("0", Clock.fixed(checkTime.plusSeconds(1), zoneId), checkTime.toEpochMilli())
+                .check(computerWithUpTime(
+                        GRACE_MINUTES + 1,
+                        0,
+                        true,
+                        false,
+                        0L,
+                        provisionedAt.toEpochMilli(),
+                        Integer.MAX_VALUE,
+                        templateWithGracePeriod(GRACE_MINUTES, true)));
+
+        assertThat(
+                "Idle termination being disabled suppressed the grace period", graceTimeoutCalled.get(), equalTo(true));
+    }
+
+    /**
+     * The grace period and the launch timeout run independently, and the shorter one wins: a still
+     * connecting agent whose launch timeout has expired is terminated even though its longer grace
+     * period has not.
+     */
+    @Test
+    void testShorterLaunchTimeoutWinsOverGracePeriod() throws Exception {
+        final int GRACE_MINUTES = 10;
+        final int LAUNCH_TIMEOUT_SECONDS = 60;
+        final Instant provisionedAt = Instant.now();
+        final Instant checkTime = provisionedAt.plus(Duration.ofMinutes(GRACE_MINUTES - 5));
+
+        new EC2RetentionStrategy("30", Clock.fixed(checkTime.plusSeconds(1), zoneId), checkTime.toEpochMilli())
+                .check(computerWithUpTime(
+                        5,
+                        0,
+                        true,
+                        true,
+                        0L,
+                        provisionedAt.toEpochMilli(),
+                        LAUNCH_TIMEOUT_SECONDS,
+                        templateWithGracePeriod(GRACE_MINUTES, true)));
+
+        assertThat("The grace period suppressed the shorter launch timeout", launchTimeoutCalled.get(), equalTo(true));
+        assertThat("The grace period expired early", graceTimeoutCalled.get(), equalTo(false));
+    }
+
+    /**
+     * A node reloaded from disk loses its transient timestamps, but {@code EC2Computer} falls back to
+     * {@code Computer#getConnectTime()} for an agent whose channel is already up. Such an agent must
+     * not be discarded no matter how long ago it was provisioned.
+     */
+    @Test
+    void testAgentReportedOnlineIsNotDiscardedAfterGracePeriod() throws Exception {
+        final int GRACE_MINUTES = 10;
+        final Instant provisionedAt = Instant.now().minus(Duration.ofHours(3));
+        final Instant checkTime = Instant.now();
+
+        new EC2RetentionStrategy("0", Clock.fixed(checkTime.plusSeconds(1), zoneId), checkTime.toEpochMilli())
+                .check(computerWithUpTime(
+                        180,
+                        0,
+                        true,
+                        false,
+                        checkTime.minus(Duration.ofMinutes(1)).toEpochMilli(),
+                        provisionedAt.toEpochMilli(),
+                        Integer.MAX_VALUE,
+                        templateWithGracePeriod(GRACE_MINUTES, true)));
+
+        assertThat(
+                "An agent whose channel is up was discarded by the grace period",
+                graceTimeoutCalled.get(),
+                equalTo(false));
+    }
+
+    /**
+     * A cloud-level hot spare rule supplies the grace period for the labels it covers, even when
+     * the template itself configures none.
+     */
+    @Test
+    void testLabelRuleGracePeriodIsEnforcedWithoutTemplateConfiguration() throws Exception {
+        final int GRACE_MINUTES = 10;
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel("ttt");
+        rule.setGracePeriodMinutes(GRACE_MINUTES);
+        rule.setDiscardAfterGracePeriod(true);
+        // The mock agents report cloudName "cloud", which is how the strategy finds the rule.
+        EC2Cloud cloud =
+                new EC2Cloud("cloud", true, "abc", "us-east-1", null, "ghi", "20", Collections.emptyList(), null, null);
+        cloud.setHotSpareConfigsByLabel(List.of(rule));
+        r.jenkins.clouds.add(cloud);
+
+        final Instant provisionedAt = Instant.now();
+        final Instant checkTime = provisionedAt.plus(Duration.ofMinutes(GRACE_MINUTES + 1));
+
+        new EC2RetentionStrategy("0", Clock.fixed(checkTime.plusSeconds(1), zoneId), checkTime.toEpochMilli())
+                .check(computerWithUpTime(
+                        GRACE_MINUTES + 1, 0, true, false, 0L, provisionedAt.toEpochMilli(), Integer.MAX_VALUE, null));
+
+        assertThat("the label rule's grace period was not applied", graceTimeoutCalled.get(), equalTo(true));
     }
 
     @Test

--- a/src/test/java/hudson/plugins/ec2/HotSpareConfigByLabelTest.java
+++ b/src/test/java/hudson/plugins/ec2/HotSpareConfigByLabelTest.java
@@ -1,0 +1,370 @@
+package hudson.plugins.ec2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import hudson.model.Node;
+import hudson.util.FormValidation;
+import java.util.Collections;
+import java.util.List;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
+
+/**
+ * Precedence between a label hot spare rule and the template it governs. The rule wins by default;
+ * a template only takes over when the rule opts in and the template sets the value explicitly.
+ */
+@WithJenkins
+class HotSpareConfigByLabelTest {
+
+    private static final String LABEL = "ttt";
+
+    private JenkinsRule r;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        r = rule;
+    }
+
+    @Test
+    void testRuleMatchesTemplatesCarryingItsLabel() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        EC2Cloud cloud = cloud(rule, template("30", 0));
+
+        assertNotNull(cloud.getHotSpareConfigFor(computer(cloud, template("30", 0))));
+        assertNull(
+                cloud.getHotSpareConfigFor(computer(cloud, templateWithLabels("30", 0, "unrelated"))),
+                "a rule must not govern a template that does not carry its label");
+    }
+
+    @Test
+    void testLabelRuleIdleTimeoutWinsOverTemplateByDefault() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setIdleTimeoutMinutes(45);
+        EC2Cloud cloud = cloud(rule);
+
+        assertThat(cloud.resolveIdleTerminationMinutes(computer(cloud, template("30", 0))), equalTo(45));
+    }
+
+    @Test
+    void testTemplateIdleTimeoutWinsWhenOverrideIsAllowedAndSet() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setIdleTimeoutMinutes(45);
+        rule.setAllowTemplateIdleTimeoutOverride(true);
+        EC2Cloud cloud = cloud(rule);
+
+        assertThat(
+                "null keeps the retention strategy value, which came from the template",
+                cloud.resolveIdleTerminationMinutes(computer(cloud, template("30", 0))),
+                nullValue());
+    }
+
+    /**
+     * The regression guard against the override nullifying the rule: an unset template value must
+     * not beat the rule, or every default template would silently win.
+     */
+    @Test
+    void testUnsetTemplateIdleTimeoutFallsBackToRuleEvenWithOverrideAllowed() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setIdleTimeoutMinutes(45);
+        rule.setAllowTemplateIdleTimeoutOverride(true);
+        EC2Cloud cloud = cloud(rule);
+
+        assertThat(cloud.resolveIdleTerminationMinutes(computer(cloud, template(null, 0))), equalTo(45));
+        assertThat(
+                "a blank string is unset, not zero",
+                cloud.resolveIdleTerminationMinutes(computer(cloud, template("  ", 0))),
+                equalTo(45));
+    }
+
+    @Test
+    void testNoRuleLeavesTheTemplateValueInPlace() throws Exception {
+        EC2Cloud cloud = cloud(null);
+
+        assertThat(cloud.resolveIdleTerminationMinutes(computer(cloud, template("30", 7))), nullValue());
+        assertThat(cloud.resolveGracePeriodMinutes(computer(cloud, template("30", 7))), equalTo(7));
+    }
+
+    @Test
+    void testLabelRuleGracePeriodWinsOverTemplateByDefault() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setGracePeriodMinutes(20);
+        EC2Cloud cloud = cloud(rule);
+
+        assertThat(cloud.resolveGracePeriodMinutes(computer(cloud, template("30", 7))), equalTo(20));
+    }
+
+    @Test
+    void testTemplateGracePeriodWinsWhenOverrideIsAllowedAndSet() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setGracePeriodMinutes(20);
+        rule.setAllowTemplateGracePeriodOverride(true);
+        EC2Cloud cloud = cloud(rule);
+
+        assertThat(cloud.resolveGracePeriodMinutes(computer(cloud, template("30", 7))), equalTo(7));
+        assertThat(
+                "a template grace period of 0 is unset, so the rule still applies",
+                cloud.resolveGracePeriodMinutes(computer(cloud, template("30", 0))),
+                equalTo(20));
+    }
+
+    /**
+     * The discard flag has no precedence rule of its own: it comes from whichever grace period was
+     * selected, so a grace period and its behaviour are never mixed from two sources.
+     */
+    @Test
+    void testDiscardFlagFollowsTheWinningGracePeriod() throws Exception {
+        HotSpareConfigByLabel labelWins = new HotSpareConfigByLabel(LABEL);
+        labelWins.setGracePeriodMinutes(20);
+        labelWins.setDiscardAfterGracePeriod(false);
+        EC2Cloud cloudWhereLabelWins = cloud(labelWins);
+        SlaveTemplate discardingTemplate = template("30", 7);
+        discardingTemplate.setDiscardAfterGracePeriod(true);
+
+        assertThat(
+                "the label rule supplied the grace period, so it supplies the flag too",
+                cloudWhereLabelWins.resolveDiscardAfterGracePeriod(computer(cloudWhereLabelWins, discardingTemplate)),
+                equalTo(false));
+
+        HotSpareConfigByLabel templateWins = new HotSpareConfigByLabel(LABEL);
+        templateWins.setGracePeriodMinutes(20);
+        templateWins.setDiscardAfterGracePeriod(true);
+        templateWins.setAllowTemplateGracePeriodOverride(true);
+        EC2Cloud cloudWhereTemplateWins = cloud(templateWins);
+        SlaveTemplate keepingTemplate = template("30", 7);
+        keepingTemplate.setDiscardAfterGracePeriod(false);
+
+        assertThat(
+                "the template supplied the grace period, so it supplies the flag too",
+                cloudWhereTemplateWins.resolveDiscardAfterGracePeriod(
+                        computer(cloudWhereTemplateWins, keepingTemplate)),
+                equalTo(false));
+    }
+
+    @Test
+    void testIdleTerminationForLabelLooksUpByLabelName() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setIdleTimeoutMinutes(45);
+        EC2Cloud cloud = cloud(rule);
+
+        assertThat(cloud.getIdleTerminationForLabel(LABEL), equalTo(45));
+        assertThat(cloud.getIdleTerminationForLabel("other"), nullValue());
+    }
+
+    /**
+     * Renders and submits the cloud configuration page, which is the only way to catch a field of
+     * the rule that the form does not bind, or a Jelly view that does not render at all.
+     */
+    @Test
+    void testRuleSurvivesAConfigurationFormRoundtrip() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setBaseHotSpares(2);
+        rule.setScalingFactor(3);
+        rule.setMaxHotSpares(6);
+        rule.setIdleTimeoutMinutes(20);
+        rule.setGracePeriodMinutes(7);
+        rule.setDiscardAfterGracePeriod(false);
+        rule.setAllowTemplateIdleTimeoutOverride(true);
+        rule.setAllowTemplateGracePeriodOverride(true);
+
+        SlaveTemplate template = template("30", 7);
+        template.setHotSpareWeight(3);
+
+        EC2Cloud cloud = cloud(rule, template);
+        cloud.setRoundRobinTemplatesByLabel(true);
+        r.jenkins.clouds.add(cloud);
+
+        r.submit(r.createWebClient().goTo(cloud.getUrl() + "configure").getFormByName("config"));
+
+        EC2Cloud reloaded = r.jenkins.clouds.get(EC2Cloud.class);
+        assertThat(reloaded.isRoundRobinTemplatesByLabel(), equalTo(true));
+        assertThat(reloaded.getHotSpareConfigsByLabel().size(), equalTo(1));
+
+        HotSpareConfigByLabel reloadedRule =
+                reloaded.getHotSpareConfigsByLabel().get(0);
+        assertThat(reloadedRule.getLabel(), equalTo(LABEL));
+        assertThat(reloadedRule.getBaseHotSpares(), equalTo(2));
+        assertThat(reloadedRule.getScalingFactor(), equalTo(3));
+        assertThat(reloadedRule.getMaxHotSpares(), equalTo(6));
+        assertThat(reloadedRule.getIdleTimeoutMinutes(), equalTo(20));
+        assertThat(reloadedRule.getGracePeriodMinutes(), equalTo(7));
+        assertThat(reloadedRule.isDiscardAfterGracePeriod(), equalTo(false));
+        assertThat(reloadedRule.isAllowTemplateIdleTimeoutOverride(), equalTo(true));
+        assertThat(reloadedRule.isAllowTemplateGracePeriodOverride(), equalTo(true));
+
+        SlaveTemplate reloadedTemplate = reloaded.getTemplates().get(0);
+        assertThat(reloadedTemplate.getHotSpareWeight(), equalTo(3));
+        assertThat(reloadedTemplate.getGracePeriodMinutes(), equalTo(7));
+    }
+
+    /**
+     * The rules are configured above the AMIs they draw on, and the label is a text field wired to
+     * the completion endpoint rather than a drop-down.
+     */
+    @Test
+    void testTheFormPutsTheRulesBeforeTheAmisAndTypesTheLabel() throws Exception {
+        EC2Cloud cloud = cloud(new HotSpareConfigByLabel(LABEL), template("30", 0));
+        r.jenkins.clouds.add(cloud);
+
+        HtmlPage page = r.createWebClient().goTo(cloud.getUrl() + "configure");
+        String html = page.getWebResponse().getContentAsString();
+
+        assertThat(
+                "the hot spare rules should come before the list of AMIs",
+                html.indexOf("Hot spares by label"),
+                lessThan(html.indexOf("List of AMIs to be launched as agents")));
+        assertThat(html, containsString("autoCompleteLabel"));
+        assertThat(
+                "the label should be typed, so it is an input rather than a select",
+                page.getFormByName("config").getInputByName("_.label").getAttribute("type"),
+                equalTo("text"));
+    }
+
+    /**
+     * The field is free text, so it carries an expression that no drop-down could have offered.
+     */
+    @Test
+    void testALabelExpressionSurvivesAConfigurationFormRoundtrip() throws Exception {
+        String expression = LABEL + " && gpu";
+        EC2Cloud cloud = cloud(new HotSpareConfigByLabel(expression), template("30", 0));
+        r.jenkins.clouds.add(cloud);
+
+        r.submit(r.createWebClient().goTo(cloud.getUrl() + "configure").getFormByName("config"));
+
+        assertThat(
+                r.jenkins
+                        .clouds
+                        .get(EC2Cloud.class)
+                        .getHotSpareConfigsByLabel()
+                        .get(0)
+                        .getLabel(),
+                equalTo(expression));
+    }
+
+    /**
+     * The label is typed rather than picked, so the field completes it from the labels the
+     * configured templates carry, including part way through an expression.
+     */
+    @Test
+    void testLabelCompletesFromTheConfiguredTemplates() {
+        r.jenkins.clouds.add(cloud(null, template("30", 0), templateWithLabels("30", 0, "windows")));
+        HotSpareConfigByLabel.DescriptorImpl descriptor =
+                r.jenkins.getDescriptorByType(HotSpareConfigByLabel.DescriptorImpl.class);
+
+        assertThat(descriptor.doAutoCompleteLabel("").getValues(), hasItems(LABEL, "windows"));
+        assertThat(descriptor.doAutoCompleteLabel("wind").getValues(), equalTo(List.of("windows")));
+        assertThat(
+                "the term after an operator is the one being completed",
+                descriptor.doAutoCompleteLabel(LABEL + " && wind").getValues(),
+                equalTo(List.of("windows")));
+        assertThat(descriptor.doAutoCompleteLabel("nosuchlabel").getValues(), empty());
+    }
+
+    /**
+     * A label expression is a valid value, but something that cannot be parsed as one is not:
+     * Jenkins would fall back to treating it as a single label atom, which no template can carry,
+     * and the rule would silently govern nothing.
+     */
+    @Test
+    void testLabelExpressionsAreAcceptedAndUnparseableValuesAreNot() {
+        HotSpareConfigByLabel.DescriptorImpl descriptor =
+                r.jenkins.getDescriptorByType(HotSpareConfigByLabel.DescriptorImpl.class);
+
+        assertThat(descriptor.doCheckLabel(LABEL).kind, equalTo(FormValidation.Kind.OK));
+        assertThat(descriptor.doCheckLabel(LABEL + " && gpu").kind, equalTo(FormValidation.Kind.OK));
+        assertThat(descriptor.doCheckLabel("!windows").kind, equalTo(FormValidation.Kind.OK));
+        assertThat(descriptor.doCheckLabel("  ").kind, equalTo(FormValidation.Kind.ERROR));
+        assertThat(descriptor.doCheckLabel(LABEL + " &&").kind, equalTo(FormValidation.Kind.ERROR));
+    }
+
+    @Test
+    void testHotSpareConfigsDefaultToEmptyRatherThanNull() throws Exception {
+        EC2Cloud cloud = cloud(null);
+        assertThat(cloud.getHotSpareConfigsByLabel().size(), equalTo(0));
+
+        cloud.setHotSpareConfigsByLabel(null);
+        assertThat(cloud.getHotSpareConfigsByLabel().size(), equalTo(0));
+    }
+
+    private MockEC2Computer computer(EC2Cloud cloud, SlaveTemplate template) throws Exception {
+        MockEC2Computer computer = MockEC2Computer.createComputer("-precedence");
+        computer.setSlaveTemplate(template);
+        return computer;
+    }
+
+    private EC2Cloud cloud(HotSpareConfigByLabel rule, SlaveTemplate... templates) {
+        EC2Cloud cloud =
+                new EC2Cloud("test-cloud", true, "abc", "us-east-1", null, "ghi", "20", List.of(templates), null, null);
+        if (rule != null) {
+            cloud.setHotSpareConfigsByLabel(List.of(rule));
+        }
+        return cloud;
+    }
+
+    private static SlaveTemplate template(String idleTerminationMinutes, int gracePeriodMinutes) {
+        return templateWithLabels(idleTerminationMinutes, gracePeriodMinutes, LABEL);
+    }
+
+    private static SlaveTemplate templateWithLabels(
+            String idleTerminationMinutes, int gracePeriodMinutes, String labels) {
+        SlaveTemplate template = new SlaveTemplate(
+                "ami-123",
+                EC2AbstractSlave.TEST_ZONE,
+                null,
+                "default",
+                "/tmp/jenkins",
+                InstanceType.M1_LARGE.toString(),
+                false,
+                labels,
+                Node.Mode.NORMAL,
+                "AMI description",
+                "",
+                "",
+                "",
+                "1",
+                "",
+                null,
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "",
+                false,
+                "subnet-123",
+                null,
+                idleTerminationMinutes,
+                0,
+                0,
+                null,
+                "",
+                false,
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                false,
+                ConnectionStrategy.PRIVATE_DNS,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
+                EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED);
+        template.setGracePeriodMinutes(gracePeriodMinutes);
+        return template;
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/HotSpareConfigByLabelTest.java
+++ b/src/test/java/hudson/plugins/ec2/HotSpareConfigByLabelTest.java
@@ -9,16 +9,23 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import hudson.model.Node;
+import hudson.model.User;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.util.FormValidation;
 import java.util.Collections;
 import java.util.List;
+import jenkins.model.Jenkins;
 import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.springframework.security.access.AccessDeniedException;
 import software.amazon.awssdk.services.ec2.model.InstanceType;
 
 /**
@@ -286,6 +293,40 @@ class HotSpareConfigByLabelTest {
         assertThat(descriptor.doCheckLabel("!windows").kind, equalTo(FormValidation.Kind.OK));
         assertThat(descriptor.doCheckLabel("  ").kind, equalTo(FormValidation.Kind.ERROR));
         assertThat(descriptor.doCheckLabel(LABEL + " &&").kind, equalTo(FormValidation.Kind.ERROR));
+    }
+
+    /**
+     * The form endpoints are reachable by anyone who can log in, so they answer only to someone who
+     * may configure the cloud. Validation goes quiet rather than failing, which is what keeps a
+     * read-only view of the configuration usable, and completion offers nothing.
+     */
+    @Test
+    void testTheFormEndpointsTellNonAdministratorsNothing() {
+        r.jenkins.clouds.add(cloud(null, template("30", 0)));
+        HotSpareConfigByLabel.DescriptorImpl descriptor =
+                r.jenkins.getDescriptorByType(HotSpareConfigByLabel.DescriptorImpl.class);
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        r.jenkins.setAuthorizationStrategy(
+                new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().to("reader"));
+
+        try (ACLContext ignored = ACL.as2(User.getById("reader", true).impersonate2())) {
+            assertThat(descriptor.doCheckLabel(LABEL + " &&").kind, equalTo(FormValidation.Kind.OK));
+            assertThat(descriptor.doCheckScalingFactor("-1").kind, equalTo(FormValidation.Kind.OK));
+            assertThat(descriptor.doCheckBaseHotSpares("-1").kind, equalTo(FormValidation.Kind.OK));
+            assertThat(descriptor.doCheckMaxHotSpares("1", "5").kind, equalTo(FormValidation.Kind.OK));
+            assertThat(descriptor.doCheckGracePeriodMinutes("-1").kind, equalTo(FormValidation.Kind.OK));
+            assertThat(descriptor.doCheckIdleTimeoutMinutes("not a number").kind, equalTo(FormValidation.Kind.OK));
+            assertThrows(AccessDeniedException.class, () -> descriptor.doAutoCompleteLabel(""));
+        }
+
+        // The same values an administrator is told about, so the assertions above mean something.
+        assertThat(descriptor.doCheckLabel(LABEL + " &&").kind, equalTo(FormValidation.Kind.ERROR));
+        assertThat(descriptor.doCheckScalingFactor("-1").kind, equalTo(FormValidation.Kind.ERROR));
+        assertThat(descriptor.doCheckBaseHotSpares("-1").kind, equalTo(FormValidation.Kind.ERROR));
+        assertThat(descriptor.doCheckMaxHotSpares("1", "5").kind, equalTo(FormValidation.Kind.ERROR));
+        assertThat(descriptor.doCheckGracePeriodMinutes("-1").kind, equalTo(FormValidation.Kind.ERROR));
+        assertThat(descriptor.doCheckIdleTimeoutMinutes("not a number").kind, equalTo(FormValidation.Kind.ERROR));
+        assertThat(descriptor.doAutoCompleteLabel("").getValues(), hasItems(LABEL));
     }
 
     @Test

--- a/src/test/java/hudson/plugins/ec2/HotSpareDemandTest.java
+++ b/src/test/java/hudson/plugins/ec2/HotSpareDemandTest.java
@@ -7,6 +7,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,7 +73,7 @@ class HotSpareDemandTest {
 
         assertThat("nothing is asking for the label yet", demand.updateTarget(config, 0, 0, 0, 0), equalTo(0));
 
-        HotSpareDemand.spareConsumed(cloud, config);
+        HotSpareDemand.spareConsumed(cloud, LABEL);
         assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
     }
 
@@ -85,13 +86,13 @@ class HotSpareDemandTest {
     void testEveryExecutorTakenLeavesTheLabelAShortfallToReplace() {
         HotSpareConfigByLabel config = rule(0, 5, null);
         HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
-        HotSpareDemand.spareConsumed(cloud, config);
+        HotSpareDemand.spareConsumed(cloud, LABEL);
         assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
 
         // Five spares are warm, and builds start taking them one at a time.
         for (int taken = 1; taken <= 4; taken++) {
             clock.advanceSeconds(10);
-            HotSpareDemand.spareConsumed(cloud, config);
+            HotSpareDemand.spareConsumed(cloud, LABEL);
             int sparesLeft = 5 - taken;
             assertThat(
                     "the target covers the spares taken, so each one is replaced",
@@ -108,15 +109,15 @@ class HotSpareDemandTest {
     void testRunningTheSparesDryGrowsTheTarget() {
         HotSpareConfigByLabel config = rule(0, 5, null);
         HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
-        HotSpareDemand.spareConsumed(cloud, config);
+        HotSpareDemand.spareConsumed(cloud, LABEL);
         assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
 
         clock.advanceMinutes(1);
-        consume(config, 5);
+        consume(5);
         assertThat("nothing warm is left, so hold more of it", demand.updateTarget(config, 0, 5, 0, 6), equalTo(10));
 
         clock.advanceMinutes(1);
-        consume(config, 5);
+        consume(5);
         assertThat(demand.updateTarget(config, 0, 10, 0, 11), equalTo(15));
     }
 
@@ -129,12 +130,12 @@ class HotSpareDemandTest {
     void testOneBuildCannotClimbBeyondAStepOfHeadroom() {
         HotSpareConfigByLabel config = rule(0, 5, null);
         HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
-        HotSpareDemand.spareConsumed(cloud, config);
+        HotSpareDemand.spareConsumed(cloud, LABEL);
         assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
 
         for (int minute = 0; minute < 10; minute++) {
             clock.advanceMinutes(1);
-            HotSpareDemand.spareConsumed(cloud, config);
+            HotSpareDemand.spareConsumed(cloud, LABEL);
             demand.updateTarget(config, 0, 5, 0, 1);
         }
 
@@ -149,12 +150,12 @@ class HotSpareDemandTest {
     void testConcurrentBuildsGrowTheTargetOnlyAsFarAsTheirOwnNumberPlusAStep() {
         HotSpareConfigByLabel config = rule(0, 5, null);
         HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
-        HotSpareDemand.spareConsumed(cloud, config);
+        HotSpareDemand.spareConsumed(cloud, LABEL);
         assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
 
         for (int minute = 0; minute < 10; minute++) {
             clock.advanceMinutes(1);
-            consume(config, 5);
+            consume(5);
             demand.updateTarget(config, 0, 5, 0, 5);
         }
 
@@ -169,14 +170,14 @@ class HotSpareDemandTest {
     void testSparesBeingTakenWithWarmOnesLeftHoldsTheTarget() {
         HotSpareConfigByLabel config = rule(0, 5, null);
         HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
-        HotSpareDemand.spareConsumed(cloud, config);
+        HotSpareDemand.spareConsumed(cloud, LABEL);
         assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
 
         clock.advanceMinutes(5);
-        HotSpareDemand.spareConsumed(cloud, config);
+        HotSpareDemand.spareConsumed(cloud, LABEL);
         assertThat(demand.updateTarget(config, 4, 1, 0, 2), equalTo(5));
         clock.advanceMinutes(5);
-        HotSpareDemand.spareConsumed(cloud, config);
+        HotSpareDemand.spareConsumed(cloud, LABEL);
         assertThat(demand.updateTarget(config, 4, 1, 0, 3), equalTo(5));
     }
 
@@ -188,7 +189,7 @@ class HotSpareDemandTest {
         HotSpareConfigByLabel config = rule(0, 5, null);
         config.setIdleTimeoutMinutes(15);
         HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
-        HotSpareDemand.spareConsumed(cloud, config);
+        HotSpareDemand.spareConsumed(cloud, LABEL);
         assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
 
         // The last build finishes. Nothing has taken an executor since.
@@ -237,16 +238,16 @@ class HotSpareDemandTest {
         HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
 
         // Five builds running, and every spare that appears is taken straight away.
-        consume(config, 5);
+        consume(5);
         assertThat(demand.updateTarget(config, 0, 0, 0, 5), equalTo(5));
 
         clock.advanceMinutes(1);
-        consume(config, 5);
+        consume(5);
         assertThat(
                 "a step of cover above the five it is running", demand.updateTarget(config, 0, 5, 0, 5), equalTo(10));
 
         clock.advanceMinutes(1);
-        consume(config, 5);
+        consume(5);
         assertThat("and no further while the load stands still", demand.updateTarget(config, 0, 10, 0, 5), equalTo(10));
     }
 
@@ -463,9 +464,45 @@ class HotSpareDemandTest {
         assertThat(HotSpareDemand.of(cloud, LABEL).getTarget(), equalTo(10));
     }
 
-    private void consume(HotSpareConfigByLabel config, int spares) {
+    /**
+     * The count an admin asked to always be held belongs to the rule, so a label the rule covers
+     * without naming starts from nothing. Charging the floor to each covered label would multiply
+     * it by however many labels there are.
+     */
+    @Test
+    void testALabelTheRuleOnlyCoversDoesNotClaimTheFloor() {
+        HotSpareConfigByLabel config = rule(3, 5, null);
+
+        assertThat(
+                "the label the rule names holds the floor",
+                HotSpareDemand.of(cloud, LABEL).updateTarget(config, 0, 0, 0, 0),
+                equalTo(3));
+        assertThat(
+                "a label it only covers starts from nothing",
+                HotSpareDemand.of(cloud, "covered").updateTarget(config, 0, 0, 0, 0, 0),
+                equalTo(0));
+    }
+
+    /**
+     * Targets are keyed by the label a job asked for, so a controller would otherwise end up
+     * holding an entry for every label it has ever seen. A label that has faded to nothing and was
+     * not looked at is dropped; one still holding spares is kept whether or not it was.
+     */
+    @Test
+    void testFadedLabelsAreForgottenAndLiveOnesAreKept() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand.of(cloud, LABEL).updateTarget(config, 0, 0, 5, 0);
+        HotSpareDemand.of(cloud, "gone").updateTarget(config, 0, 0, 0, 0, 0);
+        HotSpareDemand.of(cloud, "quiet").updateTarget(config, 0, 0, 0, 0, 0);
+
+        HotSpareDemand.forgetZeroed(cloud, Set.of("quiet"));
+
+        assertThat(HotSpareDemand.trackedLabels(cloud), equalTo(Set.of(LABEL, "quiet")));
+    }
+
+    private void consume(int spares) {
         for (int i = 0; i < spares; i++) {
-            HotSpareDemand.spareConsumed(cloud, config);
+            HotSpareDemand.spareConsumed(cloud, LABEL);
         }
     }
 

--- a/src/test/java/hudson/plugins/ec2/HotSpareDemandTest.java
+++ b/src/test/java/hudson/plugins/ec2/HotSpareDemandTest.java
@@ -1,0 +1,512 @@
+package hudson.plugins.ec2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The spare target as a load prediction: it climbs while the label cannot keep up, holds while the
+ * label is being served, and fades back to the base count once the work stops.
+ */
+class HotSpareDemandTest {
+
+    private static final String LABEL = "linux";
+
+    private MovableClock clock;
+    private EC2Cloud cloud;
+
+    @BeforeEach
+    void setUp() {
+        clock = new MovableClock();
+        HotSpareDemand.clock = clock;
+        HotSpareDemand.reset();
+        cloud = new EC2Cloud("test-cloud", true, "abc", "us-east-1", null, "ghi", "20", List.of(), null, null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        HotSpareDemand.clock = Clock.systemDefaultZone();
+        HotSpareDemand.reset();
+    }
+
+    /**
+     * The reported behaviour: a step of 5 has to mean five spares held for as long as the label is
+     * busy, not five agents handed out once. A spare running a build is not a spare, so the target
+     * stays where it is and the shortfall is reported again.
+     */
+    @Test
+    void testTheTargetIsHeldWhileTheSparesAreBeingConsumed() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        // Five builds arrive with nothing warm to take them.
+        assertThat(demand.updateTarget(config, 0, 0, 5, 0), equalTo(5));
+
+        // They are all running now, so the label holds no spares at all and needs five again.
+        clock.advanceMinutes(1);
+        assertThat(demand.updateTarget(config, 0, 0, 0, 5), equalTo(5));
+        clock.advanceMinutes(1);
+        assertThat(
+                "the target must not fade while the label is doing work",
+                demand.updateTarget(config, 0, 5, 0, 5),
+                equalTo(5));
+    }
+
+    /**
+     * A label nobody has asked for costs nothing, so the first build to take an executor is what
+     * warms it up. Nothing is queued and nothing is waiting at that point: the build in question
+     * already has its agent. The spares are for the builds after it.
+     */
+    @Test
+    void testTakingAnExecutorWarmsTheLabelUpFromNothing() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat("nothing is asking for the label yet", demand.updateTarget(config, 0, 0, 0, 0), equalTo(0));
+
+        HotSpareDemand.spareConsumed(cloud, config);
+        assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
+    }
+
+    /**
+     * The point of reacting to an executor being taken: the pool is one short the moment a build
+     * starts, and the target says so, so the replacement is provisioned while that build runs
+     * rather than after the next build has already had to wait.
+     */
+    @Test
+    void testEveryExecutorTakenLeavesTheLabelAShortfallToReplace() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+        HotSpareDemand.spareConsumed(cloud, config);
+        assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
+
+        // Five spares are warm, and builds start taking them one at a time.
+        for (int taken = 1; taken <= 4; taken++) {
+            clock.advanceSeconds(10);
+            HotSpareDemand.spareConsumed(cloud, config);
+            int sparesLeft = 5 - taken;
+            assertThat(
+                    "the target covers the spares taken, so each one is replaced",
+                    demand.updateTarget(config, sparesLeft, taken, 0, taken),
+                    equalTo(5));
+        }
+    }
+
+    /**
+     * Builds taking the last of the spares means the replacements are not arriving fast enough, so
+     * the label climbs a step even though no build has had to queue for it yet.
+     */
+    @Test
+    void testRunningTheSparesDryGrowsTheTarget() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+        HotSpareDemand.spareConsumed(cloud, config);
+        assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
+
+        clock.advanceMinutes(1);
+        consume(config, 5);
+        assertThat("nothing warm is left, so hold more of it", demand.updateTarget(config, 0, 5, 0, 6), equalTo(10));
+
+        clock.advanceMinutes(1);
+        consume(config, 5);
+        assertThat(demand.updateTarget(config, 0, 10, 0, 11), equalTo(15));
+    }
+
+    /**
+     * One build taking spare after spare is not evidence of five builds' worth of demand, however
+     * long it goes on for. Growth stops one step above the work actually in sight, so a saturated
+     * label tracks its concurrency plus a step of cover rather than climbing without limit.
+     */
+    @Test
+    void testOneBuildCannotClimbBeyondAStepOfHeadroom() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+        HotSpareDemand.spareConsumed(cloud, config);
+        assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
+
+        for (int minute = 0; minute < 10; minute++) {
+            clock.advanceMinutes(1);
+            HotSpareDemand.spareConsumed(cloud, config);
+            demand.updateTarget(config, 0, 5, 0, 1);
+        }
+
+        assertThat("one busy agent plus a step of cover", demand.getTarget(), equalTo(6));
+    }
+
+    /**
+     * Five builds of the same job saturating the label is real demand, so the target follows it,
+     * but still only as far as that demand plus a step.
+     */
+    @Test
+    void testConcurrentBuildsGrowTheTargetOnlyAsFarAsTheirOwnNumberPlusAStep() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+        HotSpareDemand.spareConsumed(cloud, config);
+        assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
+
+        for (int minute = 0; minute < 10; minute++) {
+            clock.advanceMinutes(1);
+            consume(config, 5);
+            demand.updateTarget(config, 0, 5, 0, 5);
+        }
+
+        assertThat("five busy agents plus a step of cover", demand.getTarget(), equalTo(10));
+    }
+
+    /**
+     * Spares being taken while others stay warm is exactly what the label is meant to do, so the
+     * target holds instead of climbing.
+     */
+    @Test
+    void testSparesBeingTakenWithWarmOnesLeftHoldsTheTarget() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+        HotSpareDemand.spareConsumed(cloud, config);
+        assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
+
+        clock.advanceMinutes(5);
+        HotSpareDemand.spareConsumed(cloud, config);
+        assertThat(demand.updateTarget(config, 4, 1, 0, 2), equalTo(5));
+        clock.advanceMinutes(5);
+        HotSpareDemand.spareConsumed(cloud, config);
+        assertThat(demand.updateTarget(config, 4, 1, 0, 3), equalTo(5));
+    }
+
+    /**
+     * The builds stop, so the label goes back to costing nothing.
+     */
+    @Test
+    void testALabelThatStopsBeingUsedFadesAway() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        config.setIdleTimeoutMinutes(15);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+        HotSpareDemand.spareConsumed(cloud, config);
+        assertThat(demand.updateTarget(config, 0, 0, 0, 1), equalTo(5));
+
+        // The last build finishes. Nothing has taken an executor since.
+        assertThat(demand.updateTarget(config, 5, 0, 0, 0), equalTo(5));
+        clock.advanceMinutes(15);
+        assertThat(demand.updateTarget(config, 5, 0, 0, 0), equalTo(0));
+    }
+
+    /**
+     * The demand of a big parallel build is measurable the moment its branches queue up, so the
+     * target goes straight to it. Climbing there a step per minute would leave nineteen of twenty
+     * branches waiting for the first four minutes, which is the opposite of the point.
+     */
+    @Test
+    void testABigParallelBuildRaisesTheTargetToItsWholeWidthAtOnce() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat(demand.updateTarget(config, 0, 0, 20, 0), equalTo(20));
+    }
+
+    /**
+     * The load, not the step, is what the target follows once the label is in use, whether the work
+     * is queued or already running.
+     */
+    @Test
+    void testTheTargetFollowsTheLoadUpAndTheStepIsOnlyItsFloor() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat(
+                "less work in sight than a step: the step wins", demand.updateTarget(config, 0, 0, 2, 0), equalTo(5));
+        assertThat("eight branches waiting", demand.updateTarget(config, 0, 5, 8, 0), equalTo(8));
+        assertThat("and now they are running", demand.updateTarget(config, 0, 0, 0, 8), equalTo(8));
+        assertThat("a second job joins them", demand.updateTarget(config, 0, 8, 6, 8), equalTo(14));
+    }
+
+    /**
+     * Following the load covers the work in sight. This covers the work that has not arrived yet: a
+     * label whose spares are taken the instant they appear is given one step more than its load,
+     * and no more, because a load that is not growing is not evidence of anything beyond that.
+     */
+    @Test
+    void testALabelThatKeepsRunningDryIsGivenAStepMoreThanItsLoad() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        // Five builds running, and every spare that appears is taken straight away.
+        consume(config, 5);
+        assertThat(demand.updateTarget(config, 0, 0, 0, 5), equalTo(5));
+
+        clock.advanceMinutes(1);
+        consume(config, 5);
+        assertThat(
+                "a step of cover above the five it is running", demand.updateTarget(config, 0, 5, 0, 5), equalTo(10));
+
+        clock.advanceMinutes(1);
+        consume(config, 5);
+        assertThat("and no further while the load stands still", demand.updateTarget(config, 0, 10, 0, 5), equalTo(10));
+    }
+
+    /**
+     * Growth is what the instances already on their way cannot cover, so once they can, the target
+     * settles instead of chasing the queue.
+     */
+    @Test
+    void testTheTargetSettlesOnceTheInstancesOnTheirWayCoverTheQueue() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat(demand.updateTarget(config, 0, 0, 3, 0), equalTo(5));
+        clock.advanceMinutes(1);
+        assertThat(demand.updateTarget(config, 0, 5, 3, 0), equalTo(5));
+        clock.advanceMinutes(1);
+        assertThat(demand.updateTarget(config, 5, 0, 3, 0), equalTo(5));
+    }
+
+    /**
+     * A pass runs every time a build starts, so the same load seen several times over must not read
+     * as more load. The measured part of the target is idempotent and the cover is rate-limited.
+     */
+    @Test
+    void testRepeatedChecksWithTheSameLoadDoNotKeepClimbing() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat(demand.updateTarget(config, 0, 0, 50, 0), equalTo(50));
+        clock.advanceSeconds(5);
+        assertThat(demand.updateTarget(config, 0, 50, 50, 0), equalTo(50));
+        clock.advanceSeconds(5);
+        assertThat(demand.updateTarget(config, 0, 50, 50, 0), equalTo(50));
+
+        clock.advanceMinutes(1);
+        assertThat(
+                "a minute on with the queue still unserved, so a step of cover",
+                demand.updateTarget(config, 0, 0, 50, 0),
+                equalTo(55));
+    }
+
+    /**
+     * With nothing asking for the label, the target gives up a step per idle timeout until the
+     * label costs nothing.
+     */
+    @Test
+    void testAQuietLabelFadesToTheBaseCount() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        config.setIdleTimeoutMinutes(15);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat(demand.updateTarget(config, 0, 0, 10, 0), equalTo(10));
+
+        // The work stops. The first quiet check only starts the clock.
+        assertThat(demand.updateTarget(config, 10, 0, 0, 0), equalTo(10));
+        clock.advanceMinutes(14);
+        assertThat("not a whole idle timeout yet", demand.updateTarget(config, 10, 0, 0, 0), equalTo(10));
+        clock.advanceMinutes(1);
+        assertThat(demand.updateTarget(config, 10, 0, 0, 0), equalTo(5));
+        clock.advanceMinutes(15);
+        assertThat(demand.updateTarget(config, 5, 0, 0, 0), equalTo(0));
+        clock.advanceMinutes(15);
+        assertThat("the base count is the floor", demand.updateTarget(config, 0, 0, 0, 0), equalTo(0));
+    }
+
+    @Test
+    void testAQuietLabelFadesNoFurtherThanItsBaseCount() {
+        HotSpareConfigByLabel config = rule(2, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat(
+                "the base count applies before anything is asked of the label",
+                demand.updateTarget(config, 0, 0, 0, 0),
+                equalTo(2));
+        assertThat(demand.updateTarget(config, 0, 0, 4, 0), equalTo(7));
+
+        clock.advanceMinutes(15);
+        assertThat(demand.updateTarget(config, 7, 0, 0, 0), equalTo(7));
+        clock.advanceMinutes(15);
+        assertThat(demand.updateTarget(config, 7, 0, 0, 0), equalTo(2));
+        clock.advanceMinutes(30);
+        assertThat(demand.updateTarget(config, 2, 0, 0, 0), equalTo(2));
+    }
+
+    /**
+     * A burst teaches the label a peak that later work does not justify. The target has to fade
+     * back towards the work still in sight, otherwise the spares it holds would never be reclaimed:
+     * the idle timeout only releases the agents the target has given up on.
+     */
+    @Test
+    void testTheTargetFadesTowardsTheLoadWhileTheLabelStaysBusy() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat("a twenty-branch burst", demand.updateTarget(config, 0, 0, 20, 0), equalTo(20));
+
+        // The burst is over, but two builds keep the label in use. The first pass only starts the clock.
+        assertThat(demand.updateTarget(config, 18, 0, 0, 2), equalTo(20));
+        clock.advanceMinutes(14);
+        assertThat("not a whole idle timeout yet", demand.updateTarget(config, 18, 0, 0, 2), equalTo(20));
+        clock.advanceMinutes(1);
+        assertThat(demand.updateTarget(config, 18, 0, 0, 2), equalTo(15));
+        clock.advanceMinutes(15);
+        assertThat(demand.updateTarget(config, 13, 0, 0, 2), equalTo(10));
+        clock.advanceMinutes(15);
+        assertThat(demand.updateTarget(config, 8, 0, 0, 2), equalTo(5));
+        clock.advanceMinutes(15);
+        assertThat(
+                "one step is the floor while the label is in use", demand.updateTarget(config, 3, 0, 0, 2), equalTo(5));
+    }
+
+    /**
+     * Work picking back up during the fade takes the target with it, so a label that is busy again
+     * does not carry on giving up spares it is about to need.
+     */
+    @Test
+    void testWorkComingBackDuringTheFadeStopsIt() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat(demand.updateTarget(config, 0, 0, 20, 0), equalTo(20));
+        assertThat(demand.updateTarget(config, 18, 0, 0, 2), equalTo(20));
+        clock.advanceMinutes(15);
+        assertThat(demand.updateTarget(config, 18, 0, 0, 2), equalTo(15));
+
+        clock.advanceMinutes(15);
+        assertThat("eighteen running builds", demand.updateTarget(config, 0, 0, 0, 18), equalTo(18));
+        clock.advanceMinutes(15);
+        assertThat("the fade restarts from the new peak", demand.updateTarget(config, 0, 0, 0, 18), equalTo(18));
+    }
+
+    @Test
+    void testTheCeilingLimitsHowFarTheTargetCanGrow() {
+        HotSpareConfigByLabel config = rule(0, 5, 7);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat("forty queued builds, but seven is the limit", demand.updateTarget(config, 0, 0, 40, 0), equalTo(7));
+        clock.advanceMinutes(1);
+        assertThat(demand.updateTarget(config, 0, 7, 40, 0), equalTo(7));
+    }
+
+    /**
+     * A label whose templates are all at their instance caps never keeps up, so growth has to stop
+     * at the work in sight. Otherwise the target would climb for as long as the caps held and then
+     * try to launch that imagined backlog as soon as capacity appeared.
+     */
+    @Test
+    void testGrowthStopsAtTheWorkInSight() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        for (int minute = 0; minute < 10; minute++) {
+            demand.updateTarget(config, 0, 0, 2, 0);
+            clock.advanceMinutes(1);
+        }
+
+        assertThat("two queued builds plus a step of cover", demand.getTarget(), equalTo(7));
+    }
+
+    /**
+     * A rule with no step still follows its load; the step only sets how much cover it gets on top,
+     * and one is the least that can move at all.
+     */
+    @Test
+    void testARuleWithNoStepStillFollowsItsLoadAndCoversItByOne() {
+        HotSpareConfigByLabel config = rule(0, 0, null);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat(demand.updateTarget(config, 0, 0, 10, 0), equalTo(10));
+        clock.advanceMinutes(1);
+        assertThat(demand.updateTarget(config, 0, 0, 10, 0), equalTo(11));
+    }
+
+    /**
+     * Agents that are never idle-terminated have no rate to follow, so the fade falls back to the
+     * default idle timeout rather than never happening.
+     */
+    @Test
+    void testALabelWhoseAgentsNeverTimeOutStillFades() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        config.setIdleTimeoutMinutes(0);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat(demand.updateTarget(config, 0, 0, 5, 0), equalTo(5));
+        assertThat(demand.updateTarget(config, 5, 0, 0, 0), equalTo(5));
+        clock.advanceMinutes(HotSpareConfigByLabel.DEFAULT_IDLE_TIMEOUT_MINUTES);
+        assertThat(demand.updateTarget(config, 5, 0, 0, 0), equalTo(0));
+    }
+
+    /**
+     * A negative idle timeout is a billing-period timeout, whose magnitude is still the rate the
+     * agents disappear at.
+     */
+    @Test
+    void testABillingPeriodIdleTimeoutFadesAtItsOwnRate() {
+        HotSpareConfigByLabel config = rule(0, 5, null);
+        config.setIdleTimeoutMinutes(-10);
+        HotSpareDemand demand = HotSpareDemand.of(cloud, LABEL);
+
+        assertThat(demand.updateTarget(config, 0, 0, 5, 0), equalTo(5));
+        assertThat(demand.updateTarget(config, 5, 0, 0, 0), equalTo(5));
+        clock.advanceMinutes(10);
+        assertThat(demand.updateTarget(config, 5, 0, 0, 0), equalTo(0));
+    }
+
+    @Test
+    void testEachLabelIsPredictedSeparately() {
+        HotSpareConfigByLabel linux = rule(0, 5, null);
+        HotSpareConfigByLabel windows = new HotSpareConfigByLabel("windows");
+        windows.setScalingFactor(2);
+
+        assertThat(HotSpareDemand.of(cloud, LABEL).updateTarget(linux, 0, 0, 10, 0), equalTo(10));
+        assertThat(HotSpareDemand.of(cloud, "windows").updateTarget(windows, 0, 0, 3, 0), equalTo(3));
+        assertThat(HotSpareDemand.of(cloud, LABEL).getTarget(), equalTo(10));
+    }
+
+    private void consume(HotSpareConfigByLabel config, int spares) {
+        for (int i = 0; i < spares; i++) {
+            HotSpareDemand.spareConsumed(cloud, config);
+        }
+    }
+
+    private static HotSpareConfigByLabel rule(int baseHotSpares, int step, Integer maxHotSpares) {
+        HotSpareConfigByLabel config = new HotSpareConfigByLabel(LABEL);
+        config.setBaseHotSpares(baseHotSpares);
+        config.setScalingFactor(step);
+        config.setMaxHotSpares(maxHotSpares);
+        return config;
+    }
+
+    private static final class MovableClock extends Clock {
+
+        private long millis = TimeUnit.DAYS.toMillis(1);
+
+        void advanceMinutes(long minutes) {
+            millis += TimeUnit.MINUTES.toMillis(minutes);
+        }
+
+        void advanceSeconds(long seconds) {
+            millis += TimeUnit.SECONDS.toMillis(seconds);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.systemDefault();
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return Instant.ofEpochMilli(millis);
+        }
+
+        @Override
+        public long millis() {
+            return millis;
+        }
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/LabelTemplateRotationTest.java
+++ b/src/test/java/hudson/plugins/ec2/LabelTemplateRotationTest.java
@@ -24,8 +24,10 @@ class LabelTemplateRotationTest {
 
     private boolean enabled = true;
 
+    private boolean saturateHighestWeightFirst = false;
+
     private LabelTemplateRotation rotation() {
-        return new LabelTemplateRotation(() -> enabled);
+        return new LabelTemplateRotation(() -> enabled, () -> saturateHighestWeightFirst);
     }
 
     /**
@@ -56,8 +58,9 @@ class LabelTemplateRotationTest {
     }
 
     /**
-     * Weights 3 and 1 pick the heavier template three times as often, and the picks interleave
-     * instead of bursting, which is what makes the fallback to the lighter template fast.
+     * By default a weight is a share of the requests: weights 3 and 1 pick the heavier template
+     * three times as often, and the picks interleave instead of bursting, which is what makes the
+     * fallback to the lighter template fast.
      */
     @Test
     void testWeightedRotationInterleavesPicks() {
@@ -71,6 +74,82 @@ class LabelTemplateRotationTest {
                 "the heavier template should lead six of eight requests",
                 heads.stream().filter("spot"::equals).count(),
                 equalTo(6L));
+    }
+
+    /**
+     * Saturating the highest weight first turns the same weights into a ranking: the heavier
+     * template leads every request rather than three out of four, and the lighter one stays behind
+     * it as the fallback for the request.
+     */
+    @Test
+    void testSaturatingHighestWeightKeepsTheHeaviestLeading() {
+        saturateHighestWeightFirst = true;
+        LabelTemplateRotation rotation = rotation();
+        List<SlaveTemplate> group = List.of(template("spot", 3), template("ondemand", 1));
+
+        for (int i = 0; i < 8; i++) {
+            assertThat(descriptions(rotation.order(LABEL, group)), contains("spot", "ondemand"));
+        }
+    }
+
+    /**
+     * Templates sharing a weight are one band and still take turns, so a label spreads over the
+     * instance types an admin considers equivalent instead of concentrating on the first one.
+     */
+    @Test
+    void testSaturatingHighestWeightRotatesWithinABand() {
+        saturateHighestWeightFirst = true;
+        LabelTemplateRotation rotation = rotation();
+        List<SlaveTemplate> group = List.of(template("spot a", 3), template("spot b", 3), template("ondemand", 1));
+
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("spot a", "spot b", "ondemand"));
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("spot b", "spot a", "ondemand"));
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("spot a", "spot b", "ondemand"));
+    }
+
+    /**
+     * Bands are ordered by weight rather than by configuration, so the fallback within a request
+     * always walks down the ranking.
+     */
+    @Test
+    void testSaturatingHighestWeightOrdersEveryBandByWeight() {
+        saturateHighestWeightFirst = true;
+        LabelTemplateRotation rotation = rotation();
+        List<SlaveTemplate> group = List.of(template("light", 1), template("heavy", 5), template("middle", 3));
+
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("heavy", "middle", "light"));
+    }
+
+    /**
+     * The next band down leads only once every template above it is cooling down, which is what
+     * makes an exhausted instance type hand the label over rather than share it.
+     */
+    @Test
+    void testSaturatingHighestWeightFallsToTheNextBandOnceTheTopIsCoolingDown() {
+        saturateHighestWeightFirst = true;
+        LabelTemplateRotation rotation = rotation();
+        SlaveTemplate spotA = template("spot a", 3);
+        SlaveTemplate spotB = template("spot b", 3);
+        SlaveTemplate onDemand = template("ondemand", 1);
+        List<SlaveTemplate> group = List.of(spotA, spotB, onDemand);
+
+        rotation.markTemplateUnavailable(spotA, group.size());
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("spot b", "ondemand", "spot a"));
+
+        rotation.markTemplateUnavailable(spotB, group.size());
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("ondemand", "spot a", "spot b"));
+    }
+
+    /**
+     * A weight of zero remains a last resort under the ranking as well.
+     */
+    @Test
+    void testSaturatingHighestWeightKeepsZeroWeightLast() {
+        saturateHighestWeightFirst = true;
+        LabelTemplateRotation rotation = rotation();
+        List<SlaveTemplate> group = List.of(template("lastResort", 0), template("preferred", 1));
+
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("preferred", "lastResort"));
     }
 
     /**

--- a/src/test/java/hudson/plugins/ec2/LabelTemplateRotationTest.java
+++ b/src/test/java/hudson/plugins/ec2/LabelTemplateRotationTest.java
@@ -1,0 +1,280 @@
+package hudson.plugins.ec2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import hudson.model.Node;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
+
+class LabelTemplateRotationTest {
+
+    private static final ZoneId ZONE_ID = ZoneId.systemDefault();
+    private static final String LABEL = "linux";
+
+    private boolean enabled = true;
+
+    private LabelTemplateRotation rotation() {
+        return new LabelTemplateRotation(() -> enabled);
+    }
+
+    /**
+     * Equal weights give plain round-robin: over one full cycle every template leads exactly once.
+     */
+    @Test
+    void testEqualWeightsLeadOnceEachPerCycle() {
+        LabelTemplateRotation rotation = rotation();
+        List<SlaveTemplate> group = List.of(template("a", 1), template("b", 1), template("c", 1));
+
+        List<String> heads = heads(rotation, group, 3);
+
+        assertThat(heads, contains("a", "b", "c"));
+    }
+
+    /**
+     * The full order is returned every time, so a caller can fall back to the remaining templates
+     * within the same provisioning request.
+     */
+    @Test
+    void testOrderContainsWholeGroupRotatedAroundTheHead() {
+        LabelTemplateRotation rotation = rotation();
+        List<SlaveTemplate> group = List.of(template("a", 1), template("b", 1), template("c", 1));
+
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("a", "b", "c"));
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("b", "c", "a"));
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("c", "a", "b"));
+    }
+
+    /**
+     * Weights 3 and 1 pick the heavier template three times as often, and the picks interleave
+     * instead of bursting, which is what makes the fallback to the lighter template fast.
+     */
+    @Test
+    void testWeightedRotationInterleavesPicks() {
+        LabelTemplateRotation rotation = rotation();
+        List<SlaveTemplate> group = List.of(template("spot", 3), template("ondemand", 1));
+
+        List<String> heads = heads(rotation, group, 8);
+
+        assertThat(heads, contains("spot", "spot", "ondemand", "spot", "spot", "spot", "ondemand", "spot"));
+        assertThat(
+                "the heavier template should lead six of eight requests",
+                heads.stream().filter("spot"::equals).count(),
+                equalTo(6L));
+    }
+
+    /**
+     * A weight of zero excludes a template from the rotation while any other template is available.
+     */
+    @Test
+    void testZeroWeightNeverLeadsWhileOthersAreAvailable() {
+        LabelTemplateRotation rotation = rotation();
+        List<SlaveTemplate> group = List.of(template("preferred", 1), template("lastResort", 0));
+
+        List<String> heads = heads(rotation, group, 5);
+
+        assertThat(heads, contains("preferred", "preferred", "preferred", "preferred", "preferred"));
+    }
+
+    /**
+     * ... but it is used once every other template in the group is cooling down, rather than
+     * leaving the label with nothing to provision from.
+     */
+    @Test
+    void testZeroWeightIsUsedWhenEveryOtherTemplateIsCoolingDown() {
+        LabelTemplateRotation rotation = rotation();
+        SlaveTemplate preferred = template("preferred", 1);
+        SlaveTemplate lastResort = template("lastResort", 0);
+        List<SlaveTemplate> group = List.of(preferred, lastResort);
+
+        rotation.markTemplateUnavailable(preferred, group.size());
+
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("lastResort", "preferred"));
+    }
+
+    /**
+     * A template that reported insufficient capacity is demoted to the end of the order, and
+     * returns to its normal position once the cooldown elapses.
+     */
+    @Test
+    void testCapacityCooldownDemotesTemplateUntilItExpires() {
+        Instant now = Instant.now();
+        LabelTemplateRotation rotation = rotation();
+        rotation.setClock(Clock.fixed(now, ZONE_ID));
+        SlaveTemplate a = template("a", 1);
+        SlaveTemplate b = template("b", 1);
+        List<SlaveTemplate> group = List.of(a, b);
+
+        rotation.markTemplateUnavailable(a, group.size());
+        assertThat(rotation.isTemplateInCooldown(a, group.size()), equalTo(true));
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("b", "a"));
+
+        rotation.setClock(Clock.fixed(
+                now.plus(Duration.ofMillis(LabelTemplateRotation.DEFAULT_TEMPLATE_CAPACITY_COOLDOWN_MILLIS + 1)),
+                ZONE_ID));
+        assertFalse(rotation.isTemplateInCooldown(a, group.size()), "the cooldown should have expired");
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("a", "b"));
+    }
+
+    /**
+     * When every template is cooling down the full group is still returned, so a launch is
+     * attempted rather than refused.
+     */
+    @Test
+    void testAllTemplatesCoolingDownStillReturnsTheWholeGroup() {
+        LabelTemplateRotation rotation = rotation();
+        SlaveTemplate a = template("a", 1);
+        SlaveTemplate b = template("b", 1);
+        List<SlaveTemplate> group = List.of(a, b);
+
+        rotation.markTemplateUnavailable(a, group.size());
+        rotation.markTemplateUnavailable(b, group.size());
+
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("a", "b"));
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("b", "a"));
+    }
+
+    /**
+     * A label served by a single template has nothing to fail over to, so the cooldown must not
+     * engage: the template keeps retrying across its own availability zones.
+     */
+    @Test
+    void testSingleTemplateGroupIsNeverCooledDown() {
+        LabelTemplateRotation rotation = rotation();
+        SlaveTemplate only = template("only", 1);
+        List<SlaveTemplate> group = List.of(only);
+
+        rotation.markTemplateUnavailable(only, group.size());
+        rotation.markTemplateUnavailable(only, group.size());
+
+        assertFalse(rotation.isTemplateInCooldown(only, group.size()), "a lone template must stay in rotation");
+        assertThat(descriptions(rotation.order(LABEL, group)), contains("only"));
+    }
+
+    /**
+     * With the cloud-level flag off, the configured order is returned untouched and no cooldown is
+     * recorded, so the default behaviour is fully deterministic.
+     */
+    @Test
+    void testRotationDisabledPreservesConfiguredOrder() {
+        enabled = false;
+        LabelTemplateRotation rotation = rotation();
+        SlaveTemplate a = template("a", 1);
+        SlaveTemplate b = template("b", 3);
+        SlaveTemplate c = template("c", 1);
+        List<SlaveTemplate> group = List.of(a, b, c);
+
+        rotation.markTemplateUnavailable(b, group.size());
+
+        assertFalse(rotation.isTemplateInCooldown(b, group.size()), "no cooldown should apply when rotation is off");
+        for (int i = 0; i < 3; i++) {
+            assertThat(descriptions(rotation.order(LABEL, group)), contains("a", "b", "c"));
+        }
+    }
+
+    /**
+     * Rotation state is per label, so a request for one label does not advance another's cursor.
+     */
+    @Test
+    void testRotationStateIsPerLabel() {
+        LabelTemplateRotation rotation = rotation();
+        List<SlaveTemplate> group = List.of(template("a", 1), template("b", 1));
+
+        assertThat(descriptions(rotation.order("linux", group)), contains("a", "b"));
+        assertThat(descriptions(rotation.order("windows", group)), contains("a", "b"));
+        assertThat(descriptions(rotation.order("linux", group)), contains("b", "a"));
+    }
+
+    /**
+     * A template saved before the weight existed must read as weight 1, not 0, which would exclude
+     * it from the rotation on upgrade.
+     */
+    @Test
+    void testHotSpareWeightDefaultsToOneAndRejectsNegatives() {
+        SlaveTemplate template = template("unset");
+        assertThat(template.getHotSpareWeight(), equalTo(1));
+
+        template.setHotSpareWeight(0);
+        assertThat(template.getHotSpareWeight(), equalTo(0));
+
+        template.setHotSpareWeight(-5);
+        assertThat(template.getHotSpareWeight(), equalTo(0));
+    }
+
+    private List<String> heads(LabelTemplateRotation rotation, List<SlaveTemplate> group, int requests) {
+        List<String> heads = new ArrayList<>(requests);
+        for (int i = 0; i < requests; i++) {
+            heads.add(rotation.order(LABEL, group).get(0).getDescription());
+        }
+        return heads;
+    }
+
+    private static List<String> descriptions(List<SlaveTemplate> templates) {
+        return templates.stream().map(SlaveTemplate::getDescription).collect(Collectors.toList());
+    }
+
+    private static SlaveTemplate template(String description, int hotSpareWeight) {
+        SlaveTemplate template = template(description);
+        template.setHotSpareWeight(hotSpareWeight);
+        return template;
+    }
+
+    private static SlaveTemplate template(String description) {
+        return new SlaveTemplate(
+                "ami-123",
+                EC2AbstractSlave.TEST_ZONE,
+                null,
+                "default",
+                "/tmp/jenkins",
+                InstanceType.M1_LARGE.toString(),
+                false,
+                LABEL + " windows",
+                Node.Mode.NORMAL,
+                description,
+                "",
+                "",
+                "",
+                "1",
+                "",
+                null,
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "",
+                false,
+                "subnet-123",
+                null,
+                null,
+                0,
+                0,
+                null,
+                "",
+                false,
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                false,
+                ConnectionStrategy.PRIVATE_DNS,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
+                EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED);
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/MockEC2Computer.java
+++ b/src/test/java/hudson/plugins/ec2/MockEC2Computer.java
@@ -18,7 +18,11 @@ public class MockEC2Computer extends EC2Computer {
 
     private final EC2AbstractSlave slave;
 
-    private final SlaveTemplate slaveTemplate;
+    private SlaveTemplate slaveTemplate;
+
+    private long onlineSinceMillis;
+
+    private long provisionRequestedAtMillis;
 
     public MockEC2Computer(EC2AbstractSlave slave) {
         super(slave);
@@ -141,6 +145,28 @@ public class MockEC2Computer extends EC2Computer {
     @Override
     public SlaveTemplate getSlaveTemplate() {
         return slaveTemplate;
+    }
+
+    public void setSlaveTemplate(SlaveTemplate slaveTemplate) {
+        this.slaveTemplate = slaveTemplate;
+    }
+
+    @Override
+    public long getOnlineSinceMillis() {
+        return onlineSinceMillis;
+    }
+
+    public void setOnlineSinceMillis(long onlineSinceMillis) {
+        this.onlineSinceMillis = onlineSinceMillis;
+    }
+
+    @Override
+    public long getProvisionRequestedAtMillis() {
+        return provisionRequestedAtMillis == 0 ? super.getProvisionRequestedAtMillis() : provisionRequestedAtMillis;
+    }
+
+    public void setProvisionRequestedAtMillis(long provisionRequestedAtMillis) {
+        this.provisionRequestedAtMillis = provisionRequestedAtMillis;
     }
 
     public void setState(InstanceState state) {

--- a/src/test/java/hudson/plugins/ec2/util/AmazonEC2FactoryMockImpl.java
+++ b/src/test/java/hudson/plugins/ec2/util/AmazonEC2FactoryMockImpl.java
@@ -228,42 +228,47 @@ public class AmazonEC2FactoryMockImpl implements AmazonEC2Factory {
     }
 
     private static void mockRunInstances(Ec2Client mock) {
-        Mockito.doAnswer(invocationOnMock -> {
-                    RunInstancesRequest request = invocationOnMock.getArgument(0);
-                    List<Tag> tags = request.tagSpecifications().stream()
-                            .map(TagSpecification::tags)
-                            .flatMap(List::stream)
-                            .collect(Collectors.toList());
-
-                    List<Instance> localInstances = new ArrayList<>();
-
-                    for (int i = 0; i < request.maxCount(); i++) {
-                        Instance instance = Instance.builder()
-                                .instanceId(String.valueOf(Math.random()))
-                                .instanceType(request.instanceType())
-                                .imageId(request.imageId())
-                                .tags(tags)
-                                .state(InstanceState.builder()
-                                        .name(InstanceStateName.RUNNING)
-                                        .build())
-                                .launchTime(Instant.now())
-                                .build();
-
-                        localInstances.add(instance);
-                    }
-
-                    instances.addAll(localInstances);
-
-                    return RunInstancesResponse.builder()
-                            .reservationId(Reservation.builder()
-                                    .instances(localInstances)
-                                    .build()
-                                    .reservationId())
-                            .instances(localInstances)
-                            .build();
-                })
+        Mockito.doAnswer(invocationOnMock -> launchInstances(invocationOnMock.getArgument(0)))
                 .when(mock)
                 .runInstances(Mockito.any(RunInstancesRequest.class));
+    }
+
+    /**
+     * The default launch behaviour: every instance the request asked for, recorded in
+     * {@link #instances}. Exposed so a test narrowing {@code runInstances} for one instance type
+     * can still launch through it, for instance with a reduced count to stand in for a spot pool
+     * that can only part-fill a request.
+     */
+    public static RunInstancesResponse launchInstances(RunInstancesRequest request) {
+        List<Tag> tags = request.tagSpecifications().stream()
+                .map(TagSpecification::tags)
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+
+        List<Instance> localInstances = new ArrayList<>();
+
+        for (int i = 0; i < request.maxCount(); i++) {
+            Instance instance = Instance.builder()
+                    .instanceId(String.valueOf(Math.random()))
+                    .instanceType(request.instanceType())
+                    .imageId(request.imageId())
+                    .tags(tags)
+                    .state(InstanceState.builder()
+                            .name(InstanceStateName.RUNNING)
+                            .build())
+                    .launchTime(Instant.now())
+                    .build();
+
+            localInstances.add(instance);
+        }
+
+        instances.addAll(localInstances);
+
+        return RunInstancesResponse.builder()
+                .reservationId(
+                        Reservation.builder().instances(localInstances).build().reservationId())
+                .instances(localInstances)
+                .build();
     }
 
     private static void mockTerminateInstances(Ec2Client mock) {

--- a/src/test/java/hudson/plugins/ec2/util/LabelHotSpareCheckerTest.java
+++ b/src/test/java/hudson/plugins/ec2/util/LabelHotSpareCheckerTest.java
@@ -37,9 +37,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -631,6 +634,88 @@ class LabelHotSpareCheckerTest {
         waitForAtLeastAgents(20);
         assertThat(countAgents(), equalTo(20));
         assertThat(HotSpareDemand.of(cloud, LABEL).getTarget(), equalTo(20));
+    }
+
+    /**
+     * The same through a real {@code parallel} step rather than twenty separate jobs, because that
+     * is how a build of this shape actually reaches the queue: as twenty placeholder tasks of one
+     * build, each asking for the label its {@code node} step named. The width has to be read off
+     * those tasks, or the fan-out that most needs capacity is the one the label cannot see.
+     */
+    @Test
+    void testARealParallelBuildWarmsTheLabelToItsWholeWidth() throws Exception {
+        HotSpareConfigByLabel rule = rule(0, 5, null);
+        EC2Cloud cloud = cloud(rule, template("only", 30));
+
+        r.jenkins.setQuietPeriod(0);
+        parallelBuildAcross(20, LABEL);
+
+        waitForAtLeastAgents(20);
+        assertThat(countAgents(), equalTo(20));
+        assertThat(HotSpareDemand.of(cloud, LABEL).getTarget(), equalTo(20));
+    }
+
+    /**
+     * Warm capacity already in hand is part of the width, not additional to it. Five idle spares
+     * and a build fanning out to twenty branches is fifteen instances to launch: the label ends up
+     * holding twenty, having paid for fifteen.
+     */
+    @Test
+    void testSparesAlreadyHeldCountTowardsTheWidthOfAParallelBuild() throws Exception {
+        HotSpareConfigByLabel rule = rule(0, 5, null);
+        EC2Cloud cloud = cloud(rule, template("only", 30));
+
+        // A label that has already learned it wants five, and is holding them.
+        HotSpareDemand.of(cloud, LABEL).updateTarget(rule, 0, 0, 5, 0);
+        MinimumInstanceChecker.checkForMinimumInstances();
+        assertThat(countAgents(), equalTo(5));
+        int launchedForTheFirstFive = AmazonEC2FactoryMockImpl.instances.size();
+
+        r.jenkins.setQuietPeriod(0);
+        parallelBuildAcross(20, LABEL);
+        waitForAtLeastAgents(20);
+
+        assertThat(countAgents(), equalTo(20));
+        assertThat(HotSpareDemand.of(cloud, LABEL).getTarget(), equalTo(20));
+        assertThat(
+                "the five already warm were not provisioned again",
+                AmazonEC2FactoryMockImpl.instances.size(),
+                equalTo(launchedForTheFirstFive + 15));
+    }
+
+    /**
+     * A parallel build of one label says nothing about another label of the same rule, however wide
+     * it is: twenty x86 branches are twenty x86 agents and no arm64 ones.
+     */
+    @Test
+    void testAParallelBuildOnlyWarmsTheLabelItsBranchesAskedFor() throws Exception {
+        EC2Cloud cloud = cloud(
+                rule("x86_64_medium_pr || arm64_medium_pr", 0, 5),
+                template("x86", 30, "x86_64_medium_pr"),
+                template("arm", 30, "arm64_medium_pr"));
+
+        r.jenkins.setQuietPeriod(0);
+        parallelBuildAcross(20, "x86_64_medium_pr");
+
+        waitForAtLeastAgents(20);
+        assertThat(agentsByTemplate(), equalTo(Map.of("x86", 20L)));
+        assertThat(HotSpareDemand.of(cloud, "x86_64_medium_pr").getTarget(), equalTo(20));
+        assertThat(HotSpareDemand.of(cloud, "arm64_medium_pr").getTarget(), equalTo(0));
+    }
+
+    /**
+     * Starts a build that fans out to the given number of branches, each asking for the label, and
+     * waits until every branch is in the queue waiting for an agent.
+     */
+    private void parallelBuildAcross(int branches, String label) throws Exception {
+        StringJoiner script = new StringJoiner(", ", "parallel ", "");
+        for (int branch = 0; branch < branches; branch++) {
+            script.add("branch" + branch + ": { node('" + label + "') { } }");
+        }
+        WorkflowJob job = r.createProject(WorkflowJob.class, "fan-out-" + label.hashCode());
+        job.setDefinition(new CpsFlowDefinition(script.toString(), true));
+        job.scheduleBuild2(0);
+        waitForBuildableItems(branches);
     }
 
     private void removeAllAgents() throws Exception {

--- a/src/test/java/hudson/plugins/ec2/util/LabelHotSpareCheckerTest.java
+++ b/src/test/java/hudson/plugins/ec2/util/LabelHotSpareCheckerTest.java
@@ -1,0 +1,536 @@
+package hudson.plugins.ec2.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import hudson.ExtensionList;
+import hudson.model.Executor;
+import hudson.model.FreeStyleProject;
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.model.Queue;
+import hudson.model.queue.CauseOfBlockage;
+import hudson.model.queue.QueueTaskDispatcher;
+import hudson.plugins.ec2.ConnectionStrategy;
+import hudson.plugins.ec2.EC2AbstractSlave;
+import hudson.plugins.ec2.EC2Cloud;
+import hudson.plugins.ec2.EC2Computer;
+import hudson.plugins.ec2.EC2RetentionStrategy;
+import hudson.plugins.ec2.EbsEncryptRootVolume;
+import hudson.plugins.ec2.HotSpareConfigByLabel;
+import hudson.plugins.ec2.HotSpareDemand;
+import hudson.plugins.ec2.SlaveTemplate;
+import hudson.plugins.ec2.Tenancy;
+import hudson.slaves.NodeProvisioner;
+import java.security.Security;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import jenkins.model.Jenkins;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
+
+/**
+ * Hot spare scaling driven by a label rule rather than by a single template.
+ */
+@WithJenkins
+class LabelHotSpareCheckerTest {
+
+    private static final String LABEL = "linux";
+
+    /**
+     * No test here wants a build to actually start: what is being measured is the spares a queue
+     * warms up, and a branch being picked up by an agent moves it out of the queue and the agent
+     * out of the pool, mid-count. Vetoing every assignment keeps the queue still.
+     */
+    @TestExtension
+    public static class KeepEveryBuildQueued extends QueueTaskDispatcher {
+
+        @Override
+        public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
+            return new CauseOfBlockage() {
+                @Override
+                public String getShortDescription() {
+                    return "held in the queue by LabelHotSpareCheckerTest";
+                }
+            };
+        }
+    }
+
+    private JenkinsRule r;
+
+    private MovableClock clock;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        r = rule;
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        // The mock client and its instance list are static, so a fresh one keeps the instances of
+        // one test from counting against the caps of the next.
+        AmazonEC2FactoryMockImpl.mock = AmazonEC2FactoryMockImpl.createAmazonEC2Mock();
+        clock = new MovableClock();
+        HotSpareDemand.clock = clock;
+        HotSpareDemand.reset();
+        // Jenkins provisions for a queued build on its own account, off a timer, and these tests now
+        // react to the same queue. Its agents would be indistinguishable from spares in the counts
+        // below, so the tests that use a real build measure only what the hot spare pass launched.
+        ExtensionList<NodeProvisioner.Strategy> strategies = r.jenkins.getExtensionList(NodeProvisioner.Strategy.class);
+        strategies.removeAll(new ArrayList<>(strategies));
+    }
+
+    @AfterEach
+    void tearDown() {
+        HotSpareDemand.clock = Clock.systemDefaultZone();
+        MinimumInstanceChecker.clock = Clock.systemDefaultZone();
+        HotSpareDemand.reset();
+    }
+
+    /**
+     * The point of a hot spare is to exist before the work does, so a base count must provision
+     * with an empty queue.
+     */
+    @Test
+    void testBaseHotSparesAreProvisionedWithAnEmptyQueue() throws Exception {
+        HotSpareConfigByLabel rule = rule(2, 0, null);
+        cloud(rule, template("only", 10));
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(countAgents(), equalTo(2));
+    }
+
+    /**
+     * The spares already held are subtracted, so repeated ticks converge instead of provisioning
+     * the same shortfall again.
+     */
+    @Test
+    void testRepeatedChecksDoNotProvisionTheSameShortfallTwice() throws Exception {
+        HotSpareConfigByLabel rule = rule(2, 0, null);
+        cloud(rule, template("only", 10));
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+        MinimumInstanceChecker.checkForMinimumInstances();
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(countAgents(), equalTo(2));
+    }
+
+    /**
+     * A template only allowed to hold minimum instances during a time range must not be warmed
+     * outside it. Its schedule is how an admin pays for capacity only when it is wanted, and a
+     * label rule that ignored it would quietly put the template back on the clock 24x7.
+     */
+    @Test
+    void testATemplateOutsideItsScheduleHoldsNoSpares() throws Exception {
+        HotSpareConfigByLabel rule = rule(2, 0, null);
+        SlaveTemplate template = template("only", 10);
+        template.setMinimumNumberOfInstancesTimeRangeConfig(window("11:00", "15:00"));
+        cloud(rule, template);
+        atLocalTime(18, 0);
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(countAgents(), equalTo(0));
+    }
+
+    /**
+     * Inside the window the same rule provisions as usual, so the schedule gates the spares rather
+     * than disabling them.
+     */
+    @Test
+    void testATemplateInsideItsScheduleHoldsItsSpares() throws Exception {
+        HotSpareConfigByLabel rule = rule(2, 0, null);
+        SlaveTemplate template = template("only", 10);
+        template.setMinimumNumberOfInstancesTimeRangeConfig(window("11:00", "15:00"));
+        cloud(rule, template);
+        atLocalTime(12, 0);
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(countAgents(), equalTo(2));
+    }
+
+    /**
+     * The schedule belongs to the template, not to the label, so a label served by several
+     * templates keeps its spares on whichever of them is on duty. This is the arrangement the
+     * feature is meant to replace - a template per shift, offset so one is always awake - working
+     * as a single pool.
+     */
+    @Test
+    void testSparesMoveToTheTemplateWhoseScheduleIsOpen() throws Exception {
+        HotSpareConfigByLabel rule = rule(2, 0, null);
+        SlaveTemplate dayShift = template("day", 10);
+        dayShift.setMinimumNumberOfInstancesTimeRangeConfig(window("08:00", "18:00"));
+        SlaveTemplate nightShift = template("night", 10);
+        nightShift.setMinimumNumberOfInstancesTimeRangeConfig(window("18:00", "08:00"));
+        cloud(rule, dayShift, nightShift);
+        atLocalTime(22, 0);
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(countAgents(), equalTo(2));
+        assertThat(agentsByTemplate(), equalTo(Map.of("night", 2L)));
+    }
+
+    /**
+     * The ceiling applies to the label group as a whole, not to each template in it.
+     */
+    @Test
+    void testMaxHotSparesCapsTheGroupTotal() throws Exception {
+        HotSpareConfigByLabel rule = rule(5, 0, 3);
+        cloud(rule, template("first", 10), template("second", 10));
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(countAgents(), equalTo(3));
+    }
+
+    /**
+     * Spares are counted across every template carrying the label, so a group that already holds
+     * enough is left alone even though no single template does.
+     */
+    @Test
+    void testSparesAreCountedAcrossTheWholeLabelGroup() throws Exception {
+        HotSpareConfigByLabel rule = rule(4, 0, null);
+        cloud(rule, template("first", 1), template("second", 3));
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(countAgents(), equalTo(4));
+        assertThat(
+                "each template should stay within its own instance cap",
+                agentsByTemplate(),
+                equalTo(Map.of("first", 1L, "second", 3L)));
+    }
+
+    /**
+     * A rule for a label none of the templates carries provisions nothing.
+     */
+    @Test
+    void testRuleForAnUnknownLabelProvisionsNothing() throws Exception {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel("no-such-label");
+        rule.setBaseHotSpares(3);
+        cloud(rule, template("only", 10));
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(countAgents(), equalTo(0));
+    }
+
+    /**
+     * The reported defect: a step of 5 used to hand out five agents once and then let the label
+     * drain, because the target was derived from the queue and the queue empties as soon as the
+     * builds start. The target has to survive the queue emptying, and the spares consumed have to
+     * be replaced.
+     */
+    @Test
+    void testSparesAreReplacedAsTheyAreConsumed() throws Exception {
+        HotSpareConfigByLabel rule = rule(0, 5, null);
+        SlaveTemplate template = template("only", 20);
+        // Replacements have to be new instances here, or the mock hands back the ones the departed
+        // agents left behind and the test cannot tell provisioning from adoption.
+        template.setAvoidUsingOrphanedNodes(true);
+        EC2Cloud cloud = cloud(rule, template);
+        // A burst the label could not keep up with, which is what raises the target to five.
+        HotSpareDemand.of(cloud, LABEL).updateTarget(rule, 0, 0, 5, 0);
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+        assertThat(countAgents(), equalTo(5));
+
+        // The builds take all five, so the label holds nothing warm again.
+        removeAllAgents();
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat("the five spares should have been replaced", countAgents(), equalTo(5));
+        assertThat("five more instances launched", AmazonEC2FactoryMockImpl.instances.size(), equalTo(10));
+    }
+
+    /**
+     * Nothing has asked for the label for longer than the idle timeout, so it should stop paying
+     * for spares altogether rather than holding the level its last burst asked for.
+     */
+    @Test
+    void testAQuietLabelStopsReplacingSpares() throws Exception {
+        HotSpareConfigByLabel rule = rule(0, 5, null);
+        rule.setIdleTimeoutMinutes(15);
+        EC2Cloud cloud = cloud(rule, template("only", 20));
+        HotSpareDemand.of(cloud, LABEL).updateTarget(rule, 0, 0, 5, 0);
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+        assertThat(countAgents(), equalTo(5));
+
+        removeAllAgents();
+        clock.advanceMinutes(16);
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat("the prediction should have faded to nothing", countAgents(), equalTo(0));
+        assertThat(HotSpareDemand.of(cloud, LABEL).getTarget(), equalTo(0));
+    }
+
+    /**
+     * The label with nothing warm is the case the spares exist for, and it is the one case the
+     * agents cannot report themselves: with no capacity, no executor is taken. Queueing a build has
+     * to be enough on its own, or the first build of the day waits for the periodic sweep before
+     * anything is even asked for.
+     */
+    @Test
+    void testQueueingABuildProvisionsSparesWithoutWaitingForASweep() throws Exception {
+        HotSpareConfigByLabel rule = rule(0, 3, null);
+        EC2Cloud cloud = cloud(rule, template("only", 20));
+
+        r.jenkins.setQuietPeriod(0);
+        FreeStyleProject project = r.createFreeStyleProject();
+        project.setAssignedLabel(Label.get(LABEL));
+        project.scheduleBuild2(0);
+
+        // Only what Jenkins does by itself: the queue is maintained, which makes the build buildable.
+        Queue.getInstance().maintain();
+
+        waitForAtLeastAgents(3);
+        assertThat(countAgents(), equalTo(3));
+        assertThat(HotSpareDemand.of(cloud, LABEL).getTarget(), equalTo(3));
+    }
+
+    /**
+     * The other half of the reported defect: even with the right target, waiting for the next
+     * periodic pass leaves the pool a spare short for up to a minute after every build starts. A
+     * build taking an executor is what has to start the replacement, so the spare is booting while
+     * that build runs rather than after the build behind it has already had to wait.
+     */
+    @Test
+    void testTakingAnExecutorStartsTheNextSpareStraightAway() throws Exception {
+        HotSpareConfigByLabel rule = rule(0, 2, null);
+        SlaveTemplate template = template("only", 20);
+        template.setAvoidUsingOrphanedNodes(true);
+        EC2Cloud cloud = cloud(rule, template);
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+        assertThat("a label nobody is using costs nothing", countAgents(), equalTo(0));
+
+        // A build lands on the agent Jenkins raised for it and takes its executor.
+        cloud.provision(template, 1);
+        EC2Computer computer = onlyAgent();
+        int launchedBefore = AmazonEC2FactoryMockImpl.instances.size();
+        retentionStrategyOf(computer).taskAccepted(new Executor(computer, 0), null);
+
+        /*
+         * Nothing else has happened: no queued build, no periodic pass, and the clock has not moved.
+         * The agent above counts as one of the two the label now wants, so one more is launched.
+         */
+        waitForAtLeastAgents(2);
+        assertThat(HotSpareDemand.of(cloud, LABEL).getTarget(), equalTo(2));
+        assertThat(
+                "one launch, not a whole pool", AmazonEC2FactoryMockImpl.instances.size(), equalTo(launchedBefore + 1));
+    }
+
+    /**
+     * Hot spare passes run off the thread that triggered them, so their agents are not there the
+     * instant a build is queued or an executor is taken.
+     *
+     * <p>Waits for the number of spares asked for, and no longer: a label serving builds ends up
+     * with more agents than that, because the agents running those builds are not spares.
+     */
+    private static void waitForAtLeastAgents(int expected) throws Exception {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        while (countAgents() < expected && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+        assertThat("the hot spare pass should have provisioned by now", countAgents(), greaterThanOrEqualTo(expected));
+    }
+
+    private static EC2Computer onlyAgent() {
+        return Arrays.stream(Jenkins.get().getComputers())
+                .filter(EC2Computer.class::isInstance)
+                .map(EC2Computer.class::cast)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no EC2 agent was provisioned"));
+    }
+
+    private static EC2RetentionStrategy retentionStrategyOf(EC2Computer computer) {
+        EC2AbstractSlave node = computer.getNode();
+        assertThat(node, notNullValue());
+        return (EC2RetentionStrategy) node.getRetentionStrategy();
+    }
+
+    /**
+     * A build fanning out to twenty parallel branches puts twenty tasks in the queue at once, and
+     * that is measured demand rather than a guess. The label goes to twenty on the spot instead of
+     * climbing there five at a time over four minutes with nineteen branches waiting.
+     */
+    @Test
+    void testAWideParallelBuildWarmsTheLabelToItsWholeWidth() throws Exception {
+        HotSpareConfigByLabel rule = rule(0, 5, null);
+        EC2Cloud cloud = cloud(rule, template("only", 30));
+
+        r.jenkins.setQuietPeriod(0);
+        for (int branch = 0; branch < 20; branch++) {
+            FreeStyleProject project = r.createFreeStyleProject();
+            project.setAssignedLabel(Label.get(LABEL));
+            project.scheduleBuild2(0);
+        }
+        Queue.getInstance().maintain();
+
+        waitForAtLeastAgents(20);
+        assertThat(countAgents(), equalTo(20));
+        assertThat(HotSpareDemand.of(cloud, LABEL).getTarget(), equalTo(20));
+    }
+
+    private void removeAllAgents() throws Exception {
+        for (Node node : new ArrayList<>(r.jenkins.getNodes())) {
+            r.jenkins.removeNode(node);
+        }
+    }
+
+    /**
+     * A window on every day of the week, so only the time of day decides whether the template is
+     * allowed to be holding instances.
+     */
+    private static MinimumNumberOfInstancesTimeRangeConfig window(String from, String to) {
+        MinimumNumberOfInstancesTimeRangeConfig window = new MinimumNumberOfInstancesTimeRangeConfig();
+        window.setMinimumNoInstancesActiveTimeRangeFrom(from);
+        window.setMinimumNoInstancesActiveTimeRangeTo(to);
+        window.setMonday(true);
+        window.setTuesday(true);
+        window.setWednesday(true);
+        window.setThursday(true);
+        window.setFriday(true);
+        window.setSaturday(true);
+        window.setSunday(true);
+        return window;
+    }
+
+    /** Fixes the wall clock the schedules are read against. */
+    private static void atLocalTime(int hour, int minute) {
+        LocalDateTime when = LocalDateTime.of(2019, Month.SEPTEMBER, 24, hour, minute); // A Tuesday
+        MinimumInstanceChecker.clock =
+                Clock.fixed(when.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+    }
+
+    private static HotSpareConfigByLabel rule(int baseHotSpares, int scalingFactor, Integer maxHotSpares) {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
+        rule.setBaseHotSpares(baseHotSpares);
+        rule.setScalingFactor(scalingFactor);
+        rule.setMaxHotSpares(maxHotSpares);
+        return rule;
+    }
+
+    private static int countAgents() {
+        return (int) Arrays.stream(Jenkins.get().getComputers())
+                .filter(EC2Computer.class::isInstance)
+                .count();
+    }
+
+    private static Map<String, Long> agentsByTemplate() {
+        return Arrays.stream(Jenkins.get().getComputers())
+                .filter(EC2Computer.class::isInstance)
+                .map(EC2Computer.class::cast)
+                .map(EC2Computer::getNode)
+                .filter(node -> node != null)
+                .collect(Collectors.groupingBy(node -> node.templateDescription, Collectors.counting()));
+    }
+
+    private EC2Cloud cloud(HotSpareConfigByLabel rule, SlaveTemplate... templates) throws Exception {
+        SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
+        // A cloud-wide cap high enough to leave the template caps as the only limit in play.
+        EC2Cloud cloud = new EC2Cloud(
+                "test-cloud", true, "abc", "us-east-1", null, "ghi", "100", List.of(templates), null, null);
+        cloud.setHotSpareConfigsByLabel(List.of(rule));
+        r.jenkins.clouds.add(cloud);
+        return cloud;
+    }
+
+    private static final class MovableClock extends Clock {
+
+        private long millis = TimeUnit.DAYS.toMillis(1);
+
+        void advanceMinutes(long minutes) {
+            millis += TimeUnit.MINUTES.toMillis(minutes);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.systemDefault();
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return Instant.ofEpochMilli(millis);
+        }
+
+        @Override
+        public long millis() {
+            return millis;
+        }
+    }
+
+    private static SlaveTemplate template(String description, int instanceCap) {
+        return new SlaveTemplate(
+                "ami-" + description,
+                EC2AbstractSlave.TEST_ZONE,
+                null,
+                "default",
+                "/tmp/jenkins",
+                InstanceType.M1_LARGE.toString(),
+                false,
+                LABEL,
+                Node.Mode.NORMAL,
+                description,
+                "",
+                "",
+                "",
+                "1",
+                "",
+                null,
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "",
+                false,
+                null,
+                null,
+                null,
+                0,
+                0,
+                String.valueOf(instanceCap),
+                null,
+                false,
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                false,
+                ConnectionStrategy.PRIVATE_IP,
+                -1,
+                Collections.emptyList(),
+                null,
+                Tenancy.Default,
+                EbsEncryptRootVolume.DEFAULT,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED,
+                EC2AbstractSlave.DEFAULT_ENCLAVE_ENABLED);
+    }
+}

--- a/src/test/java/hudson/plugins/ec2/util/LabelHotSpareCheckerTest.java
+++ b/src/test/java/hudson/plugins/ec2/util/LabelHotSpareCheckerTest.java
@@ -141,8 +141,10 @@ class LabelHotSpareCheckerTest {
         HotSpareConfigByLabel rule = rule(2, 0, null);
         SlaveTemplate template = template("only", 10);
         template.setMinimumNumberOfInstancesTimeRangeConfig(window("11:00", "15:00"));
-        cloud(rule, template);
+        // Before the cloud is saved: saving one runs a hot spare pass, which would read the
+        // schedules against whatever the wall clock happens to say.
         atLocalTime(18, 0);
+        cloud(rule, template);
 
         MinimumInstanceChecker.checkForMinimumInstances();
 
@@ -158,8 +160,8 @@ class LabelHotSpareCheckerTest {
         HotSpareConfigByLabel rule = rule(2, 0, null);
         SlaveTemplate template = template("only", 10);
         template.setMinimumNumberOfInstancesTimeRangeConfig(window("11:00", "15:00"));
-        cloud(rule, template);
         atLocalTime(12, 0);
+        cloud(rule, template);
 
         MinimumInstanceChecker.checkForMinimumInstances();
 
@@ -179,13 +181,70 @@ class LabelHotSpareCheckerTest {
         dayShift.setMinimumNumberOfInstancesTimeRangeConfig(window("08:00", "18:00"));
         SlaveTemplate nightShift = template("night", 10);
         nightShift.setMinimumNumberOfInstancesTimeRangeConfig(window("18:00", "08:00"));
-        cloud(rule, dayShift, nightShift);
         atLocalTime(22, 0);
+        cloud(rule, dayShift, nightShift);
 
         MinimumInstanceChecker.checkForMinimumInstances();
 
         assertThat(countAgents(), equalTo(2));
         assertThat(agentsByTemplate(), equalTo(Map.of("night", 2L)));
+    }
+
+    /**
+     * A template carrying several labels can be covered by a rule for each of them. The rules are
+     * counted against the same agents rather than added together, so the label wanting the most
+     * decides how many the template holds and the other one adds nothing.
+     */
+    @Test
+    void testOverlappingRulesDoNotAddUpOnASharedTemplate() throws Exception {
+        // The smaller rule first, since that is also the order the idle timeout is resolved in.
+        EC2Cloud cloud = cloud(List.of(rule("bar", 1), rule("foo", 4)), template("shared", 10, "foo bar"));
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat("four for foo, of which bar's one is a subset", countAgents(), equalTo(4));
+        assertThat(HotSpareDemand.of(cloud, "foo").getTarget(), equalTo(4));
+        assertThat(HotSpareDemand.of(cloud, "bar").getTarget(), equalTo(1));
+    }
+
+    /**
+     * The other half of that: overlapping is not the same as sharing everything, so a rule provisions
+     * only from the templates carrying its own label.
+     */
+    @Test
+    void testARuleOnlyProvisionsFromTheTemplatesItCovers() throws Exception {
+        cloud(
+                List.of(rule("foo", 2), rule("baz", 3)),
+                template("shared", 10, "foo bar"),
+                template("elsewhere", 10, "baz"));
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(agentsByTemplate(), equalTo(Map.of("shared", 2L, "elsewhere", 3L)));
+    }
+
+    /**
+     * Work in sight is counted through the templates of the group, so a build asking for one label
+     * of a shared template is demand for every rule covering it. The labels are not independent
+     * signals when they are the same machines.
+     */
+    @Test
+    void testWorkForOneLabelIsWorkInSightForEveryRuleCoveringTheTemplate() throws Exception {
+        EC2Cloud cloud = cloud(List.of(rule("bar", 0), rule("foo", 0)), template("shared", 10, "foo bar"));
+
+        r.jenkins.setQuietPeriod(0);
+        FreeStyleProject project = r.createFreeStyleProject();
+        project.setAssignedLabel(Label.get("bar"));
+        project.scheduleBuild2(0);
+        Queue.getInstance().maintain();
+        waitForABuildableItem();
+
+        assertThat(MinimumInstanceChecker.countQueueItemsForLabel(cloud, Label.get("bar")), equalTo(1));
+        assertThat(
+                "a build asking for bar is work in sight for foo as well",
+                MinimumInstanceChecker.countQueueItemsForLabel(cloud, Label.get("foo")),
+                equalTo(1));
     }
 
     /**
@@ -347,6 +406,18 @@ class LabelHotSpareCheckerTest {
      * <p>Waits for the number of spares asked for, and no longer: a label serving builds ends up
      * with more agents than that, because the agents running those builds are not spares.
      */
+    private static void waitForABuildableItem() throws Exception {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        while (Queue.getInstance().getBuildableItems().isEmpty() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+            Queue.getInstance().maintain();
+        }
+        assertThat(
+                "the build should have reached the queue by now",
+                Queue.getInstance().getBuildableItems().size(),
+                greaterThanOrEqualTo(1));
+    }
+
     private static void waitForAtLeastAgents(int expected) throws Exception {
         long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
         while (countAgents() < expected && System.currentTimeMillis() < deadline) {
@@ -423,6 +494,14 @@ class LabelHotSpareCheckerTest {
                 Clock.fixed(when.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
     }
 
+    /** A rule for another label, with a fixed count and no scaling of its own. */
+    private static HotSpareConfigByLabel rule(String label, int baseHotSpares) {
+        HotSpareConfigByLabel rule = new HotSpareConfigByLabel(label);
+        rule.setBaseHotSpares(baseHotSpares);
+        rule.setScalingFactor(0);
+        return rule;
+    }
+
     private static HotSpareConfigByLabel rule(int baseHotSpares, int scalingFactor, Integer maxHotSpares) {
         HotSpareConfigByLabel rule = new HotSpareConfigByLabel(LABEL);
         rule.setBaseHotSpares(baseHotSpares);
@@ -447,11 +526,15 @@ class LabelHotSpareCheckerTest {
     }
 
     private EC2Cloud cloud(HotSpareConfigByLabel rule, SlaveTemplate... templates) throws Exception {
+        return cloud(List.of(rule), templates);
+    }
+
+    private EC2Cloud cloud(List<HotSpareConfigByLabel> rules, SlaveTemplate... templates) throws Exception {
         SSHCredentialHelper.assureSshCredentialAvailableThroughCredentialProviders("ghi");
         // A cloud-wide cap high enough to leave the template caps as the only limit in play.
         EC2Cloud cloud = new EC2Cloud(
                 "test-cloud", true, "abc", "us-east-1", null, "ghi", "100", List.of(templates), null, null);
-        cloud.setHotSpareConfigsByLabel(List.of(rule));
+        cloud.setHotSpareConfigsByLabel(rules);
         r.jenkins.clouds.add(cloud);
         return cloud;
     }
@@ -486,6 +569,10 @@ class LabelHotSpareCheckerTest {
     }
 
     private static SlaveTemplate template(String description, int instanceCap) {
+        return template(description, instanceCap, LABEL);
+    }
+
+    private static SlaveTemplate template(String description, int instanceCap, String labels) {
         return new SlaveTemplate(
                 "ami-" + description,
                 EC2AbstractSlave.TEST_ZONE,
@@ -494,7 +581,7 @@ class LabelHotSpareCheckerTest {
                 "/tmp/jenkins",
                 InstanceType.M1_LARGE.toString(),
                 false,
-                LABEL,
+                labels,
                 Node.Mode.NORMAL,
                 description,
                 "",

--- a/src/test/java/hudson/plugins/ec2/util/LabelHotSpareCheckerTest.java
+++ b/src/test/java/hudson/plugins/ec2/util/LabelHotSpareCheckerTest.java
@@ -3,6 +3,7 @@ package hudson.plugins.ec2.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.notNullValue;
 
 import hudson.ExtensionList;
@@ -35,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
@@ -225,13 +227,13 @@ class LabelHotSpareCheckerTest {
     }
 
     /**
-     * Work in sight is counted through the templates of the group, so a build asking for one label
-     * of a shared template is demand for every rule covering it. The labels are not independent
-     * signals when they are the same machines.
+     * Work in sight belongs to the label that asked for it. A build wanting one label of a shared
+     * template says nothing about the other, even though the same machines serve both: what the
+     * build asked for is the only evidence of what it would have accepted.
      */
     @Test
-    void testWorkForOneLabelIsWorkInSightForEveryRuleCoveringTheTemplate() throws Exception {
-        EC2Cloud cloud = cloud(List.of(rule("bar", 0), rule("foo", 0)), template("shared", 10, "foo bar"));
+    void testWorkForOneLabelIsNotWorkInSightForAnother() throws Exception {
+        cloud(List.of(rule("bar", 0), rule("foo", 0)), template("shared", 10, "foo bar"));
 
         r.jenkins.setQuietPeriod(0);
         FreeStyleProject project = r.createFreeStyleProject();
@@ -240,11 +242,150 @@ class LabelHotSpareCheckerTest {
         Queue.getInstance().maintain();
         waitForABuildableItem();
 
-        assertThat(MinimumInstanceChecker.countQueueItemsForLabel(cloud, Label.get("bar")), equalTo(1));
+        assertThat(MinimumInstanceChecker.countQueueItemsRequesting(Label.get("bar")), equalTo(1));
         assertThat(
-                "a build asking for bar is work in sight for foo as well",
-                MinimumInstanceChecker.countQueueItemsForLabel(cloud, Label.get("foo")),
-                equalTo(1));
+                "a build asking for bar is not work in sight for foo",
+                MinimumInstanceChecker.countQueueItemsRequesting(Label.get("foo")),
+                equalTo(0));
+    }
+
+    /**
+     * The reported defect: a rule covering both architectures had a run of x86 pull request builds
+     * warming arm64 instances that none of those builds could ever have used. A rule says how the
+     * labels it covers should behave; it does not make them one pool.
+     */
+    @Test
+    void testABuildForOneLabelDoesNotWarmTheOtherHardwareOfTheRule() throws Exception {
+        EC2Cloud cloud = cloud(
+                rule("x86_64_medium_pr || arm64_medium_pr", 0, 5),
+                template("x86", 10, "x86_64_medium_pr"),
+                template("arm", 10, "arm64_medium_pr"));
+
+        queueBuildFor("x86_64_medium_pr");
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(agentsByTemplate(), equalTo(Map.of("x86", 5L)));
+        assertThat(
+                "arm64 was never asked for",
+                HotSpareDemand.of(cloud, "arm64_medium_pr").getTarget(),
+                equalTo(0));
+    }
+
+    /**
+     * The same, for the label that made the defect visible in practice: a rule grouping small
+     * agents with the generator label used to have generator builds warm both architectures of
+     * small agent.
+     */
+    @Test
+    void testALabelSharingARuleWithOthersScalesOnItsOwn() throws Exception {
+        EC2Cloud cloud = cloud(
+                rule("x86_64_small || arm64_small || jervis_generator", 0, 2),
+                template("x86", 10, "x86_64_small jervis_generator"),
+                template("arm", 10, "arm64_small"));
+
+        queueBuildFor("jervis_generator");
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(agentsByTemplate(), equalTo(Map.of("x86", 2L)));
+        assertThat(HotSpareDemand.of(cloud, "jervis_generator").getTarget(), equalTo(2));
+        assertThat(HotSpareDemand.of(cloud, "arm64_small").getTarget(), equalTo(0));
+    }
+
+    /**
+     * Labels scaling apart is not the same as their spares being separate machines. Where one
+     * template serves both labels, a warm agent counts for both of them, so two labels wanting two
+     * spares each are served by two agents rather than four.
+     */
+    @Test
+    void testLabelsServedByOneTemplateShareItsSpares() throws Exception {
+        EC2Cloud cloud = cloud(rule("foo || bar", 0, 2), template("shared", 10, "foo bar"));
+
+        queueBuildFor("foo");
+        queueBuildFor("bar");
+        MinimumInstanceChecker.checkForMinimumInstances();
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat("one set of spares, serving both labels", countAgents(), equalTo(2));
+        assertThat(HotSpareDemand.of(cloud, "foo").getTarget(), equalTo(2));
+        assertThat(HotSpareDemand.of(cloud, "bar").getTarget(), equalTo(2));
+    }
+
+    /**
+     * A job asking for a compound expression is a label in its own right: the rule covering the
+     * templates that carry both atoms governs it, and it is warmed separately from either atom on
+     * its own.
+     */
+    @Test
+    void testACompoundExpressionIsTrackedUnderTheRuleThatCoversIt() throws Exception {
+        EC2Cloud cloud =
+                cloud(rule("foo || bar", 0, 2), template("both", 10, "foo bar"), template("foo-only", 10, "foo"));
+
+        queueBuildFor("foo && bar");
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(
+                "only the template carrying both labels can serve it", agentsByTemplate(), equalTo(Map.of("both", 2L)));
+        assertThat(HotSpareDemand.of(cloud, "foo&&bar").getTarget(), equalTo(2));
+        assertThat(
+                "the atoms are separate demand", HotSpareDemand.of(cloud, "foo").getTarget(), equalTo(0));
+    }
+
+    /**
+     * A build takes a spare on an agent that serves several labels, and only the label it asked for
+     * is short of one. The others were not using that agent.
+     */
+    @Test
+    void testTakingAnExecutorOnlyWarmsTheLabelTheBuildAskedFor() throws Exception {
+        SlaveTemplate template = template("shared", 20, "foo bar");
+        EC2Cloud cloud = cloud(rule("foo || bar", 0, 2), template);
+
+        cloud.provision(template, 1);
+        EC2Computer computer = onlyAgent();
+        retentionStrategyOf(computer).taskAccepted(new Executor(computer, 0), taskAskingFor("foo"));
+
+        waitForAtLeastAgents(2);
+        assertThat(HotSpareDemand.of(cloud, "foo").getTarget(), equalTo(2));
+        assertThat(HotSpareDemand.of(cloud, "bar").getTarget(), equalTo(0));
+    }
+
+    /**
+     * The count an admin asked to always be held belongs to the rule, not to each label it covers,
+     * so a rule over four labels with a floor of two holds two agents rather than eight.
+     */
+    @Test
+    void testTheFloorIsHeldOncePerRuleRatherThanPerLabel() throws Exception {
+        cloud(rule("foo || bar", 2, 0), template("first", 10, "foo"), template("second", 10, "bar"));
+
+        MinimumInstanceChecker.checkForMinimumInstances();
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(countAgents(), equalTo(2));
+    }
+
+    /**
+     * Targets are keyed by whatever label a job asked for, so a controller would otherwise
+     * accumulate one for every label it has ever seen. A label that has faded to nothing is
+     * forgotten; the labels the rules name stay, because that is where the floors live.
+     */
+    @Test
+    void testALabelThatHasFadedToNothingIsForgotten() throws Exception {
+        HotSpareConfigByLabel rule = rule("foo || bar", 0, 2);
+        rule.setIdleTimeoutMinutes(15);
+        EC2Cloud cloud = cloud(rule, template("shared", 10, "foo bar"));
+
+        queueBuildFor("foo");
+        MinimumInstanceChecker.checkForMinimumInstances();
+        assertThat(HotSpareDemand.trackedLabels(cloud), hasItem("foo"));
+
+        cancelAllQueuedBuilds();
+        removeAllAgents();
+        // One pass to see the label go quiet, and one an idle timeout later to fade it to nothing.
+        clock.advanceMinutes(16);
+        MinimumInstanceChecker.checkForMinimumInstances();
+        clock.advanceMinutes(16);
+        MinimumInstanceChecker.checkForMinimumInstances();
+
+        assertThat(HotSpareDemand.trackedLabels(cloud), equalTo(Set.of("foo || bar")));
     }
 
     /**
@@ -387,7 +528,7 @@ class LabelHotSpareCheckerTest {
         cloud.provision(template, 1);
         EC2Computer computer = onlyAgent();
         int launchedBefore = AmazonEC2FactoryMockImpl.instances.size();
-        retentionStrategyOf(computer).taskAccepted(new Executor(computer, 0), null);
+        retentionStrategyOf(computer).taskAccepted(new Executor(computer, 0), taskAskingFor(LABEL));
 
         /*
          * Nothing else has happened: no queued build, no periodic pass, and the clock has not moved.
@@ -407,15 +548,37 @@ class LabelHotSpareCheckerTest {
      * with more agents than that, because the agents running those builds are not spares.
      */
     private static void waitForABuildableItem() throws Exception {
+        waitForBuildableItems(1);
+    }
+
+    private static void waitForBuildableItems(int expected) throws Exception {
         long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
-        while (Queue.getInstance().getBuildableItems().isEmpty() && System.currentTimeMillis() < deadline) {
+        while (Queue.getInstance().getBuildableItems().size() < expected && System.currentTimeMillis() < deadline) {
             Thread.sleep(50);
             Queue.getInstance().maintain();
         }
         assertThat(
                 "the build should have reached the queue by now",
                 Queue.getInstance().getBuildableItems().size(),
-                greaterThanOrEqualTo(1));
+                greaterThanOrEqualTo(expected));
+    }
+
+    /** Queues a build that will only run on the given label, and waits for it to be buildable. */
+    private void queueBuildFor(String label) throws Exception {
+        r.jenkins.setQuietPeriod(0);
+        int queuedBefore = Queue.getInstance().getBuildableItems().size();
+        FreeStyleProject project = r.createFreeStyleProject();
+        project.setAssignedLabel(Label.get(label));
+        project.scheduleBuild2(0);
+        Queue.getInstance().maintain();
+        waitForBuildableItems(queuedBefore + 1);
+    }
+
+    private static void cancelAllQueuedBuilds() {
+        for (Queue.Item item : Queue.getInstance().getItems()) {
+            Queue.getInstance().cancel(item);
+        }
+        Queue.getInstance().maintain();
     }
 
     private static void waitForAtLeastAgents(int expected) throws Exception {
@@ -432,6 +595,13 @@ class LabelHotSpareCheckerTest {
                 .map(EC2Computer.class::cast)
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("no EC2 agent was provisioned"));
+    }
+
+    /** A build that would only run on the given label, for the paths that read what it asked for. */
+    private Queue.Task taskAskingFor(String label) throws Exception {
+        FreeStyleProject project = r.createFreeStyleProject();
+        project.setAssignedLabel(Label.get(label));
+        return project;
     }
 
     private static EC2RetentionStrategy retentionStrategyOf(EC2Computer computer) {
@@ -496,9 +666,13 @@ class LabelHotSpareCheckerTest {
 
     /** A rule for another label, with a fixed count and no scaling of its own. */
     private static HotSpareConfigByLabel rule(String label, int baseHotSpares) {
+        return rule(label, baseHotSpares, 0);
+    }
+
+    private static HotSpareConfigByLabel rule(String label, int baseHotSpares, int scalingFactor) {
         HotSpareConfigByLabel rule = new HotSpareConfigByLabel(label);
         rule.setBaseHotSpares(baseHotSpares);
-        rule.setScalingFactor(0);
+        rule.setScalingFactor(scalingFactor);
         return rule;
     }
 

--- a/src/test/resources/hudson/plugins/ec2/Unix-withHotSparesByLabel.yml
+++ b/src/test/resources/hudson/plugins/ec2/Unix-withHotSparesByLabel.yml
@@ -1,0 +1,34 @@
+---
+jenkins:
+  clouds:
+    - amazonEC2:
+        name: "hotSpares"
+        useInstanceProfileForCredentials: true
+        sshKeysCredentialsId: "random credentials id"
+        roundRobinTemplatesByLabel: true
+        hotSpareConfigsByLabel:
+          - label: "linux"
+            baseHotSpares: 2
+            scalingFactor: 3
+            maxHotSpares: 6
+            idleTimeoutMinutes: 20
+            gracePeriodMinutes: 7
+            discardAfterGracePeriod: false
+            allowTemplateIdleTimeoutOverride: true
+            allowTemplateGracePeriodOverride: true
+        templates:
+          - description: "spot"
+            ami: "ami-12345"
+            labelString: "linux ubuntu"
+            type: "t2.micro"
+            remoteFS: "/home/ec2-user"
+            mode: "NORMAL"
+            hotSpareWeight: 3
+            gracePeriodMinutes: 4
+            discardAfterGracePeriod: false
+          - description: "ondemand"
+            ami: "ami-67890"
+            labelString: "linux ubuntu"
+            type: "t2.small"
+            remoteFS: "/home/ec2-user"
+            mode: "NORMAL"

--- a/src/test/resources/hudson/plugins/ec2/Unix-withHotSparesByLabel.yml
+++ b/src/test/resources/hudson/plugins/ec2/Unix-withHotSparesByLabel.yml
@@ -6,6 +6,7 @@ jenkins:
         useInstanceProfileForCredentials: true
         sshKeysCredentialsId: "random credentials id"
         roundRobinTemplatesByLabel: true
+        saturateHighestWeightFirst: true
         hotSpareConfigsByLabel:
           - label: "linux"
             baseHotSpares: 2


### PR DESCRIPTION
Short description
-----------------

Until now, single use executors are great but had a significant time trade-off (builds take a long time due to provisioning delays) or cost trade-off depending how hot spares are configured.  This feature is meant to balance the benefits of one shot executors with cost and performance; fixing bugs along the way.

Hot spare capacity is no longer a static configuration.  It dynamically changes hot spare capacity based on jobs requesting node labels.   Useful for single-use execution of agents.  A single label can match multiple templates and multiple instance types may satisfy a given label (e.g.  RAM requirements for a build).

Full description
----------------

This feature enables autoscaling of hot spare capacity in a configuration where agents are 100% ephemeral.  The main purpose of this feature is to provide autoscaling of multiple EC2 templates by matching agent labels and grouping their hot spares across all templates that match the given label.  Label-based hot spare capacity is tracked at the EC2 cloud level.

New configuration options (all options use DataBoundSetter instead of constructor changes and is compatible with Jenkins config as code):

* At the cloud level: Hot spares by label is available.  It appears before AMI template list.  Two options under Advanced tab (round-robin and saturate highest weight first which change template fallback behavior when multiple templates have the same label).
* New options within templates: Hot spare weight, Provisioning grace period, Discard agents that never come online

New tunable system properties:

* `jenkins.ec2.hotSpareGrowthIntervalMs` (default 60s)
* `jenkins.ec2.inFlightInstanceTtlMs` (default 2m)
* `hudson.plugins.ec2.LabelTemplateRotation.templateCapacityCooldownMillis` (default 5m) deliberately separate from `hudson.plugins.ec2.SlaveTemplate.subnetCapacityCooldownMillis` introduced by https://github.com/jenkinsci/ec2-plugin/pull/2027.  Cooldown for availability zone fallback and template fallback are tracked separately.

Primary features:

* All features are opt-in only, upgrade is clean and does not require code changes from existing Jenkins config as code.
* Limits are respected within templates including configured schedules.
* Autoscaling hot spares by label considers multiple templates having the same label.
* Weighted round robin: Individual templates have weighting where two templates with the same label might have one preferred over the other due to its configured weight.  Not all templates are equal because an admin might want to favor a specific cheaper template before other templates (e.g. cheaper instance type or spot instances before on-demand instances) which provides the ability to control costs.
* Select templates for hot spare scaling policy using a single label or label expression.
* Base scaling sets the minimum number of instances to have as hot spare capacity across all templates.
* Hot spare step is the smallest pool that gets step-provisioned when ramping up capacity.  For example, a hot spare step of 5 will provision 5 nodes when a job requests a matching label.
* Maximum hot spares limits the total number of nodes allowed for a given label across all templates even if limits within individual templates have not been reached.  Individual template limits are still respected.
* Idle termination time is the time agents terminate after hot spare capacity is scaled back down (when Jenkins is idle).  If agents are within a hot spare capacity then idle termination is ignored since the target desire is the hot spare capacity.  This prevents agents from continuously cycling.
* Provisioning grace period is how long an agent is allowed to take to come online.  There's an additional option to terminate immediately after grace period is reached or to start the idle termination time clock.

Smarter fallback logic all within the same provisioning request:

* When an availability zone is at capacity it will fallback to another availability zone within the same provisioning request.
* If multiple templates have the same label (and each template having multiple AZs), then templates where all AZs are at capacity will fall back to another template for the same label.  Useful for falling back to multiple instance types or spot instances falling back to on-demand.
* Weight option within templates dictates what the next fallback is (or round robin if equal weight).

More responsive provisioning:

* Queueing jobs warms a cold label immediately if a label doesn't have capacity yet (rather than waiting for a warming period like previous design).
* As soon as an executor gets consumed by a job it immediately triggers hot-spare provisioning request to fill capacity back in.
* Within a single job run, there's on-demand hot-spare increase and idle-agent hot-spare fade.  For example, if a job has a parallel struct with 20 nodes, then on-demand hot spares will jump to 20 nodes and eventually scale back down based on current work in sight.  As jobs request capacity, the EC2 plugin responds to it directly and so hot spare autoscaling is not strictly based on the number of jobs being run but also based on the number of nodes requested within the run.  This is more cost efficient and performant.
* When spares are taken at full capacity the hot spare scaling is stepped above the load.  Slowly increasing the amount of hot spares for the matching labels.  Individual template caps are respected.  The scaling is across the whole EC2 cloud.  Every minute if there's over-provisioned hot spares, then the hot spare capacity is faded by the configured step interval (the minimum step pool configured by _Hot spare step_).

Other notable bugs fixed:

* Idle time is now measured from the moment the agent became usable rather than from the instance launch.

Pull requests which might be closed
-----------------------------------

This pull request covers features requested in other pull requests.  Consider closing the following pull requests.

* https://github.com/jenkinsci/ec2-plugin/pull/2035 Capacity errors are handled by availability zone fallback and falling back to other templates with matching labels.
* https://github.com/jenkinsci/ec2-plugin/pull/945 idle timeout no longer conflicts with hot spare capacity.  Idle timeout is ignored when target is met.
* https://github.com/jenkinsci/ec2-plugin/pull/430
* https://github.com/jenkinsci/ec2-plugin/pull/414 "fixed" by grace period deprovisioning but if this PR is the root cause I might want to take a crack at it after this pull request.  Agents stuck in "launching" state is a frequent bug I encounter at my scale.

Issues that will be closed
--------------------------

The following issues will auto-close on merge.  The "closes" syntax will auto-close the issues.

closes https://github.com/jenkinsci/ec2-plugin/issues/2028 autoscaling hot spares by label is this feature.

closes https://github.com/jenkinsci/ec2-plugin/issues/1998 for the same reason as https://github.com/jenkinsci/ec2-plugin/issues/2028.

closes https://github.com/jenkinsci/ec2-plugin/issues/2030 instance cap is honored and has a test.

closes https://github.com/jenkinsci/ec2-plugin/issues/1883 for the same reason as https://github.com/jenkinsci/ec2-plugin/issues/2030.

closes https://github.com/jenkinsci/ec2-plugin/issues/2033 because instance cap is adhered and now has a test.  Multiple spot instance types are now possible with automatic backoff and fallback to other spot templates that have the same label.

closes https://github.com/jenkinsci/ec2-plugin/issues/2005 for the same reason as https://github.com/jenkinsci/ec2-plugin/issues/2033.

closes https://github.com/jenkinsci/ec2-plugin/issues/1993 for the same reason as https://github.com/jenkinsci/ec2-plugin/issues/2033.

closes https://github.com/jenkinsci/ec2-plugin/issues/1903 for the same reason as https://github.com/jenkinsci/ec2-plugin/issues/2033.

closes https://github.com/jenkinsci/ec2-plugin/issues/1398 for the same reason as https://github.com/jenkinsci/ec2-plugin/issues/2033.  It uses in-flight reservations, though a legacy spot request is only counted once it's fulfilled until the request expires.

closes https://github.com/jenkinsci/ec2-plugin/issues/1837 ([JENKINS-66373]) where hot spares stabilize at the desired capacity without unnecessarily deprovisioning.  Idle timeout is ignored in deference to specified (or autoscaling) hot spare capacity.

closes https://github.com/jenkinsci/ec2-plugin/issues/1774 configurable grace period deletes agents that do not connect within the grace period.

closes https://github.com/jenkinsci/ec2-plugin/issues/1744 because hot spare rules are now counted per cloud (with templates that contain the same label).  Two clouds no longer count against each other.

closes https://github.com/jenkinsci/ec2-plugin/issues/1533 because fixing the fallback behavior when multiple templates have the same label also happens to fix falling back when the label is also referenced by static agents.  When all static agents are consumed EC2 plugin will now provision a matching label via autoscaling (with one or more templates matching the same label).

closes https://github.com/jenkinsci/ec2-plugin/issues/1526 temporary offline agents are no longer counted as capacity.

[JENKINS-66373]: https://issues.jenkins.io/browse/JENKINS-66373

Benchmarks
----------

* Time from build start to hot spare step capacity initializing provisioning: ~8 seconds.
* Time from build start to usable agents: ~25 seconds (including above 8s).

Screenshots
-----------

Cloud-level config options:

<img width="2330" height="1446" alt="Image" src="https://github.com/user-attachments/assets/47c12372-771e-49ef-9c91-38283341716f" />

Cloud-level new advanced options with their help expanded:

<img width="2272" height="1344" alt="image" src="https://github.com/user-attachments/assets/228e6bcc-2330-4745-bc9b-9868b77315af" />

Template-level config options:

<img width="890" height="698" alt="Image" src="https://github.com/user-attachments/assets/df010ca0-c020-47c7-8566-faa4448dd468" />

Related AI analysis
-------------------

I've published my AI analysis notes at https://github.com/samrocketman/jenkins-ai-analysis/tree/main/ec2-autoscaling-hot-spares

Testing done
------------

Thoroughly tested in my staging Jenkins infrastructure with multiple Jenkins deployment test suites.

I ran config as code with no changes to support this feature and it continues to work as-is with no modifications.

> Note: I plan to deploy this pre-release to my production infrastructure as well.  If this gets merged before I "test in prod" then I'll simply perform a release upgrade.

Submitter checklist
-------------------

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed